### PR TITLE
feat: enforce password complexity on registration (#519)

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,15 +1,45 @@
 import { Router, Request, Response } from 'express';
+import { z } from 'zod';
 import { generateToken, verifyToken, JWTPayload, generateRefreshToken, verifyRefreshToken } from '../auth/jwt';
 import { createSSORouter } from '../auth/sso';
 import { createOIDCRouter, initializeOIDCProviders } from '../auth/oidc';
 import { enforceSSOForEmployees } from '../middleware/ssoEnforcement';
 import { tokenController } from '../controllers/tokenController';
 import { authenticateToken } from '../middleware/auth';
-import { authenticateUser, getUserPermissions, User } from '../services/userService';
+import { authenticateUser, createUser, getUserPermissions, User } from '../services/userService';
 import { verifyTOTPToken, verifyBackupCode, is2FAEnabled } from '../auth/2fa';
 import { evaluateAdminLoginAnomaly } from '../services/loginAnomaly';
+import { validateRequest } from '../middleware/validation';
+import { hashPassword } from '../utils/password';
 
 export const authRoutes = Router();
+
+export const registerSchema = z.object({
+  phone_number: z.string().min(1, 'phone_number is required'),
+  password: z
+    .string()
+    .min(12, 'Password must be at least 12 characters')
+    .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+    .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+    .regex(/[^A-Za-z0-9]/, 'Password must contain at least one special character'),
+});
+
+/**
+ * POST /api/auth/register
+ */
+authRoutes.post('/register', validateRequest(registerSchema), async (req: Request, res: Response) => {
+  const { phone_number, password } = req.body as z.infer<typeof registerSchema>;
+  try {
+    const passwordHash = await hashPassword(password);
+    const user = await createUser({ phone_number, password_hash: passwordHash } as any);
+    res.status(201).json({ message: 'User registered successfully', userId: user.id });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Registration failed',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
 
 // Initialize OIDC Strategy (Google/Azure)
 initializeOIDCProviders();

--- a/src/utils/password.test.ts
+++ b/src/utils/password.test.ts
@@ -1,4 +1,5 @@
 import { hashPassword, comparePassword } from "./password";
+import { registerSchema } from "../routes/auth";
 
 describe("Password utils", () => {
   it("should hash a password and compare correctly", async () => {
@@ -13,5 +14,42 @@ describe("Password utils", () => {
 
     const invalid = await comparePassword("wrongpass", hash);
     expect(invalid).toBe(false);
+  });
+});
+
+describe("registerSchema password complexity", () => {
+  const valid = { phone_number: "+237670000000", password: "Secure@Pass1!" };
+
+  it("accepts a valid password", () => {
+    expect(() => registerSchema.parse(valid)).not.toThrow();
+  });
+
+  it("rejects passwords shorter than 12 characters", () => {
+    const result = registerSchema.safeParse({ ...valid, password: "Short1!" });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result)).toMatch(/12 characters/);
+  });
+
+  it("rejects passwords without an uppercase letter", () => {
+    const result = registerSchema.safeParse({ ...valid, password: "nouppercase1!" });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result)).toMatch(/uppercase/);
+  });
+
+  it("rejects passwords without a lowercase letter", () => {
+    const result = registerSchema.safeParse({ ...valid, password: "NOLOWERCASE1!" });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result)).toMatch(/lowercase/);
+  });
+
+  it("rejects passwords without a special character", () => {
+    const result = registerSchema.safeParse({ ...valid, password: "NoSpecialChar1" });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result)).toMatch(/special character/);
+  });
+
+  it("rejects missing phone_number", () => {
+    const result = registerSchema.safeParse({ password: valid.password });
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Closes #519

## Changes
- Added `registerSchema` (Zod) to `src/routes/auth.ts` enforcing:
  - Minimum 12 characters
  - At least one uppercase letter
  - At least one lowercase letter
  - At least one special character
- Added `POST /api/auth/register` endpoint using `validateRequest` middleware and `hashPassword`
- Updated `src/utils/password.test.ts` with a full complexity validation test suite (6 cases)

## Acceptance Criteria
- [x] Weak passwords rejected at signup with clear per-field error messages