### PR TITLE
feat: implement provider-specific retry matrix to skip terminal fault…

### DIFF
--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -149,6 +149,7 @@ async function processTransaction(data: TransactionJobData): Promise<Transaction
   const retryConfig = {
     maxAttempts,
     baseDelayMs,
+    provider,
     onRetry: async ({
       attempt,
       error,
@@ -203,7 +204,7 @@ async function processTransaction(data: TransactionJobData): Promise<Transaction
           await transactionModel.updateMetadata(transactionId, updatedMetadata);
         }
 
-        await job.updateProgress(90);
+        await updateProgress(transactionId, 90);
   try {
     await updateProgress(transactionId, 10);
 

--- a/src/services/mobilemoney/mobileMoneyService.ts
+++ b/src/services/mobilemoney/mobileMoneyService.ts
@@ -40,6 +40,7 @@ class MobileMoneyError extends Error {
   constructor(
     public code: string,
     message: string,
+    public originalError?: unknown
   ) {
     super(message);
     this.name = "MobileMoneyError";
@@ -250,6 +251,7 @@ export class MobileMoneyService {
           error,
           allowFailover ? "primary" : "backup",
         ),
+        error
       );
     }
   }
@@ -272,12 +274,13 @@ export class MobileMoneyService {
         status: "success",
       });
 
-      return { success: true, data: result.data };
+      return { success: true as const, data: result.data, providerResponseTimeMs: result.providerResponseTimeMs };
     }
 
     throw new MobileMoneyError(
       "PROVIDER_ERROR",
       `Payment failed for provider '${providerKey}'`,
+      result.error
     );
   }
 
@@ -299,12 +302,13 @@ export class MobileMoneyService {
         status: "success",
       });
 
-      return { success: true, data: result.data };
+      return { success: true as const, data: result.data, providerResponseTimeMs: result.providerResponseTimeMs };
     }
 
     throw new MobileMoneyError(
       "PROVIDER_ERROR",
       `Payout failed for provider '${providerKey}'`,
+      result.error
     );
   }
 

--- a/src/services/retry.ts
+++ b/src/services/retry.ts
@@ -9,10 +9,28 @@ const TRANSIENT_HINTS =
 const PERMANENT_HINTS =
   /invalid|insufficient|bad request|malformed|unauthorized|forbidden|not found|wrong\s+number|duplicate|rejected|bad\s+request|400|401|403|404|422/i;
 
-export function isTransientError(error: unknown): boolean {
+export function isTransientError(error: unknown, provider?: string): boolean {
+  let innerError = error;
+  if (error && typeof error === "object" && "originalError" in error && (error as any).originalError) {
+    innerError = (error as any).originalError;
+  }
+
+  if (provider && innerError && typeof innerError === "object" && "response" in innerError) {
+    const status = (innerError as any).response?.status;
+    if (status) {
+      const p = provider.toLowerCase();
+      if (p === "mtn") {
+        if (status === 400 || status === 401 || status === 404 || status === 409) return false;
+      } else if (p === "airtel" || p === "orange") {
+        if (status === 400 || status === 401) return false;
+      }
+      if (status >= 500 || status === 429) return true;
+    }
+  }
+
   const msg =
     error instanceof Error
-      ? `${error.message} ${(error as NodeJS.ErrnoException).code ?? ""}`
+      ? `${error.message} ${(error as NodeJS.ErrnoException).code ?? ""} ${innerError instanceof Error ? innerError.message : String(innerError)}`
       : String(error);
 
   if (PERMANENT_HINTS.test(msg)) return false;
@@ -26,6 +44,7 @@ function sleep(ms: number): Promise<void> {
 export interface WithRetryOptions {
   maxAttempts: number;
   baseDelayMs: number;
+  provider?: string;
   /** Called after a failed attempt when another attempt will follow */
   onRetry?: (info: { attempt: number; error: unknown }) => void | Promise<void>;
 }
@@ -48,7 +67,7 @@ export async function withRetry<T>(
     } catch (error) {
       lastError = error;
       const canRetry =
-        isTransientError(error) && attempt < maxAttempts;
+        isTransientError(error, options.provider) && attempt < maxAttempts;
       if (!canRetry) throw error;
 
       console.warn(


### PR DESCRIPTION
Fixes #504.

This pull request introduces provider-specific mapping limits natively evaluating HTTP status codes out of Axio exception catches. This establishes intelligent failure resolutions by differentiating transient connectivity loops from permanently unresolvable constraints like Unregistered MSISDNs / Missing API constraints.

**Changes included:**
- Augmented `MobileMoneyError` propagation mechanics within `MobileMoneyService` resolving underlying original execution payloads natively back to evaluating layers.
- Embedded a strict logic matrix enforcing exact HTTP status checks internally into `isTransientError` (404/401 closures, 400 parameter constraints).
- Implemented short-circuit tracking bypassing continuous worker retries over strictly terminal limitations.
