### PR TITLE
refactor(transactions): use TransactionStatus enum instead of string …

### DIFF
--- a/examples/lock-usage.ts
+++ b/examples/lock-usage.ts
@@ -3,7 +3,7 @@
  */
 
 import { lockManager, LockKeys } from '../src/utils/lock';
-import { TransactionModel } from '../src/models/transaction';
+import { TransactionModel, TransactionStatus } from '../src/models/transaction';
 
 const transactionModel = new TransactionModel();
 
@@ -22,7 +22,7 @@ export async function createTransactionSafely(
   return await lockManager.withLock(lockKey, async () => {
     // Check for existing pending transaction
     const existing = await transactionModel.findById(phoneNumber);
-    if (existing && existing.status === 'pending') {
+    if (existing && existing.status === TransactionStatus.Pending) {
       throw new Error('Transaction already in progress for this phone number');
     }
     
@@ -33,7 +33,7 @@ export async function createTransactionSafely(
       phoneNumber,
       provider,
       stellarAddress,
-      status: 'pending'
+      status: TransactionStatus.Pending
     });
   }, 15000);
 }
@@ -52,7 +52,7 @@ export async function processTransactionSafely(transactionId: string) {
       throw new Error('Transaction not found');
     }
     
-    if (tx.status !== 'pending') {
+    if (tx.status !== TransactionStatus.Pending) {
       throw new Error('Transaction already processed');
     }
     
@@ -62,7 +62,7 @@ export async function processTransactionSafely(transactionId: string) {
     // Simulate processing
     await new Promise(resolve => setTimeout(resolve, 1000));
     
-    await transactionModel.updateStatus(transactionId, 'completed');
+    await transactionModel.updateStatus(transactionId, TransactionStatus.Completed);
     
     return tx;
   }, 30000);

--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { StellarService } from "../services/stellar/stellarService";
 import { MobileMoneyService } from "../services/mobilemoney/mobileMoneyService";
-import { TransactionModel } from "../models/transaction";
+import { TransactionModel, TransactionStatus } from "../models/transaction";
 import { lockManager, LockKeys } from "../utils/lock";
 import { addTransactionJob, getJobProgress } from "../queue";
 
@@ -22,7 +22,7 @@ export const depositHandler = async (req: Request, res: Response) => {
           phoneNumber,
           provider,
           stellarAddress,
-          status: "pending",
+          status: TransactionStatus.Pending,
           tags: [],
         });
 
@@ -38,7 +38,7 @@ export const depositHandler = async (req: Request, res: Response) => {
         return {
           transactionId: transaction.id,
           referenceNumber: transaction.referenceNumber,
-          status: "pending",
+          status: TransactionStatus.Pending,
           jobId: job.id,
         };
       },
@@ -71,7 +71,7 @@ export const withdrawHandler = async (req: Request, res: Response) => {
       phoneNumber,
       provider,
       stellarAddress,
-      status: "pending",
+      status: TransactionStatus.Pending,
       tags: [],
     });
 
@@ -87,7 +87,7 @@ export const withdrawHandler = async (req: Request, res: Response) => {
     res.json({
       transactionId: transaction.id,
       referenceNumber: transaction.referenceNumber,
-      status: "pending",
+      status: TransactionStatus.Pending,
       jobId: job.id,
     });
   } catch (error) {
@@ -105,7 +105,7 @@ export const getTransactionHandler = async (req: Request, res: Response) => {
     }
 
     let jobProgress = null;
-    if (transaction.status === "pending") {
+    if (transaction.status === TransactionStatus.Pending) {
       jobProgress = await getJobProgress(id);
     }
 

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -1,6 +1,12 @@
 import { pool } from '../config/database';
 import { generateReferenceNumber } from '../utils/referenceGenerator';
 
+export enum TransactionStatus {
+  Pending = 'pending',
+  Completed = 'completed',
+  Failed = 'failed',
+}
+
 const MAX_TAGS = 10;
 // Tags must be lowercase alphanumeric words, hyphens allowed (e.g. "refund", "high-priority")
 const TAG_REGEX = /^[a-z0-9-]+$/;
@@ -20,7 +26,7 @@ export interface Transaction {
   phoneNumber: string;
   provider: string;
   stellarAddress: string;
-  status: 'pending' | 'completed' | 'failed';
+  status: TransactionStatus;
   tags: string[];
   createdAt: Date;
 }
@@ -45,7 +51,7 @@ export class TransactionModel {
     return result.rows[0] || null;
   }
 
-  async updateStatus(id: string, status: string): Promise<void> {
+  async updateStatus(id: string, status: TransactionStatus): Promise<void> {
     await pool.query('UPDATE transactions SET status = $1 WHERE id = $2', [status, id]);
   }
 

--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -5,7 +5,7 @@ import {
   TRANSACTION_QUEUE_NAME,
 } from "./transactionQueue";
 import { queueOptions } from "./config";
-import { TransactionModel } from "../models/transaction";
+import { TransactionModel, TransactionStatus } from "../models/transaction";
 import { MobileMoneyService } from "../services/mobilemoney/mobileMoneyService";
 import { StellarService } from "../services/stellar/stellarService";
 
@@ -65,7 +65,7 @@ export const transactionWorker = new Worker<
 
         await job.updateProgress(90);
 
-        await transactionModel.updateStatus(transactionId, "completed");
+        await transactionModel.updateStatus(transactionId, TransactionStatus.Completed);
 
         await job.updateProgress(100);
 
@@ -96,7 +96,7 @@ export const transactionWorker = new Worker<
 
         await job.updateProgress(90);
 
-        await transactionModel.updateStatus(transactionId, "completed");
+        await transactionModel.updateStatus(transactionId, TransactionStatus.Completed);
 
         await job.updateProgress(100);
 
@@ -111,7 +111,7 @@ export const transactionWorker = new Worker<
       }
     } catch (error) {
       console.error(`[${job.id}] Transaction failed:`, error);
-      await transactionModel.updateStatus(transactionId, "failed");
+      await transactionModel.updateStatus(transactionId, TransactionStatus.Failed);
       throw error;
     }
   },

