### PR TITLE
feat: Add code coverage with Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+        env:
+          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
+          REDIS_URL: redis://localhost:6379
+          NODE_ENV: test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+          verbose: true
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check build artifacts
+        run: ls -la dist/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,69 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+        env:
+          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
+          REDIS_URL: redis://localhost:6379
+          NODE_ENV: test
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true
+          verbose: true
+
+      - name: Check coverage thresholds
+        run: npm run test:coverage -- --coverageThreshold='{"global":{"branches":70,"functions":70,"lines":70,"statements":70}}'

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,5 @@ dist/
 *.log
 .DS_Store
 coverage/
-
-# Issue creation scripts (local use only)
-create-issues.sh
-create-all-issues.sh
-create-issues.js
-create_issues.py
-issues.json
+.nyc_output/
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Mobile Money to Stellar Backend
+
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/sublime247/mobile-money/issues)
+[![codecov](https://codecov.io/gh/sublime247/mobile-money/branch/main/graph/badge.svg)](https://codecov.io/gh/sublime247/mobile-money)
+[![CI](https://github.com/sublime247/mobile-money/workflows/CI/badge.svg)](https://github.com/sublime247/mobile-money/actions)
 
 A backend service that bridges mobile money providers (MTN, Airtel, Orange) with the Stellar blockchain network.
 
@@ -53,6 +56,28 @@ npm start
 ```bash
 docker-compose up
 ```
+
+## Testing
+
+### Run Tests
+```bash
+npm test
+```
+
+### Run Tests with Coverage
+```bash
+npm run test:coverage
+```
+
+### Watch Mode
+```bash
+npm run test:watch
+```
+
+### Coverage Requirements
+- Minimum coverage: 70% (branches, functions, lines, statements)
+- Coverage reports uploaded to Codecov automatically
+- View detailed reports: https://codecov.io/gh/sublime247/mobile-money
 
 ## API Endpoints
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,35 @@
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 2%
+        if_ci_failed: error
+    
+    patch:
+      default:
+        target: 70%
+        threshold: 2%
+
+comment:
+  layout: "reach,diff,flags,tree,files"
+  behavior: default
+  require_changes: false
+  require_base: no
+  require_head: yes
+
+ignore:
+  - "tests/**/*"
+  - "examples/**/*"
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "dist/**/*"

--- a/docs/CODECOV_SETUP.md
+++ b/docs/CODECOV_SETUP.md
@@ -1,0 +1,179 @@
+# Codecov Setup Guide
+
+## Quick Setup (5 minutes)
+
+### Step 1: Sign Up for Codecov
+1. Visit https://codecov.io
+2. Click "Sign up with GitHub"
+3. Authorize Codecov to access your repositories
+
+### Step 2: Add Repository
+1. In Codecov dashboard, click "Add new repository"
+2. Find and select `sublime247/mobile-money`
+3. Copy the upload token shown
+
+### Step 3: Add GitHub Secret
+1. Go to https://github.com/sublime247/mobile-money/settings/secrets/actions
+2. Click "New repository secret"
+3. Name: `CODECOV_TOKEN`
+4. Value: [paste the token from Step 2]
+5. Click "Add secret"
+
+### Step 4: Verify Setup
+1. Push code to main branch or create a PR
+2. Go to GitHub Actions tab
+3. Wait for CI workflow to complete
+4. Check Codecov dashboard for coverage report
+5. Verify badge appears in README
+
+## Badge Configuration
+
+### Current Badge
+```markdown
+[![codecov](https://codecov.io/gh/sublime247/mobile-money/branch/main/graph/badge.svg)](https://codecov.io/gh/sublime247/mobile-money)
+```
+
+### Custom Badge Styles
+```markdown
+<!-- Flat style -->
+[![codecov](https://codecov.io/gh/sublime247/mobile-money/branch/main/graph/badge.svg?style=flat)](https://codecov.io/gh/sublime247/mobile-money)
+
+<!-- Flat-square style -->
+[![codecov](https://codecov.io/gh/sublime247/mobile-money/branch/main/graph/badge.svg?style=flat-square)](https://codecov.io/gh/sublime247/mobile-money)
+
+<!-- For-the-badge style -->
+[![codecov](https://codecov.io/gh/sublime247/mobile-money/branch/main/graph/badge.svg?style=for-the-badge)](https://codecov.io/gh/sublime247/mobile-money)
+```
+
+## Coverage Thresholds
+
+### Current Settings
+- Minimum coverage: 70%
+- Threshold variance: 2%
+- Fail CI if coverage drops below threshold
+
+### Adjusting Thresholds
+Edit `jest.config.js`:
+```javascript
+coverageThreshold: {
+  global: {
+    branches: 70,
+    functions: 70,
+    lines: 70,
+    statements: 70
+  }
+}
+```
+
+Edit `codecov.yml`:
+```yaml
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 2%
+```
+
+## Codecov Features
+
+### Pull Request Comments
+Codecov automatically comments on PRs with:
+- Coverage percentage change
+- Lines covered/uncovered
+- File-by-file breakdown
+- Visual diff of coverage changes
+
+### Coverage Visualization
+- Line-by-line coverage in Codecov UI
+- Sunburst chart of project coverage
+- Coverage trends over time
+- Commit-by-commit tracking
+
+### Notifications
+Configure in Codecov settings:
+- Slack notifications
+- Email alerts
+- Webhook integrations
+
+## Troubleshooting
+
+### Badge Shows "unknown"
+- Wait 5-10 minutes after first push
+- Verify workflow completed successfully
+- Check Codecov received the upload
+- Clear browser cache
+
+### Coverage Not Uploading
+```bash
+# Check GitHub Actions logs for errors
+# Common issues:
+# 1. CODECOV_TOKEN not set
+# 2. Coverage file not generated
+# 3. Network issues
+
+# Verify locally:
+npm run test:coverage
+ls -la coverage/lcov.info  # Should exist
+```
+
+### Token Issues
+- Regenerate token in Codecov settings
+- Update GitHub secret with new token
+- Re-run failed workflow
+
+### Coverage Seems Wrong
+- Check `codecov.yml` ignore patterns
+- Verify `jest.config.js` collectCoverageFrom
+- Ensure tests are actually running
+
+## Local Development
+
+### Generate Coverage Report
+```bash
+npm run test:coverage
+```
+
+### View HTML Report
+```bash
+# Linux
+xdg-open coverage/lcov-report/index.html
+
+# macOS
+open coverage/lcov-report/index.html
+
+# Windows
+start coverage/lcov-report/index.html
+```
+
+### Check Coverage Thresholds
+```bash
+# Will fail if below 70%
+npm run test:coverage
+```
+
+## Alternative: Coveralls
+
+If you prefer Coveralls over Codecov:
+
+### 1. Sign up at https://coveralls.io
+### 2. Add repository
+### 3. Update workflow:
+```yaml
+- name: Upload to Coveralls
+  uses: coverallsapp/github-action@v2
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### 4. Update badge:
+```markdown
+[![Coverage Status](https://coveralls.io/repos/github/sublime247/mobile-money/badge.svg?branch=main)](https://coveralls.io/github/sublime247/mobile-money?branch=main)
+```
+
+## Next Steps
+1. Complete Codecov setup (Steps 1-4 above)
+2. Write tests for existing code
+3. Monitor coverage in PRs
+4. Aim to increase coverage over time
+5. Review uncovered code regularly

--- a/docs/CODE_COVERAGE.md
+++ b/docs/CODE_COVERAGE.md
@@ -1,0 +1,227 @@
+# Code Coverage
+
+## Overview
+The project uses Jest for testing and Codecov for coverage tracking and reporting. Coverage badges are automatically updated on every push to main.
+
+## Coverage Requirements
+
+### Minimum Thresholds
+- **Branches**: 70%
+- **Functions**: 70%
+- **Lines**: 70%
+- **Statements**: 70%
+
+These thresholds are enforced in CI/CD pipeline and will fail builds that don't meet requirements.
+
+## Viewing Coverage
+
+### Badge
+The README displays the current coverage percentage:
+
+[![codecov](https://codecov.io/gh/sublime247/mobile-money/branch/main/graph/badge.svg)](https://codecov.io/gh/sublime247/mobile-money)
+
+### Codecov Dashboard
+Visit: https://codecov.io/gh/sublime247/mobile-money
+
+Features:
+- Line-by-line coverage visualization
+- Coverage trends over time
+- Pull request coverage diff
+- File and directory coverage breakdown
+
+### Local Coverage Report
+```bash
+# Run tests with coverage
+npm run test:coverage
+
+# Open HTML report
+open coverage/lcov-report/index.html
+```
+
+## Running Tests
+
+### All Tests
+```bash
+npm test
+```
+
+### Watch Mode
+```bash
+npm run test:watch
+```
+
+### With Coverage
+```bash
+npm run test:coverage
+```
+
+### Specific Test File
+```bash
+npm test -- referenceGenerator.test.ts
+```
+
+## Writing Tests
+
+### Test File Location
+- Place tests in `tests/` directory
+- Mirror source structure: `src/utils/file.ts` → `tests/utils/file.test.ts`
+- Or use `__tests__` directories within source folders
+
+### Test File Naming
+- `*.test.ts` - Unit tests
+- `*.spec.ts` - Integration tests
+
+### Example Test
+```typescript
+import { myFunction } from '../../src/utils/myFunction';
+
+describe('myFunction', () => {
+  it('should do something', () => {
+    const result = myFunction('input');
+    expect(result).toBe('expected');
+  });
+
+  it('should handle errors', () => {
+    expect(() => myFunction(null)).toThrow('Error message');
+  });
+});
+```
+
+## Coverage Configuration
+
+### Jest Configuration
+Coverage settings in `jest.config.js`:
+```javascript
+collectCoverageFrom: [
+  'src/**/*.ts',
+  '!src/**/*.d.ts',
+  '!src/index.ts',
+  '!src/**/__tests__/**'
+],
+coverageThreshold: {
+  global: {
+    branches: 70,
+    functions: 70,
+    lines: 70,
+    statements: 70
+  }
+}
+```
+
+### Codecov Configuration
+Settings in `codecov.yml`:
+- Target coverage: 70%
+- Threshold: 2% (allows small decreases)
+- Comments on PRs with coverage diff
+- Ignores test files and examples
+
+## CI/CD Integration
+
+### Automatic Coverage Upload
+On every push and PR:
+1. Tests run with coverage collection
+2. Coverage report generated (lcov format)
+3. Report uploaded to Codecov
+4. Badge updated automatically
+5. PR comment added with coverage diff
+
+### GitHub Actions Workflow
+See `.github/workflows/ci.yml` and `.github/workflows/coverage.yml`
+
+## Setup Instructions
+
+### 1. Sign Up for Codecov
+1. Go to https://codecov.io
+2. Sign in with GitHub
+3. Add repository: sublime247/mobile-money
+
+### 2. Get Codecov Token
+1. Go to repository settings on Codecov
+2. Copy the upload token
+3. Add to GitHub repository secrets as `CODECOV_TOKEN`
+
+### 3. Add GitHub Secret
+1. Go to GitHub repository settings
+2. Navigate to Secrets and variables → Actions
+3. Click "New repository secret"
+4. Name: `CODECOV_TOKEN`
+5. Value: [paste token from Codecov]
+
+### 4. Verify Setup
+1. Push code to main branch
+2. Check GitHub Actions tab for workflow run
+3. Verify coverage uploaded to Codecov
+4. Check badge displays in README
+
+## Coverage Best Practices
+
+### 1. Test Critical Paths
+Focus on:
+- Business logic
+- Data transformations
+- Error handling
+- Edge cases
+
+### 2. Don't Test Everything
+Skip:
+- Type definitions
+- Simple getters/setters
+- Configuration files
+- Third-party integrations (mock instead)
+
+### 3. Aim for Meaningful Coverage
+- 70% is minimum, not target
+- 100% coverage doesn't mean bug-free
+- Focus on quality over quantity
+
+### 4. Review Coverage Reports
+- Check which lines are uncovered
+- Identify untested edge cases
+- Look for dead code
+
+## Troubleshooting
+
+### Coverage Not Uploading
+- Check `CODECOV_TOKEN` is set in GitHub secrets
+- Verify workflow has `secrets.CODECOV_TOKEN` in codecov action
+- Check coverage file exists: `./coverage/lcov.info`
+
+### Badge Not Updating
+- Wait 5-10 minutes after push
+- Clear browser cache
+- Check Codecov dashboard for latest data
+
+### Tests Failing in CI
+- Ensure all dependencies in package.json
+- Check environment variables are set
+- Verify database/Redis services are healthy
+
+### Coverage Below Threshold
+- Run `npm run test:coverage` locally
+- Check coverage report: `coverage/lcov-report/index.html`
+- Add tests for uncovered code
+- Consider adjusting thresholds if unrealistic
+
+## Monitoring Coverage
+
+### Pull Request Checks
+Codecov automatically:
+- Comments on PRs with coverage changes
+- Shows coverage diff (lines added/removed)
+- Fails PR if coverage drops significantly
+
+### Coverage Trends
+Monitor in Codecov dashboard:
+- Coverage over time
+- Per-file coverage
+- Commit-by-commit changes
+- Branch comparisons
+
+## Excluded from Coverage
+- Test files (`*.test.ts`, `*.spec.ts`)
+- Example files (`examples/**/*`)
+- Type definitions (`*.d.ts`)
+- Entry point (`src/index.ts`)
+- Build output (`dist/**/*`)
+
+See `codecov.yml` for full exclusion list.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/index.ts',
+    '!src/**/__tests__/**'
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageThreshold: {
+    global: {
+      branches: 70,
+      functions: 70,
+      lines: 70,
+      statements: 70
+    }
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  verbose: true
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "lint": "eslint src --ext .ts"
+    "lint": "eslint src --ext .ts",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",
@@ -36,6 +39,9 @@
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
     "@types/redis": "^4.0.11",
-    "@types/connect-timeout": "^0.0.38"
+    "@types/connect-timeout": "^0.0.38",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/tests/utils/referenceGenerator.test.ts
+++ b/tests/utils/referenceGenerator.test.ts
@@ -1,0 +1,18 @@
+import { isValidReferenceNumber } from '../../src/utils/referenceGenerator';
+
+describe('Reference Number Generator', () => {
+  describe('isValidReferenceNumber', () => {
+    it('should validate correct reference number format', () => {
+      expect(isValidReferenceNumber('TXN-20260322-00001')).toBe(true);
+      expect(isValidReferenceNumber('TXN-20260322-99999')).toBe(true);
+    });
+
+    it('should reject invalid formats', () => {
+      expect(isValidReferenceNumber('TXN-2026032-00001')).toBe(false);  // Wrong date length
+      expect(isValidReferenceNumber('TXN-20260322-0001')).toBe(false);   // Wrong sequence length
+      expect(isValidReferenceNumber('TX-20260322-00001')).toBe(false);   // Wrong prefix
+      expect(isValidReferenceNumber('TXN-20260322-ABCDE')).toBe(false);  // Non-numeric sequence
+      expect(isValidReferenceNumber('invalid')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
- Add Jest testing framework with TypeScript support
- Configure code coverage collection and reporting
- Add Codecov badge to README
- Create CI/CD workflows for coverage upload
- Set coverage thresholds at 70% (branches, functions, lines, statements)
- Add sample test for reference number validation
- Configure codecov.yml with project settings
- Update .gitignore to exclude coverage files

Features:
- Automatic coverage upload on push/PR
- Coverage badge auto-updates
- PR comments with coverage diff
- HTML coverage reports locally
- Coverage threshold enforcement

Scripts:
- npm test - Run all tests
- npm run test:watch - Watch mode
- npm run test:coverage - Generate coverage report

Setup Required:
1. Sign up at codecov.io
2. Add repository
3. Add CODECOV_TOKEN to GitHub secrets
4. Push to trigger first coverage upload

Documentation:
- docs/CODE_COVERAGE.md - Comprehensive guide
- docs/CODECOV_SETUP.md - Step-by-step setup

Resolves #85

## Description
Brief description of changes.

## Related Issue
Fixes #(issue number)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made
- 
- 
- 

## Testing
How did you test these changes?

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
