### PR TITLE
fix(#515): log provider response time in metadata

### DIFF
--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -200,6 +200,14 @@ async function processTransaction(data: TransactionJobData): Promise<Transaction
         return result;
       }, retryConfig);
 
+      // Issue #515: Log provider response time in transaction metadata
+      if (mobileMoneyResult.providerResponseTimeMs !== undefined) {
+        await transactionModel.patchMetadata(transactionId, {
+          providerResponseTimeMs: mobileMoneyResult.providerResponseTimeMs,
+          providerRespondedAt: new Date().toISOString(),
+        }).catch(err => console.warn(`[${transactionId}] Failed to log provider response time:`, err));
+      }
+
       await updateProgress(transactionId, 50);
 
       if (!mobileMoneyResult.success) {
@@ -250,6 +258,14 @@ async function processTransaction(data: TransactionJobData): Promise<Transaction
         }
         return result;
       }, retryConfig);
+
+      // Issue #515: Log provider response time in transaction metadata
+      if (mobileMoneyResult.providerResponseTimeMs !== undefined) {
+        await transactionModel.patchMetadata(transactionId, {
+          providerResponseTimeMs: mobileMoneyResult.providerResponseTimeMs,
+          providerRespondedAt: new Date().toISOString(),
+        }).catch(err => console.warn(`[${transactionId}] Failed to log provider response time:`, err));
+      }
 
       await updateProgress(transactionId, 50);
 

--- a/src/services/mobilemoney/mobileMoneyService.ts
+++ b/src/services/mobilemoney/mobileMoneyService.ts
@@ -27,6 +27,7 @@ interface ProviderExecutionResult {
   provider?: string;
   data?: unknown;
   error?: unknown;
+  providerResponseTimeMs?: number;
 }
 
 class MobileMoneyError extends Error {
@@ -136,12 +137,14 @@ export class MobileMoneyService {
     op: "requestPayment" | "sendPayout",
     phoneNumber: string,
     amount: string,
-  ) {
-    if (op === "requestPayment") {
-      return provider.requestPayment(phoneNumber, amount);
-    }
+  ): Promise<{ success: boolean; data?: unknown; error?: unknown; providerResponseTimeMs: number }> {
+    const startTime = performance.now();
+    const result = op === "requestPayment"
+      ? await provider.requestPayment(phoneNumber, amount)
+      : await provider.sendPayout(phoneNumber, amount);
+    const providerResponseTimeMs = Math.round((performance.now() - startTime) * 100) / 100;
 
-    return provider.sendPayout(phoneNumber, amount);
+    return { ...result, providerResponseTimeMs };
   }
 
   private getOperationType(op: "requestPayment" | "sendPayout") {
@@ -192,6 +195,7 @@ export class MobileMoneyService {
               success: true,
               provider: providerKey,
               data: result.data,
+              providerResponseTimeMs: result.providerResponseTimeMs,
             };
           }
 
@@ -272,14 +276,14 @@ export class MobileMoneyService {
       amount,
     );
 
-    // result shape: { success: true, provider: <usedProvider>, data }
+    // result shape: { success: true, provider: <usedProvider>, data, providerResponseTimeMs }
     if (result.success) {
       transactionTotal.inc({
         type: "payment",
         provider: result.provider as string,
         status: "success",
       });
-      return { success: true, data: result.data };
+      return { success: true, data: result.data, providerResponseTimeMs: result.providerResponseTimeMs };
     }
 
     // Shouldn't reach here; safeguard
@@ -305,7 +309,7 @@ export class MobileMoneyService {
         provider: result.provider as string,
         status: "success",
       });
-      return { success: true, data: result.data };
+      return { success: true, data: result.data, providerResponseTimeMs: result.providerResponseTimeMs };
     }
 
     throw new MobileMoneyError(


### PR DESCRIPTION
## Description
Fixes #515 - Log Provider Response Time in Transaction Metadata.

### Changes
- Instrumented `callProvider` in `MobileMoneyService` with high-resolution `performance.now()` timing.
- Added `providerResponseTimeMs` property to public service methods response.
- Updated the queue worker `worker.ts` to patch the JSONB transaction metadata with `providerResponseTimeMs` and `providerRespondedAt` timestamps after successful or failed calls.