--- a/src/routes/bulk.ts
+++ b/src/routes/bulk.ts
@@ -25,7 +25,7 @@ import { Router, Request, Response, NextFunction } from 'express';
 import multer, { MulterError } from 'multer';
 import csvParser from 'csv-parser';
 import { Readable } from 'stream';
-import { TransactionModel } from '../models/transaction';
+import { TransactionModel, TransactionStatus } from '../models/transaction';
 import { MobileMoneyService } from '../services/mobilemoney/mobileMoneyService';
 import { StellarService } from '../services/stellar/stellarService';
 
@@ -162,7 +162,7 @@ async function processJob(jobId: string, rows: CsvRow[]): Promise<void> {
         phoneNumber: row.phoneNumber,
         provider: row.provider.toUpperCase(),
         stellarAddress: row.stellarAddress,
-        status: 'pending',
+        status: TransactionStatus.Pending,
         tags: [],
       });
 
@@ -174,9 +174,9 @@ async function processJob(jobId: string, rows: CsvRow[]): Promise<void> {
 
       if (mobileResult.success && stellarService) {
         await stellarService.sendPayment(row.stellarAddress, row.amount);
-        await transactionModel.updateStatus(transaction.id, 'completed');
+        await transactionModel.updateStatus(transaction.id, TransactionStatus.Completed);
       } else {
-        await transactionModel.updateStatus(transaction.id, 'failed');
+        await transactionModel.updateStatus(transaction.id, TransactionStatus.Failed);
       }
 
       job.succeeded++;


### PR DESCRIPTION
**Summary**  
Replaces ad hoc `'pending' | 'completed' | 'failed'` strings for **transaction** row status with a single `TransactionStatus` enum exported from the transaction model, and updates all code paths that create, update, or compare that status so types and usage stay consistent.

**Motivation**  
String literals for status are easy to mistype and hard to refactor. A shared enum gives compile-time safety, clearer intent, and a single place to document allowed values that match the database.

**Changes**  
- **`src/models/transaction.ts`**  
  - Add `export enum TransactionStatus` with string values `pending`, `completed`, `failed` (unchanged at the DB layer).  
  - Set `Transaction.status` to `TransactionStatus`.  
  - Narrow `TransactionModel.updateStatus` to accept `TransactionStatus` instead of `string`.

- **`src/controllers/transactionController.ts`**  
  - Use `TransactionStatus.Pending` when creating transactions and in JSON responses where the transaction status is returned.  
  - Compare with `TransactionStatus.Pending` when deciding whether to attach job progress.

- **`src/routes/bulk.ts`**  
  - Use the enum for per-row transaction `create` / `updateStatus` calls.  
  - **Unchanged:** bulk **job** lifecycle still uses `JobStatus` (`pending` / `processing` / `completed` / `failed`) — that is job state, not transaction row status.

- **`src/queue/worker.ts`**  
  - Use the enum for `updateStatus` on success and failure.  
  - **Unchanged:** BullMQ worker event names (`"completed"`, `"failed"`) remain string literals as required by the library.

- **`examples/lock-usage.ts`**  
  - Align examples with the same enum for consistency with application code.

**Out of scope (intentionally)**  
- HTTP response codes (`res.status(...)`).  
- Prometheus / provider metrics labels (`success` / `failure`, etc.).  
- Dispute status and bulk job status types.

**Testing**  
- `npx tsc --noEmit`  
- `npm test` (existing Jest suites)

**Migration / rollout**  
No schema or API contract change: enum values are the same strings as before; clients still see `pending`, `completed`, and `failed` in JSON where applicable.

Closes: #8 