### PR TITLE
feat: Add transaction receipt generation (#30)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@types/node-cron": "^3.0.11",
         "@types/pg": "^8.10.9",
         "@types/redis": "^4.0.11",
+        "@types/supertest": "^7.2.0",
         "@types/ws": "^8.5.14",
         "@typescript-eslint/eslint-plugin": "^8.57.2",
         "@typescript-eslint/parser": "^8.57.2",
@@ -2710,8 +2711,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -2831,8 +2831,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
       "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -2945,6 +2944,28 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -4739,25 +4760,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/detect-europe-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -6325,25 +6327,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
-    },
-    "node_modules/is-standalone-pwa": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -10003,55 +9986,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/ua-is-frozen": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
-    },
-    "node_modules/ua-parser-js": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
-      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "dependencies": {
-        "detect-europe-js": "^0.1.2",
-        "is-standalone-pwa": "^0.1.1",
-        "ua-is-frozen": "^0.1.2"
-      },
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/node-cron": "^3.0.11",
     "@types/pg": "^8.10.9",
     "@types/redis": "^4.0.11",
+    "@types/supertest": "^7.2.0",
     "@types/ws": "^8.5.14",
     "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@typescript-eslint/parser": "^8.57.2",

--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -419,8 +419,7 @@ export const cancelTransactionHandler = async (req: Request, res: Response) => {
     res.json({
       message: "Transaction cancelled successfully",
       transaction: updatedTransaction,
-    };
-    return res.json(body);
+    });
   } catch (err) {
     console.error("Failed to cancel transaction:", err);
     res.status(500).json({ error: "Failed to cancel transaction" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { transactionRoutes } from "./routes/transactions";
 import { bulkRoutes } from "./routes/bulk";
 import { transactionDisputeRoutes, disputeRoutes } from "./routes/disputes";
 import { statsRoutes } from "./routes/stats";
+import { reportsRoutes } from "./routes/reports";
 import { errorHandler } from "./middleware/errorHandler";
 import { connectRedis, redisClient } from "./config/redis";
 import { pool } from "./config/database";
@@ -131,6 +132,7 @@ app.use("/api/transactions", transactionDisputeRoutes);
 app.use("/api/transactions/bulk", bulkRoutes);
 app.use("/api/disputes", disputeRoutes);
 app.use("/api/stats", statsRoutes);
+app.use("/api/reports", reportsRoutes);
 
 // Queue endpoints
 app.get("/health/queue", getQueueHealth);
@@ -190,5 +192,3 @@ app.listen(PORT, () => {
     `Rate limit: ${RATE_LIMIT_MAX_REQUESTS} requests per ${RATE_LIMIT_WINDOW_MS / 1000}s`,
   );
 });
-
-export default app;

--- a/src/middleware/timeout.ts
+++ b/src/middleware/timeout.ts
@@ -81,6 +81,7 @@ export function customTimeout(timeoutMs: number) {
  */
 export const TimeoutPresets = {
   quick: customTimeout(5000), // 5 seconds - for simple queries
+  medium: customTimeout(15000), // 15 seconds - for report generation
   standard: customTimeout(30000), // 30 seconds - default operations
   long: customTimeout(60000), // 60 seconds - complex transactions
   extended: customTimeout(120000), // 2 minutes - batch operations

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -1,0 +1,308 @@
+import { Router, Request, Response } from "express";
+import { pool } from "../config/database";
+import { redisClient } from "../config/redis";
+import { requireAuth, AuthRequest } from "../middleware/auth";
+import { TimeoutPresets, haltOnTimedout } from "../middleware/timeout";
+
+export const reportsRoutes = Router();
+
+interface ReconciliationQuery {
+  startDate: string;
+  endDate: string;
+  format?: 'json' | 'csv';
+}
+
+interface ReconciliationReport {
+  period: {
+    start: string;
+    end: string;
+  };
+  summary: {
+    totalTransactions: number;
+    successfulTransactions: number;
+    failedTransactions: number;
+    successRate: number;
+    totalVolume: number;
+    totalFees: number;
+  };
+  byProvider: {
+    [provider: string]: {
+      count: number;
+      volume: number;
+    };
+  };
+  dailyBreakdown?: Array<{
+    date: string;
+    totalTransactions: number;
+    successfulTransactions: number;
+    failedTransactions: number;
+    totalVolume: number;
+    totalFees: number;
+  }>;
+}
+
+// Helper function to calculate fees (2% of amount)
+const calculateFee = (amount: number): number => {
+  return amount * 0.02;
+};
+
+// Helper function to format CSV
+const formatCSV = (report: ReconciliationReport): string => {
+  const headers = [
+    'Date',
+    'Provider',
+    'Total Transactions',
+    'Successful Transactions',
+    'Failed Transactions',
+    'Success Rate (%)',
+    'Total Volume',
+    'Total Fees'
+  ];
+
+  const rows = [headers.join(',')];
+
+  // Add summary row
+  rows.push([
+    report.period.start + ' to ' + report.period.end,
+    'ALL',
+    report.summary.totalTransactions.toString(),
+    report.summary.successfulTransactions.toString(),
+    report.summary.failedTransactions.toString(),
+    report.summary.successRate.toString(),
+    report.summary.totalVolume.toString(),
+    report.summary.totalFees.toString()
+  ].join(','));
+
+  // Add provider breakdown
+  Object.entries(report.byProvider).forEach(([provider, data]) => {
+    rows.push([
+      report.period.start + ' to ' + report.period.end,
+      provider,
+      data.count.toString(),
+      '',
+      '',
+      '',
+      data.volume.toString(),
+      calculateFee(data.volume).toString()
+    ].join(','));
+  });
+
+  // Add daily breakdown if available
+  if (report.dailyBreakdown) {
+    report.dailyBreakdown.forEach(day => {
+      rows.push([
+        day.date,
+        'ALL',
+        day.totalTransactions.toString(),
+        day.successfulTransactions.toString(),
+        day.failedTransactions.toString(),
+        ((day.successfulTransactions / day.totalTransactions) * 100).toFixed(1),
+        day.totalVolume.toString(),
+        day.totalFees.toString()
+      ].join(','));
+    });
+  }
+
+  return rows.join('\n');
+};
+
+// GET /api/reports/reconciliation
+reportsRoutes.get(
+  "/reconciliation",
+  TimeoutPresets.medium,
+  haltOnTimedout,
+  requireAuth,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { startDate, endDate, format = 'json' } = req.query as unknown as ReconciliationQuery;
+
+      // Validate required parameters
+      if (!startDate || !endDate) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "startDate and endDate query parameters are required"
+        });
+      }
+
+      // Validate date format
+      const start = new Date(startDate);
+      const end = new Date(endDate);
+      
+      if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "Invalid date format. Use YYYY-MM-DD format"
+        });
+      }
+
+      if (start > end) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: "startDate must be before or equal to endDate"
+        });
+      }
+
+      // Create cache key
+      const cacheKey = `reconciliation_report:${startDate}:${endDate}:${format}`;
+      
+      // Try to get from cache first
+      if (redisClient?.isOpen) {
+        try {
+          const cached = await redisClient.get(cacheKey);
+          if (cached) {
+            console.log(`Cache hit for ${cacheKey}`);
+            return format === 'csv' 
+              ? res.header('Content-Type', 'text/csv').send(cached)
+              : res.json(JSON.parse(cached));
+          }
+        } catch (cacheError) {
+          console.warn("Cache read failed:", cacheError);
+        }
+      }
+
+      // Query database for transaction summaries
+      const query = `
+        SELECT 
+          provider,
+          status,
+          DATE(created_at) as date,
+          COUNT(*) as count,
+          COALESCE(SUM(amount), 0) as volume
+        FROM transactions 
+        WHERE DATE(created_at) >= $1 
+          AND DATE(created_at) <= $2
+        GROUP BY provider, status, DATE(created_at)
+        ORDER BY date DESC, provider
+      `;
+
+      const result = await pool.query(query, [startDate, endDate]);
+
+      // Process results
+      const providerData: { [key: string]: { count: number; volume: number; successful: number; failed: number } } = {};
+      const dailyData: { [date: string]: { total: number; successful: number; failed: number; volume: number } } = {};
+      
+      let totalTransactions = 0;
+      let successfulTransactions = 0;
+      let failedTransactions = 0;
+      let totalVolume = 0;
+
+      result.rows.forEach(row => {
+        const { provider, status, date, count, volume } = row;
+        
+        // Initialize provider data if not exists
+        if (!providerData[provider]) {
+          providerData[provider] = { count: 0, volume: 0, successful: 0, failed: 0 };
+        }
+        
+        // Initialize daily data if not exists
+        if (!dailyData[date]) {
+          dailyData[date] = { total: 0, successful: 0, failed: 0, volume: 0 };
+        }
+
+        const countNum = parseInt(count);
+        const volumeNum = parseFloat(volume);
+
+        // Update provider totals
+        providerData[provider].count += countNum;
+        providerData[provider].volume += volumeNum;
+        
+        if (status === 'completed') {
+          providerData[provider].successful += countNum;
+        } else if (status === 'failed') {
+          providerData[provider].failed += countNum;
+        }
+
+        // Update daily totals
+        dailyData[date].total += countNum;
+        dailyData[date].volume += volumeNum;
+        
+        if (status === 'completed') {
+          dailyData[date].successful += countNum;
+        } else if (status === 'failed') {
+          dailyData[date].failed += countNum;
+        }
+
+        // Update grand totals
+        totalTransactions += countNum;
+        totalVolume += volumeNum;
+        
+        if (status === 'completed') {
+          successfulTransactions += countNum;
+        } else if (status === 'failed') {
+          failedTransactions += countNum;
+        }
+      });
+
+      // Calculate success rate
+      const successRate = totalTransactions > 0 ? (successfulTransactions / totalTransactions) * 100 : 0;
+      const totalFees = calculateFee(totalVolume);
+
+      // Build provider breakdown
+      const byProvider: { [provider: string]: { count: number; volume: number } } = {};
+      Object.entries(providerData).forEach(([provider, data]) => {
+        byProvider[provider] = {
+          count: data.count,
+          volume: data.volume
+        };
+      });
+
+      // Build daily breakdown
+      const dailyBreakdown = Object.entries(dailyData)
+        .map(([date, data]) => ({
+          date,
+          totalTransactions: data.total,
+          successfulTransactions: data.successful,
+          failedTransactions: data.failed,
+          totalVolume: data.volume,
+          totalFees: calculateFee(data.volume)
+        }))
+        .sort((a, b) => a.date.localeCompare(b.date));
+
+      // Build report
+      const report: ReconciliationReport = {
+        period: {
+          start: startDate,
+          end: endDate
+        },
+        summary: {
+          totalTransactions,
+          successfulTransactions,
+          failedTransactions,
+          successRate: Math.round(successRate * 10) / 10, // Round to 1 decimal place
+          totalVolume: Math.round(totalVolume * 100) / 100, // Round to 2 decimal places
+          totalFees: Math.round(totalFees * 100) / 100
+        },
+        byProvider,
+        dailyBreakdown
+      };
+
+      // Cache the result for 1 hour (3600 seconds)
+      if (redisClient?.isOpen) {
+        try {
+          const cacheValue = format === 'csv' ? formatCSV(report) : JSON.stringify(report);
+          await redisClient.setEx(cacheKey, 3600, cacheValue);
+          console.log(`Cached ${cacheKey} for 1 hour`);
+        } catch (cacheError) {
+          console.warn("Cache write failed:", cacheError);
+        }
+      }
+
+      // Return response
+      if (format === 'csv') {
+        const csv = formatCSV(report);
+        res.header('Content-Type', 'text/csv');
+        res.header('Content-Disposition', `attachment; filename="reconciliation_report_${startDate}_to_${endDate}.csv"`);
+        return res.send(csv);
+      }
+
+      res.json(report);
+
+    } catch (error) {
+      console.error("Error generating reconciliation report:", error);
+      res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to generate reconciliation report"
+      });
+    }
+  }
+);

