### PR TITLE
feat: add transaction receipt generator

### DIFF
--- a/src/utils/receipt.ts
+++ b/src/utils/receipt.ts
@@ -1,0 +1,245 @@
+type ReceiptAmount = number | string | null | undefined;
+type ReceiptDateInput = Date | string | number | null | undefined;
+
+export interface ReceiptTransaction {
+  id: string;
+  amount: ReceiptAmount;
+  provider: string;
+  status: string;
+  phoneNumber?: string;
+  stellarAddress?: string;
+  sender?: string;
+  receiver?: string;
+  fee?: ReceiptAmount;
+  total?: ReceiptAmount;
+  transactionHash?: string;
+  referenceNumber?: string;
+  createdAt?: ReceiptDateInput;
+  currency?: string;
+}
+
+export interface ReceiptOptions {
+  generatedAt?: ReceiptDateInput;
+  receiptNumber?: string;
+}
+
+const RECEIPT_COUNTERS = new Map<string, number>();
+
+function formatReceiptDateStamp(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}${month}${day}`;
+}
+
+function nextReceiptSequence(dateStamp: string): number {
+  const nextSequence = (RECEIPT_COUNTERS.get(dateStamp) ?? 0) + 1;
+  RECEIPT_COUNTERS.set(dateStamp, nextSequence);
+  return nextSequence;
+}
+
+function toDate(value?: ReceiptDateInput): Date {
+  if (value instanceof Date) return value;
+  if (typeof value === "string" || typeof value === "number") {
+    return new Date(value);
+  }
+  return new Date();
+}
+
+function parseAmount(value: ReceiptAmount): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function formatAmount(value: ReceiptAmount, currency: string): string {
+  const parsedValue = parseAmount(value);
+  if (parsedValue === null) return `0 ${currency}`;
+
+  return `${new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: Number.isInteger(parsedValue) ? 0 : 2,
+    maximumFractionDigits: 7,
+  }).format(parsedValue)} ${currency}`;
+}
+
+function formatDate(value?: ReceiptDateInput): string {
+  const date = toDate(value);
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "2-digit",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(date);
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function buildReceiptViewModel(
+  transaction: ReceiptTransaction,
+  options: ReceiptOptions = {},
+) {
+  const generatedAt = toDate(options.generatedAt ?? transaction.createdAt);
+  const dateStamp = formatReceiptDateStamp(generatedAt);
+  const receiptNumber =
+    options.receiptNumber ??
+    `RCP-${dateStamp}-${String(nextReceiptSequence(dateStamp)).padStart(5, "0")}`;
+  const currency = transaction.currency ?? "XAF";
+  const amountValue = parseAmount(transaction.amount) ?? 0;
+  const feeValue = parseAmount(transaction.fee) ?? 0;
+  const totalValue = parseAmount(transaction.total) ?? amountValue + feeValue;
+
+  return {
+    receiptNumber,
+    receiptDate: formatDate(generatedAt),
+    amount: formatAmount(amountValue, currency),
+    fee: formatAmount(feeValue, currency),
+    total: formatAmount(totalValue, currency),
+    provider: transaction.provider,
+    status: toTitleCase(transaction.status),
+    sender: transaction.sender ?? transaction.phoneNumber ?? "N/A",
+    receiver: transaction.receiver ?? transaction.stellarAddress ?? "N/A",
+    transactionId: transaction.id,
+    referenceNumber: transaction.referenceNumber,
+    transactionHash: transaction.transactionHash,
+  };
+}
+
+/**
+ * Generates a unique receipt number using the format `RCP-YYYYMMDD-XXXXX`.
+ *
+ * @example
+ * const receiptNumber = generateReceiptNumber(new Date("2026-03-22T10:30:00Z"));
+ * // RCP-20260322-00001
+ */
+export function generateReceiptNumber(generatedAt?: ReceiptDateInput): string {
+  const date = toDate(generatedAt);
+  const dateStamp = formatReceiptDateStamp(date);
+  const sequence = nextReceiptSequence(dateStamp);
+  return `RCP-${dateStamp}-${String(sequence).padStart(5, "0")}`;
+}
+
+/**
+ * Generates a plain-text transaction receipt suitable for SMS previews or email bodies.
+ *
+ * @example
+ * const receipt = generateReceipt({
+ *   id: "abc123",
+ *   amount: "10000",
+ *   fee: "100",
+ *   provider: "MTN Mobile Money",
+ *   status: "completed",
+ *   phoneNumber: "+237 6XX XXX XXX",
+ *   stellarAddress: "GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+ *   createdAt: "2026-03-22T10:30:00Z",
+ * });
+ */
+export function generateReceipt(
+  transaction: ReceiptTransaction,
+  options: ReceiptOptions = {},
+): string {
+  const receipt = buildReceiptViewModel(transaction, options);
+  const lines = [
+    "========================================",
+    "        TRANSACTION RECEIPT",
+    "========================================",
+    `Receipt No: ${receipt.receiptNumber}`,
+    `Date: ${receipt.receiptDate}`,
+    "",
+    "Transaction Details:",
+    `- Amount: ${receipt.amount}`,
+    `- Fee: ${receipt.fee}`,
+    `- Total: ${receipt.total}`,
+    `- Provider: ${receipt.provider}`,
+    `- Status: ${receipt.status}`,
+    "",
+    `From: ${receipt.sender}`,
+    `To: ${receipt.receiver}`,
+    "",
+    `Transaction ID: ${receipt.transactionId}`,
+  ];
+
+  if (receipt.referenceNumber) {
+    lines.push(`Reference No: ${receipt.referenceNumber}`);
+  }
+
+  if (receipt.transactionHash) {
+    lines.push(`Stellar Hash: ${receipt.transactionHash}`);
+  }
+
+  lines.push(
+    "",
+    "Thank you for using our service!",
+    "========================================",
+  );
+
+  return lines.join("\n");
+}
+
+/**
+ * Generates an HTML receipt for email delivery.
+ *
+ * @example
+ * const html = generateReceiptHtml(transaction);
+ */
+export function generateReceiptHtml(
+  transaction: ReceiptTransaction,
+  options: ReceiptOptions = {},
+): string {
+  const receipt = buildReceiptViewModel(transaction, options);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <body style="margin:0;padding:24px;background:#f5f7fb;font-family:Arial,sans-serif;color:#0f172a;">
+    <div style="max-width:560px;margin:0 auto;background:#ffffff;border:1px solid #dbe4f0;border-radius:12px;overflow:hidden;">
+      <div style="padding:24px;border-bottom:1px solid #dbe4f0;">
+        <p style="margin:0 0 8px;font-size:12px;letter-spacing:0.08em;text-transform:uppercase;color:#64748b;">Transaction Receipt</p>
+        <h1 style="margin:0;font-size:24px;">${escapeHtml(receipt.receiptNumber)}</h1>
+        <p style="margin:8px 0 0;color:#475569;">${escapeHtml(receipt.receiptDate)}</p>
+      </div>
+      <div style="padding:24px;">
+        <h2 style="margin:0 0 12px;font-size:16px;">Transaction Details</h2>
+        <table style="width:100%;border-collapse:collapse;">
+          <tr><td style="padding:8px 0;color:#64748b;">Amount</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.amount)}</td></tr>
+          <tr><td style="padding:8px 0;color:#64748b;">Fee</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.fee)}</td></tr>
+          <tr><td style="padding:8px 0;color:#64748b;">Total</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.total)}</td></tr>
+          <tr><td style="padding:8px 0;color:#64748b;">Provider</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.provider)}</td></tr>
+          <tr><td style="padding:8px 0;color:#64748b;">Status</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.status)}</td></tr>
+          <tr><td style="padding:8px 0;color:#64748b;">From</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.sender)}</td></tr>
+          <tr><td style="padding:8px 0;color:#64748b;">To</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.receiver)}</td></tr>
+          <tr><td style="padding:8px 0;color:#64748b;">Transaction ID</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.transactionId)}</td></tr>
+          ${
+            receipt.referenceNumber
+              ? `<tr><td style="padding:8px 0;color:#64748b;">Reference No</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.referenceNumber)}</td></tr>`
+              : ""
+          }
+          ${
+            receipt.transactionHash
+              ? `<tr><td style="padding:8px 0;color:#64748b;">Stellar Hash</td><td style="padding:8px 0;text-align:right;">${escapeHtml(receipt.transactionHash)}</td></tr>`
+              : ""
+          }
+        </table>
+      </div>
+    </div>
+  </body>
+</html>`;
+}

