### PR TITLE
chore(deps): configure dependabot to group security updates for CVEs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+      - "security" # Added to help route security patches
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -31,6 +32,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # NEW: Group security updates to reduce noise (Issue #558)
+      npm-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "cargo"
     directory: "/contracts"
@@ -48,6 +54,7 @@ updates:
     labels:
       - "dependencies"
       - "rust"
+      - "security"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -56,6 +63,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # NEW: Group security updates for Rust
+      cargo-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -73,10 +85,16 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+      - "security"
     commit-message:
       prefix: "ci"
       include: "scope"
     groups:
       github-actions:
+        patterns:
+          - "*"
+      # NEW: Group security updates for Actions
+      actions-security-updates:
+        applies-to: "security-updates"
         patterns:
           - "*"


### PR DESCRIPTION
## Description
Fixes #558 

This PR updates the existing Dependabot configuration to explicitly handle and group Security Patches (CVEs) across all ecosystems (`npm`, `cargo`, and `github-actions`). 

By utilizing the `applies-to: "security-updates"` grouping directive, Dependabot will now automatically bundle known vulnerability patches into single Pull Requests. This fulfills the acceptance criteria of maintaining a green security posture while significantly reducing repository noise/spam.

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality / config)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have commented my code where necessary
- [x] I have updated the documentation
- [x] My changes generate no new warnings *(Note: Pre-existing ESLint warnings/errors in the codebase remain untouched to avoid scope creep).*

*(Note: The actual enabling of Dependabot Security Updates must be toggled in the Repository Settings > Code Security and Analysis tab by a repo admin, but this config file will properly route, label, and group them once triggered).*