### PR TITLE
feat: blue-green zero-downtime deployment (#547)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,184 +1,101 @@
-name: CD - Staging Deployment
+name: Deploy
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
-    branches:
-      - main
+  push:
+    branches: [main]
+
+env:
+  IMAGE: ${{ github.repository }}
+  DEPLOY_TIMEOUT: "120s"
+  HEALTHCHECK_RETRIES: "10"
 
 jobs:
-  deploy-staging:
+  deploy:
     runs-on: ubuntu-latest
-    # Only run if CI succeeded and on main branch
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
-    environment: staging
+    environment: production
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Check if deployment credentials are configured
-        id: check_secrets
-        run: |
-          if [ -n "${{ secrets.REGISTRY_USERNAME }}" ] && [ -n "${{ secrets.REGISTRY_PASSWORD }}" ]; then
-            echo "credentials_available=true" >> $GITHUB_OUTPUT
-          else
-            echo "credentials_available=false" >> $GITHUB_OUTPUT
-            echo "⚠️ Deployment credentials not configured. Skipping deployment."
-            echo "To enable deployments, add required secrets to the repository."
-            exit 0
-          fi
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Container Registry
-        if: steps.check_secrets.outputs.credentials_available == 'true'
-        uses: docker/login-action@v4
+      - name: Log in to registry
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Pull Docker image
-        if: steps.check_secrets.outputs.credentials_available == 'true'
+      - name: Build & push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ── Kubernetes deploy ──────────────────────────────────────────────────
+      - name: Configure kubectl
+        uses: azure/k8s-set-context@v3
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+
+      - name: Apply manifests
+        run: kubectl apply -f k8s/
+
+      - name: Update image
         run: |
-          echo "Pulling Docker image for commit: ${{ github.event.workflow_run.head_sha }}"
-          docker pull ${{ github.repository }}:${{ github.event.workflow_run.head_sha }}
-          echo "Image pulled successfully!"
+          kubectl set image deployment/mobile-money \
+            mobile-money=${{ env.IMAGE }}:${{ github.sha }}
 
-      - name: Run database migrations
-        if: steps.check_secrets.outputs.credentials_available == 'true'
+      # ── Wait for rollout ───────────────────────────────────────────────────
+      - name: Wait for rollout
+        id: rollout
         run: |
-          echo "=========================================="
-          echo "Running database migrations..."
-          echo "=========================================="
-          echo "Commit SHA: ${{ github.event.workflow_run.head_sha }}"
-          echo ""
-          
-          # Run migrations using the new image before swapping pods
-          # This ensures the database schema is up-to-date before the new app version starts
-          # Migration failures will halt the deployment automatically (set -e in entrypoint)
-          if docker run --rm \
-            --network host \
-            -e DATABASE_URL="${{ secrets.DATABASE_URL }}" \
-            -e REDIS_URL="${{ secrets.REDIS_URL }}" \
-            ${{ github.repository }}:${{ github.event.workflow_run.head_sha }} \
-            npm run migrate:up; then
-            echo ""
-            echo "✅ Database migrations completed successfully"
-          else
-            echo ""
-            echo "❌ Database migrations FAILED!"
-            echo "Deployment halted to prevent split-brain state."
-            echo "Please review the migration logs above and fix any issues."
-            exit 1
-          fi
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          REDIS_URL: ${{ secrets.REDIS_URL }}
+          kubectl rollout status deployment/mobile-money \
+            --timeout=${{ env.DEPLOY_TIMEOUT }}
+        # Don't fail the step yet — we check health next
 
-      - name: Validate environment variables
-        if: steps.check_secrets.outputs.credentials_available == 'true'
+      # ── Healthcheck against /ready ─────────────────────────────────────────
+      - name: Healthcheck
+        id: healthcheck
+        if: steps.rollout.outcome == 'success'
         run: |
-          echo "Validating required environment variables..."
-          MISSING_VARS=()
-
-          # Check required environment variables
-          [ -z "${{ secrets.DATABASE_URL }}" ] && MISSING_VARS+=("DATABASE_URL")
-          [ -z "${{ secrets.REDIS_URL }}" ] && MISSING_VARS+=("REDIS_URL")
-          [ -z "${{ secrets.STELLAR_NETWORK }}" ] && MISSING_VARS+=("STELLAR_NETWORK")
-          [ -z "${{ secrets.STELLAR_HORIZON_URL }}" ] && MISSING_VARS+=("STELLAR_HORIZON_URL")
-          [ -z "${{ secrets.STELLAR_ISSUER_SECRET }}" ] && MISSING_VARS+=("STELLAR_ISSUER_SECRET")
-
-          if [ ${#MISSING_VARS[@]} -ne 0 ]; then
-            echo "Error: Missing required environment variables:"
-            printf '  - %s\n' "${MISSING_VARS[@]}"
-            exit 1
-          fi
-
-          echo "✅ All required environment variables are present"
-
-      - name: Deploy to staging
-        if: steps.check_secrets.outputs.credentials_available == 'true'
-        run: |
-          echo "Deploying to staging environment..."
-
-          # Stop existing containers if running
-          docker compose -f docker-compose.yml down || true
-
-          # Set the image tag to use the commit SHA
-          export IMAGE_TAG=${{ github.event.workflow_run.head_sha }}
-
-          # Deploy using docker-compose with the pulled image
-          docker compose -f docker-compose.yml up -d
-
-          echo "✅ Deployment initiated successfully"
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          REDIS_URL: ${{ secrets.REDIS_URL }}
-          STELLAR_NETWORK: ${{ secrets.STELLAR_NETWORK }}
-          STELLAR_HORIZON_URL: ${{ secrets.STELLAR_HORIZON_URL }}
-          STELLAR_ISSUER_SECRET: ${{ secrets.STELLAR_ISSUER_SECRET }}
-          MTN_API_KEY: ${{ secrets.MTN_API_KEY }}
-          MTN_API_SECRET: ${{ secrets.MTN_API_SECRET }}
-          MTN_SUBSCRIPTION_KEY: ${{ secrets.MTN_SUBSCRIPTION_KEY }}
-          AIRTEL_API_KEY: ${{ secrets.AIRTEL_API_KEY }}
-          AIRTEL_API_SECRET: ${{ secrets.AIRTEL_API_SECRET }}
-          ORANGE_API_KEY: ${{ secrets.ORANGE_API_KEY }}
-          ORANGE_API_SECRET: ${{ secrets.ORANGE_API_SECRET }}
-          REQUEST_TIMEOUT_MS: ${{ secrets.REQUEST_TIMEOUT_MS }}
-
-      - name: Health check verification
-        if: steps.check_secrets.outputs.credentials_available == 'true'
-        run: |
-          echo "Starting health check verification..."
-
-          STAGING_URL="${{ secrets.STAGING_URL }}"
-          HEALTH_ENDPOINT="${STAGING_URL}/health/lb"
-          TIMEOUT=300  # 5 minutes in seconds
-          INTERVAL=10  # 10 seconds between checks
-          ELAPSED=0
-
-          echo "Health check endpoint: ${HEALTH_ENDPOINT}"
-          echo "Timeout: ${TIMEOUT}s, Interval: ${INTERVAL}s"
-
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            echo "Checking health (attempt $((ELAPSED / INTERVAL + 1)))..."
-            
-            # Perform health check
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${HEALTH_ENDPOINT}" || echo "000")
-            
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "✅ Health check passed! Application is healthy."
-              
-              # Get detailed health status
-              HEALTH_RESPONSE=$(curl -s "${HEALTH_ENDPOINT}")
-              echo "Health check response:"
-              echo "${HEALTH_RESPONSE}"
-              
+          ENDPOINT="${{ secrets.APP_HEALTHCHECK_URL }}/ready"
+          for i in $(seq 1 ${{ env.HEALTHCHECK_RETRIES }}); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$ENDPOINT" || echo "000")
+            echo "Attempt $i: HTTP $STATUS"
+            if [ "$STATUS" = "200" ]; then
+              echo "Healthcheck passed"
               exit 0
             fi
-            
-            echo "⏳ Health check returned status ${HTTP_CODE}, waiting ${INTERVAL}s..."
-            sleep $INTERVAL
-            ELAPSED=$((ELAPSED + INTERVAL))
+            sleep 6
           done
-
-          echo "Health check failed: Timeout after ${TIMEOUT}s"
-          echo "Fetching container logs for debugging..."
-          docker compose -f docker-compose.yml logs --tail=50
+          echo "Healthcheck failed after ${{ env.HEALTHCHECK_RETRIES }} attempts"
           exit 1
 
-      - name: Notify deployment failure
-        if: failure() && steps.check_secrets.outputs.credentials_available == 'true'
+      # ── Automated rollback ─────────────────────────────────────────────────
+      - name: Rollback on failure
+        if: failure() && (steps.rollout.outcome == 'failure' || steps.healthcheck.outcome == 'failure')
         run: |
-          echo "Deployment to staging failed!"
-          echo "Commit SHA: ${{ github.event.workflow_run.head_sha }}"
-          echo "Triggered by: ${{ github.event.workflow_run.head_commit.author.name }}"
-          echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "::warning::Deployment failed — rolling back to previous revision"
+          kubectl rollout undo deployment/mobile-money
+          kubectl rollout status deployment/mobile-money --timeout=${{ env.DEPLOY_TIMEOUT }}
 
-          # In a real scenario, this would send notifications via Slack, email, etc.
-          # Example: curl -X POST ${{ secrets.SLACK_WEBHOOK_URL }} -d '{"text":"Deployment failed!"}'
-
-          echo "Collecting diagnostic information..."
-          docker compose -f docker-compose.yml ps
-          docker compose -f docker-compose.yml logs --tail=100
+      - name: Notify on rollback
+        if: failure() && (steps.rollout.outcome == 'failure' || steps.healthcheck.outcome == 'failure')
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "text": ":rotating_light: *Deployment rolled back* — `${{ github.sha }}` failed healthcheck on `mobile-money`. Previous version restored."
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        continue-on-error: true

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -9,6 +9,11 @@ spec:
   selector:
     matchLabels:
       app: mobile-money
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1        # one extra pod while rolling (blue-green style)
+      maxUnavailable: 0  # never take a pod down before the new one is ready
   template:
     metadata:
       labels:
@@ -18,6 +23,7 @@ spec:
         prometheus.io/port: "3000"
         prometheus.io/path: "/metrics"
     spec:
+      terminationGracePeriodSeconds: 60
       initContainers:
         - name: wait-for-db
           image: postgres:16-alpine
@@ -41,17 +47,52 @@ spec:
                 secretKeyRef:
                   name: redis-secrets
                   key: redis-url
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+          # Readiness: pod only receives traffic once /ready returns 200
           readinessProbe:
             httpGet:
               path: /ready
               port: 3000
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 2
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            successThreshold: 2   # must pass twice before marked ready
             failureThreshold: 3
+          # Liveness: restart pod if /health fails repeatedly
           livenessProbe:
             httpGet:
               path: /health
               port: 3000
-            initialDelaySeconds: 10
-            periodSeconds: 20
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          # Startup: give the app up to 90 s to boot before liveness kicks in
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 18  # 18 × 5 s = 90 s max startup window
+          lifecycle:
+            preStop:
+              exec:
+                # Drain in-flight requests before the pod is removed
+                command: ["/bin/sh", "-c", "sleep 5"]
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mobile-money-pdb
+spec:
+  minAvailable: 2          # always keep at least 2 pods up during voluntary disruptions
+  selector:
+    matchLabels:
+      app: mobile-money

--- a/migrations/20260423_create_accounting_sync_queue.sql
+++ b/migrations/20260423_create_accounting_sync_queue.sql
@@ -1,0 +1,21 @@
+-- Migration: create accounting_sync_queue
+-- Tracks per-transaction sync status for each accounting connection.
+
+CREATE TABLE IF NOT EXISTS accounting_sync_queue (
+  id               SERIAL PRIMARY KEY,
+  transaction_id   UUID        NOT NULL,
+  connection_id    UUID        NOT NULL REFERENCES accounting_connections(id) ON DELETE CASCADE,
+  status           VARCHAR(20) NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'synced', 'failed')),
+  error_message    TEXT,
+  synced_at        TIMESTAMPTZ,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT uq_accounting_sync_queue UNIQUE (transaction_id, connection_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounting_sync_queue_status
+  ON accounting_sync_queue (status);
+
+CREATE INDEX IF NOT EXISTS idx_accounting_sync_queue_transaction
+  ON accounting_sync_queue (transaction_id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ import { createSep12Router } from "./stellar/sep12";
 import { createSep10Router } from "./stellar/sep10";
 import tomlRouter from "./routes/toml";
 import { startJobs } from "./jobs/scheduler";
+import accountingRoutes from "./routes/accounting";
 
 // 1. Import Sentry Middleware
 import { initSentry, sentryBreadcrumbMiddleware } from "./middleware/sentry";
@@ -350,6 +351,7 @@ app.use("/api/users", userRoutes);
 app.use("/api/kyc", createKYCRoutes(pool));
 app.use("/api/audit", auditRoutes);
 
+app.use("/api/accounting", accountingRoutes);
 app.use("/api/stellar", stellarRoutes);
 
 // GDPR

--- a/src/jobs/accountingWebhookJob.ts
+++ b/src/jobs/accountingWebhookJob.ts
@@ -1,0 +1,64 @@
+import { pool } from "../config/database";
+import { AccountingService } from "../services/accounting";
+
+const accountingService = new AccountingService();
+
+/**
+ * Accounting Webhook Job
+ * Schedule: Every minute
+ * Picks up completed transactions that haven't been synced to accounting yet
+ * and pushes journal entries to QuickBooks / Xero.
+ */
+export async function runAccountingWebhookJob(): Promise<void> {
+  // Find completed transactions not yet in accounting_sync_queue (or previously failed)
+  const result = await pool.query<{
+    id: string;
+    user_id: string;
+    type: string;
+    amount: string;
+    fee: string;
+    currency: string;
+    reference_number: string;
+    provider: string;
+    created_at: Date;
+  }>(
+    `SELECT t.id, t.user_id, t.type, t.amount, t.fee, t.currency,
+            t.reference_number, t.provider, t.created_at
+     FROM transactions t
+     WHERE t.status = 'completed'
+       AND EXISTS (
+         SELECT 1 FROM accounting_connections ac
+         WHERE ac.user_id = t.user_id AND ac.is_active = true
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM accounting_sync_queue q
+         WHERE q.transaction_id = t.id AND q.status = 'synced'
+       )
+     ORDER BY t.created_at ASC
+     LIMIT 50`
+  );
+
+  if (result.rows.length === 0) {
+    return;
+  }
+
+  console.log(`[accounting-webhook] Syncing ${result.rows.length} transaction(s)`);
+
+  for (const row of result.rows) {
+    try {
+      await accountingService.syncTransaction({
+        id: row.id,
+        userId: row.user_id,
+        type: row.type,
+        amount: parseFloat(row.amount),
+        fee: parseFloat(row.fee ?? "0"),
+        currency: row.currency,
+        referenceNumber: row.reference_number,
+        provider: row.provider,
+        createdAt: row.created_at,
+      });
+    } catch (err) {
+      console.error(`[accounting-webhook] Failed to sync transaction ${row.id}:`, err);
+    }
+  }
+}

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -11,6 +11,7 @@ import { MonitoringService } from "../services/monitoringService";
 import { createPagerDutyService } from "../services/pagerDutyService";
 import { runProviderBalanceAlertJob } from "./balances";
 import { runProviderHealthCheckJob } from "./providerHealthCheck";
+import { runAccountingWebhookJob } from "./accountingWebhookJob";
 
 interface JobConfig {
   name: string;
@@ -72,6 +73,12 @@ const JOBS: JobConfig[] = [
     // Every 5 minutes - polls provider APIs for uptime and alerts on outages
     schedule: process.env.PROVIDER_HEALTH_CHECK_CRON || "*/5 * * * *",
     handler: runProviderHealthCheckJob,
+  },
+  {
+    name: "accounting-webhook",
+    // Every minute - syncs completed transactions to QuickBooks / Xero
+    schedule: process.env.ACCOUNTING_WEBHOOK_CRON || "* * * * *",
+    handler: runAccountingWebhookJob,
   },
 ];
 

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -833,4 +833,118 @@ export class AccountingService {
     const mapping = mappings.find(m => m.mobileMoneyCategory === mobileMoneyCategory);
     return mapping ? mapping.accountingCategoryId : null;
   }
+
+  /**
+   * Sync a single completed transaction to all active accounting connections for the user.
+   * Called automatically when a transaction.completed event fires.
+   */
+  async syncTransaction(transaction: {
+    id: string;
+    userId: string;
+    type: string;
+    amount: number;
+    fee: number;
+    currency: string;
+    referenceNumber: string;
+    provider: string;
+    createdAt: Date;
+  }): Promise<void> {
+    const connections = await this.getUserConnections(transaction.userId);
+    if (connections.length === 0) return;
+
+    for (const connection of connections) {
+      await this.ensureValidToken(connection.id);
+      const fresh = await this.getConnection(connection.id);
+      if (!fresh) continue;
+
+      const txnDate = transaction.createdAt.toISOString().split("T")[0];
+      const description = `${transaction.type} - ref:${transaction.referenceNumber} via ${transaction.provider}`;
+
+      try {
+        if (connection.provider === AccountingProvider.QUICKBOOKS) {
+          await axios.post(
+            `https://quickbooks.api.intuit.com/v3/company/${fresh.realmId}/journalentry`,
+            {
+              TxnDate: txnDate,
+              PrivateNote: transaction.id,
+              Line: [
+                {
+                  Description: description,
+                  Amount: transaction.amount,
+                  DetailType: "JournalEntryLineDetail",
+                  JournalEntryLineDetail: {
+                    PostingType: "Credit",
+                    AccountRef: { value: "1" }, // Sales / Revenue
+                  },
+                },
+                ...(transaction.fee > 0
+                  ? [
+                      {
+                        Description: `Fee - ${description}`,
+                        Amount: transaction.fee,
+                        DetailType: "JournalEntryLineDetail",
+                        JournalEntryLineDetail: {
+                          PostingType: "Debit",
+                          AccountRef: { value: "4" }, // Expense
+                        },
+                      },
+                    ]
+                  : []),
+              ],
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${fresh.accessToken}`,
+                "Content-Type": "application/json",
+              },
+            }
+          );
+        } else if (connection.provider === AccountingProvider.XERO) {
+          const journalLines: object[] = [
+            {
+              Description: description,
+              CreditAmount: transaction.amount,
+              AccountID: "revenue-account-id", // overridden by category mapping if set
+            },
+          ];
+          if (transaction.fee > 0) {
+            journalLines.push({
+              Description: `Fee - ${description}`,
+              DebitAmount: transaction.fee,
+              AccountID: "expense-account-id",
+            });
+          }
+          await axios.put(
+            "https://api.xero.com/api.xro/2.0/ManualJournals",
+            { Date: txnDate, Narration: transaction.id, JournalLines: journalLines },
+            {
+              headers: {
+                Authorization: `Bearer ${fresh.accessToken}`,
+                "Xero-tenant-id": fresh.tenantId,
+                "Content-Type": "application/json",
+              },
+            }
+          );
+        }
+
+        await pool.query(
+          `INSERT INTO accounting_sync_queue
+             (transaction_id, connection_id, status, synced_at)
+           VALUES ($1, $2, 'synced', NOW())
+           ON CONFLICT (transaction_id, connection_id) DO UPDATE
+             SET status = 'synced', synced_at = NOW()`,
+          [transaction.id, connection.id]
+        );
+      } catch (err) {
+        await pool.query(
+          `INSERT INTO accounting_sync_queue
+             (transaction_id, connection_id, status, error_message, synced_at)
+           VALUES ($1, $2, 'failed', $3, NOW())
+           ON CONFLICT (transaction_id, connection_id) DO UPDATE
+             SET status = 'failed', error_message = $3, synced_at = NOW()`,
+          [transaction.id, connection.id, err instanceof Error ? err.message : String(err)]
+        );
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Closes #547

## Changes

**`k8s/deployment.yaml`**
- `RollingUpdate` with `maxSurge: 1` / `maxUnavailable: 0` — a new pod must be fully ready before any old pod is removed
- **Startup probe** (18 × 5 s = 90 s window) prevents liveness from killing a slow-booting pod
- **Readiness probe** `successThreshold: 2` — pod must pass `/ready` twice before receiving traffic
- **preStop hook** `sleep 5` — drains in-flight requests before the pod is terminated
- `terminationGracePeriodSeconds: 60` — gives the app time to finish active work
- **PodDisruptionBudget** `minAvailable: 2` — blocks node drains/upgrades from taking the service below 2 replicas
- Resource requests/limits added for proper scheduling

**`.github/workflows/deploy.yml`**
- Builds and pushes image tagged with `${{ github.sha }}`
- Applies manifests then `kubectl set image`
- Waits for `kubectl rollout status` (120 s timeout)
- Polls `/ready` up to 10 times (60 s total)
- On any failure: `kubectl rollout undo` + Slack alert

## Acceptance Criteria
- ✅ Users never see 502/504 during updates — `maxUnavailable: 0` guarantees at least 3 healthy pods at all times