--- a/tests/utils/receipt.test.ts
+++ b/tests/utils/receipt.test.ts
@@ -1,0 +1,87 @@
+import {
+  generateReceipt,
+  generateReceiptHtml,
+  generateReceiptNumber,
+} from "../../src/utils/receipt";
+
+describe("receipt utilities", () => {
+  const baseTransaction = {
+    id: "abc123-def456",
+    amount: "10000",
+    fee: "100",
+    provider: "MTN Mobile Money",
+    status: "completed",
+    phoneNumber: "+237 6XX XXX XXX",
+    stellarAddress: "GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    transactionHash: "7a8b9c123456",
+    referenceNumber: "TXN-20260322-00001",
+  };
+
+  it("generates receipt numbers in the expected format", () => {
+    const receiptNumber = generateReceiptNumber("2026-03-22T10:30:00Z");
+
+    expect(receiptNumber).toMatch(/^RCP-20260322-\d{5}$/);
+  });
+
+  it("generates unique receipt numbers for the same day", () => {
+    const first = generateReceiptNumber("2026-03-23T08:00:00Z");
+    const second = generateReceiptNumber("2026-03-23T09:00:00Z");
+
+    expect(first).not.toBe(second);
+  });
+
+  it("renders a readable plain-text receipt with transaction details", () => {
+    const receipt = generateReceipt(baseTransaction, {
+      generatedAt: "2026-03-24T10:30:00Z",
+      receiptNumber: "RCP-20260324-00042",
+    });
+
+    expect(receipt).toContain("TRANSACTION RECEIPT");
+    expect(receipt).toContain("Receipt No: RCP-20260324-00042");
+    expect(receipt).toContain("Date: March 24, 2026");
+    expect(receipt).toContain("- Amount: 10,000 XAF");
+    expect(receipt).toContain("- Fee: 100 XAF");
+    expect(receipt).toContain("- Total: 10,100 XAF");
+    expect(receipt).toContain("- Provider: MTN Mobile Money");
+    expect(receipt).toContain("- Status: Completed");
+    expect(receipt).toContain("From: +237 6XX XXX XXX");
+    expect(receipt).toContain("To: GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    expect(receipt).toContain("Transaction ID: abc123-def456");
+    expect(receipt).toContain("Reference No: TXN-20260322-00001");
+    expect(receipt).toContain("Stellar Hash: 7a8b9c123456");
+  });
+
+  it("omits the stellar hash section when no hash is available", () => {
+    const receipt = generateReceipt(
+      {
+        ...baseTransaction,
+        transactionHash: undefined,
+      },
+      {
+        generatedAt: "2026-03-25T10:30:00Z",
+        receiptNumber: "RCP-20260325-00001",
+      },
+    );
+
+    expect(receipt).not.toContain("Stellar Hash:");
+  });
+
+  it("generates an HTML receipt for email delivery", () => {
+    const html = generateReceiptHtml(
+      {
+        ...baseTransaction,
+        provider: "MTN <strong>Mobile</strong> Money",
+      },
+      {
+        generatedAt: "2026-03-26T10:30:00Z",
+        receiptNumber: "RCP-20260326-00010",
+      },
+    );
+
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("RCP-20260326-00010");
+    expect(html).toContain("10,100 XAF");
+    expect(html).toContain("GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    expect(html).toContain("MTN &lt;strong&gt;Mobile&lt;/strong&gt; Money");
+  });
+});


### PR DESCRIPTION
## Summary
- add `src/utils/receipt.ts` with unique receipt-number generation in `RCP-YYYYMMDD-XXXXX` format
- generate readable plain-text receipts with amount, fee, total, provider, status, sender, receiver, transaction ID, optional reference number, and optional Stellar hash
- add HTML receipt generation for email delivery
- add unit tests and inline usage examples for the receipt utility

## Testing
- node .\node_modules\typescript\bin\tsc --pretty false --noEmit --target es2020 --module commonjs --moduleResolution node --esModuleInterop --types jest,node src\utils\receipt.ts tests\utils\receipt.test.ts
- npx tsx -e "import { generateReceipt, generateReceiptHtml, generateReceiptNumber } from './src/utils/receipt.ts'; const tx={id:'abc123-def456',amount:'10000',fee:'100',provider:'MTN Mobile Money',status:'completed',phoneNumber:'+237 6XX XXX XXX',stellarAddress:'GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',transactionHash:'7a8b9c123456',referenceNumber:'TXN-20260322-00001'}; const receipt=generateReceipt(tx,{generatedAt:'2026-03-24T10:30:00Z',receiptNumber:'RCP-20260324-00042'}); const html=generateReceiptHtml(tx,{generatedAt:'2026-03-24T10:30:00Z',receiptNumber:'RCP-20260324-00042'}); const number=generateReceiptNumber('2026-03-24T10:30:00Z'); if(!receipt.includes('TRANSACTION RECEIPT')||!receipt.includes('10,100 XAF')||!html.includes('<!DOCTYPE html>')||!/^RCP-20260324-\\d{5}$/.test(number)){ process.exit(1);} console.log('receipt smoke passed');"
- npx prettier --check src/utils/receipt.ts tests/utils/receipt.test.ts

## Notes
- the issue title mentions a retry mechanism, but the detailed body and acceptance criteria are for receipt generation, so this PR follows the body requirements
- full `npm run type-check` is currently blocked by an unrelated existing syntax error in `src/controllers/transactionController.ts`
- the targeted Jest path run timed out under the repo’s current test setup

Closes #27