--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -8,11 +8,8 @@ import {
   getTransactionHistoryHandler, // Added for pagination/filtering
   updateNotesHandler,
   searchTransactionsHandler,
-  validateTransaction,
 } from "../controllers/transactionController";
 import { TimeoutPresets, haltOnTimedout } from "../middleware/timeout";
-
-import { validateTransaction } from "../controllers/transactionController";
 
 export const transactionRoutes = Router();
 

--- a/tests/reports.test.ts
+++ b/tests/reports.test.ts
@@ -1,0 +1,292 @@
+import request from 'supertest';
+import app from '../src/index';
+import { pool } from '../src/config/database';
+
+describe('Reports Integration Tests', () => {
+  const adminApiKey = process.env.ADMIN_API_KEY || 'dev-admin-key';
+
+  beforeAll(async () => {
+    // Setup test data
+    await pool.query(`
+      INSERT INTO transactions (reference_number, type, amount, phone_number, provider, stellar_address, status, created_at) VALUES
+      ('TEST001', 'deposit', 1000.00, '+256700000001', 'MTN', 'GD1234567890', 'completed', '2026-03-01 10:00:00'),
+      ('TEST002', 'withdraw', 500.00, '+256700000002', 'Airtel', 'GD1234567891', 'completed', '2026-03-01 11:00:00'),
+      ('TEST003', 'deposit', 750.00, '+256700000003', 'Orange', 'GD1234567892', 'failed', '2026-03-02 10:00:00'),
+      ('TEST004', 'deposit', 2000.00, '+256700000004', 'MTN', 'GD1234567893', 'completed', '2026-03-02 12:00:00'),
+      ('TEST005', 'withdraw', 300.00, '+256700000005', 'Airtel', 'GD1234567894', 'failed', '2026-03-03 09:00:00')
+      ON CONFLICT (reference_number) DO NOTHING
+    `);
+  });
+
+  afterAll(async () => {
+    // Cleanup test data
+    await pool.query("DELETE FROM transactions WHERE reference_number LIKE 'TEST%'");
+  });
+
+  describe('GET /api/reports/reconciliation', () => {
+    
+    // Test 1: Authentication required
+    it('should return 401 without authentication', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-03');
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+    });
+
+    // Test 2: Invalid API key
+    it('should return 401 with invalid API key', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-03')
+        .set('X-API-Key', 'invalid-key');
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+    });
+
+    // Test 3: Missing required parameters
+    it('should return 400 when startDate is missing', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?endDate=2026-03-03')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('startDate and endDate query parameters are required');
+    });
+
+    // Test 4: Missing required parameters
+    it('should return 400 when endDate is missing', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('startDate and endDate query parameters are required');
+    });
+
+    // Test 5: Invalid date format
+    it('should return 400 for invalid date format', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=01-03-2026&endDate=2026-03-03')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('Invalid date format');
+    });
+
+    // Test 6: Start date after end date
+    it('should return 400 when startDate is after endDate', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-05&endDate=2026-03-01')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('startDate must be before or equal to endDate');
+    });
+
+    // Test 7: Successful JSON report generation
+    it('should return 200 and generate JSON reconciliation report', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-03')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(200);
+      
+      const report = res.body;
+      expect(report).toHaveProperty('period');
+      expect(report).toHaveProperty('summary');
+      expect(report).toHaveProperty('byProvider');
+      expect(report).toHaveProperty('dailyBreakdown');
+
+      // Check period
+      expect(report.period.start).toBe('2026-03-01');
+      expect(report.period.end).toBe('2026-03-03');
+
+      // Check summary structure
+      expect(report.summary).toHaveProperty('totalTransactions');
+      expect(report.summary).toHaveProperty('successfulTransactions');
+      expect(report.summary).toHaveProperty('failedTransactions');
+      expect(report.summary).toHaveProperty('successRate');
+      expect(report.summary).toHaveProperty('totalVolume');
+      expect(report.summary).toHaveProperty('totalFees');
+
+      // Check provider breakdown
+      expect(report.byProvider).toHaveProperty('MTN');
+      expect(report.byProvider).toHaveProperty('Airtel');
+      expect(report.byProvider).toHaveProperty('Orange');
+
+      // Verify calculations
+      expect(report.summary.totalTransactions).toBe(5);
+      expect(report.summary.successfulTransactions).toBe(3);
+      expect(report.summary.failedTransactions).toBe(2);
+      expect(report.summary.successRate).toBe(60.0);
+      expect(report.summary.totalVolume).toBe(4550.00);
+      expect(report.summary.totalFees).toBe(91.00);
+
+      // Check provider breakdown
+      expect(report.byProvider.MTN.count).toBe(2);
+      expect(report.byProvider.MTN.volume).toBe(3000.00);
+      expect(report.byProvider.Airtel.count).toBe(2);
+      expect(report.byProvider.Airtel.volume).toBe(800.00);
+      expect(report.byProvider.Orange.count).toBe(1);
+      expect(report.byProvider.Orange.volume).toBe(750.00);
+    });
+
+    // Test 8: Successful CSV report generation
+    it('should return 200 and generate CSV reconciliation report', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-03&format=csv')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toBe('text/csv; charset=utf-8');
+      expect(res.headers['content-disposition']).toContain('reconciliation_report_2026-03-01_to_2026-03-03.csv');
+      
+      const csv = res.text;
+      expect(csv).toContain('Date,Provider,Total Transactions,Successful Transactions,Failed Transactions,Success Rate (%),Total Volume,Total Fees');
+      expect(csv).toContain('2026-03-01 to 2026-03-03,ALL,5,3,2,60.0,4550,91');
+      expect(csv).toContain('MTN');
+      expect(csv).toContain('Airtel');
+      expect(csv).toContain('Orange');
+    });
+
+    // Test 9: Empty date range
+    it('should return 200 for date range with no transactions', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-04-01&endDate=2026-04-02')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(200);
+      
+      const report = res.body;
+      expect(report.summary.totalTransactions).toBe(0);
+      expect(report.summary.successfulTransactions).toBe(0);
+      expect(report.summary.failedTransactions).toBe(0);
+      expect(report.summary.successRate).toBe(0);
+      expect(report.summary.totalVolume).toBe(0);
+      expect(report.summary.totalFees).toBe(0);
+      expect(Object.keys(report.byProvider)).toHaveLength(0);
+    });
+
+    // Test 10: Single day report
+    it('should generate report for single day', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-01')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(200);
+      
+      const report = res.body;
+      expect(report.summary.totalTransactions).toBe(2);
+      expect(report.summary.successfulTransactions).toBe(2);
+      expect(report.summary.failedTransactions).toBe(0);
+      expect(report.summary.successRate).toBe(100.0);
+    });
+
+    // Test 11: Large date range performance
+    it('should handle large date ranges efficiently', async () => {
+      const startTime = Date.now();
+      
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-01-01&endDate=2026-12-31')
+        .set('X-API-Key', adminApiKey);
+      
+      const endTime = Date.now();
+      const duration = endTime - startTime;
+      
+      expect(res.status).toBe(200);
+      expect(duration).toBeLessThan(10000); // Should complete within 10 seconds
+    });
+
+    // Test 12: Caching functionality
+    it('should cache report results', async () => {
+      // First request
+      const startTime1 = Date.now();
+      const res1 = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-03')
+        .set('X-API-Key', adminApiKey);
+      const endTime1 = Date.now();
+      const duration1 = endTime1 - startTime1;
+
+      // Second request (should be cached)
+      const startTime2 = Date.now();
+      const res2 = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-03')
+        .set('X-API-Key', adminApiKey);
+      const endTime2 = Date.now();
+      const duration2 = endTime2 - startTime2;
+
+      expect(res1.status).toBe(200);
+      expect(res2.status).toBe(200);
+      expect(res1.body).toEqual(res2.body);
+      
+      // Second request should be faster due to caching
+      expect(duration2).toBeLessThan(duration1);
+    });
+  });
+
+  describe('Report Data Validation', () => {
+    
+    // Test 13: Fee calculation accuracy
+    it('should calculate fees correctly (2% of volume)', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-03')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(200);
+      
+      const report = res.body;
+      const expectedFees = report.summary.totalVolume * 0.02;
+      expect(report.summary.totalFees).toBeCloseTo(expectedFees, 2);
+    });
+
+    // Test 14: Success rate calculation
+    it('should calculate success rate correctly', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-03')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(200);
+      
+      const report = res.body;
+      const expectedSuccessRate = (report.summary.successfulTransactions / report.summary.totalTransactions) * 100;
+      expect(report.summary.successRate).toBeCloseTo(expectedSuccessRate, 1);
+    });
+
+    // Test 15: Daily breakdown accuracy
+    it('should provide accurate daily breakdown', async () => {
+      const res = await request(app)
+        .get('/api/reports/reconciliation?startDate=2026-03-01&endDate=2026-03-03')
+        .set('X-API-Key', adminApiKey);
+      
+      expect(res.status).toBe(200);
+      
+      const report = res.body;
+      expect(report.dailyBreakdown).toHaveLength(3); // 3 days: 2026-03-01, 2026-03-02, 2026-03-03
+
+      // Check March 1st data
+      const march1 = report.dailyBreakdown.find((day: any) => day.date === '2026-03-01');
+      expect(march1).toBeDefined();
+      expect(march1!.totalTransactions).toBe(2);
+      expect(march1!.successfulTransactions).toBe(2);
+      expect(march1!.failedTransactions).toBe(0);
+      expect(march1!.totalVolume).toBe(1500.00);
+
+      // Check March 2nd data
+      const march2 = report.dailyBreakdown.find((day: any) => day.date === '2026-03-02');
+      expect(march2).toBeDefined();
+      expect(march2!.totalTransactions).toBe(2);
+      expect(march2!.successfulTransactions).toBe(1);
+      expect(march2!.failedTransactions).toBe(1);
+      expect(march2!.totalVolume).toBe(2750.00);
+
+      // Check March 3rd data
+      const march3 = report.dailyBreakdown.find((day: any) => day.date === '2026-03-03');
+      expect(march3).toBeDefined();
+      expect(march3!.totalTransactions).toBe(1);
+      expect(march3!.successfulTransactions).toBe(0);
+      expect(march3!.failedTransactions).toBe(1);
+      expect(march3!.totalVolume).toBe(300.00);
+    });
+  });
+});


### PR DESCRIPTION
- Implement GET /api/reports/reconciliation endpoint
- Add date range filtering with validation
- Calculate transaction summaries by provider (MTN, Airtel, Orange)
- Compute success/failure rates and total fees
- Provide daily breakdown for reconciliation
- Add CSV export functionality with ?format=csv parameter
- Implement Redis caching for performance (1-hour cache)
- Require authentication via X-API-Key header
- Add comprehensive integration tests (15 test cases)
- Fix existing TypeScript errors in codebase
- Add medium timeout preset for report generation

Closes #30

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
