### PR TITLE
feat: implement sms opt-out and africastalking

### DIFF
--- a/migrations/20260424_add_sms_opt_out_to_users.sql
+++ b/migrations/20260424_add_sms_opt_out_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN sms_opt_out BOOLEAN DEFAULT false;

--- a/src/models/users.ts
+++ b/src/models/users.ts
@@ -13,6 +13,7 @@ export interface User {
   tokenVersion?: number;
   createdAt: Date;
   updatedAt: Date;
+  smsOptOut?: boolean;
   // TODO: The `User` type and database table needs to
   // be update with these fields:  is_active: boolean,   deactivated_at:Date`
 }
@@ -35,6 +36,7 @@ export class UserModel {
       tokenVersion: row.token_version ?? 0,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      smsOptOut: row.sms_opt_out ?? false,
     };
   }
 
@@ -109,6 +111,7 @@ export class UserModel {
         status: row.status,
         createdAt: row.created_at,
         updatedAt: row.updated_at,
+        smsOptOut: row.sms_opt_out ?? false,
       };
     } catch (error) {
       await client.query('ROLLBACK');

--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -170,6 +170,14 @@ async function processTransaction(data: TransactionJobData): Promise<Transaction
   ) => {
     try {
       const txRow = await transactionModel.findById(transactionId);
+      if (!txRow?.userId) return;
+
+      const user = await userModel.findById(txRow.userId);
+      if (user?.smsOptOut) {
+        console.log(`[${transactionId}] SMS notifications skipped (User Opted Out)`);
+        return;
+      }
+
       const ref = txRow?.referenceNumber ?? transactionId;
       await smsService.notifyTransactionEvent(phoneNumber, {
         referenceNumber: ref,

--- a/src/services/sms.ts
+++ b/src/services/sms.ts
@@ -1,4 +1,6 @@
 import twilio from "twilio";
+// @ts-ignore
+import africastalking from "africastalking";
 import {
   parsePhoneNumberFromString,
   type CountryCode,
@@ -104,23 +106,30 @@ export interface SmsSendResult {
 }
 
 export class SmsService {
-  private client: ReturnType<typeof twilio> | null = null;
+  private twilioClient: ReturnType<typeof twilio> | null = null;
+  private atClient: any = null;
+  private provider: string;
 
   constructor() {
-    const provider = (process.env.SMS_PROVIDER || "none").toLowerCase();
-    if (provider === "twilio") {
+    this.provider = (process.env.SMS_PROVIDER || "none").toLowerCase();
+    if (this.provider === "twilio") {
       const sid = process.env.TWILIO_ACCOUNT_SID;
       const token = process.env.TWILIO_AUTH_TOKEN;
-      if (sid && token) this.client = twilio(sid, token);
+      if (sid && token) this.twilioClient = twilio(sid, token);
+    } else if (this.provider === "africastalking") {
+      const apiKey = process.env.AFRICASTALKING_API_KEY;
+      const username = process.env.AFRICASTALKING_USERNAME;
+      if (apiKey && username) {
+        this.atClient = africastalking({ apiKey, username });
+      }
     }
   }
 
   shouldSend(): boolean {
     if (process.env.NODE_ENV === "test") return false;
-    const provider = (process.env.SMS_PROVIDER || "none").toLowerCase();
-    if (provider === "none" || provider === "off" || provider === "disabled")
+    if (this.provider === "none" || this.provider === "off" || this.provider === "disabled")
       return false;
-    return provider === "twilio" && this.client !== null;
+    return (this.provider === "twilio" && this.twilioClient !== null) || (this.provider === "africastalking" && this.atClient !== null);
   }
 
   async sendToPhone(toRaw: string, body: string): Promise<SmsSendResult> {
@@ -150,17 +159,40 @@ export class SmsService {
     }
 
     try {
-      const message = await this.client!.messages.create({
-        to,
-        from,
-        body,
-      });
-      console.log("[sms] delivered", {
-        to,
-        sid: message.sid,
-        status: message.status,
-      });
-      return { sent: true, messageSid: message.sid };
+      let messageSidStr = "unknown";
+      
+      if (this.provider === "twilio") {
+        const message = await this.twilioClient!.messages.create({
+          to,
+          from,
+          body,
+        });
+        messageSidStr = message.sid;
+        console.log("[sms] delivered via Twilio", {
+          to,
+          sid: message.sid,
+          status: message.status,
+        });
+      } else if (this.provider === "africastalking") {
+        const result = await this.atClient.SMS.send({
+          to: [to],
+          message: body,
+          from: process.env.AFRICASTALKING_SENDER_ID
+        });
+        const msgData = result?.SMSMessageData?.Recipients?.[0];
+        if (msgData?.status === "Success") {
+          messageSidStr = msgData.messageId;
+        } else {
+          throw new Error(`AT sending failed with status: ${msgData?.status}`);
+        }
+        console.log("[sms] delivered via Africa's Talking", {
+          to,
+          sid: messageSidStr,
+          status: msgData?.status,
+        });
+      }
+
+      return { sent: true, messageSid: messageSidStr };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error("[sms] send failed", { to, error: msg });


### PR DESCRIPTION
Fixes #510.

This pull request introduces the required mechanics to issue transparent, branded notifications upon successful completion of mobile payouts over robust SMS corridors.

**Changes included:**
- Integrated `africastalking` to gracefully act alongside Twilio according to the environment configurations inside the `SmsService` provider routing logic.
- Analyzed existing codebase mechanics and verified `en.json`, `es.json`, and `fr.json` translation availability.
- Established system-wide compliances around Opt-Out protocols by extending the `User` schema definition and intercepting messages immediately inside the primary background `worker`.
- Injected `sms_opt_out` constraints into the internal PostgreSQL registry via an atomic deployment migration script (`migrations/20260424_add_sms_opt_out_to_users.sql`).
