### PR TITLE
feat: #596 build developer dashboard for API usage stats

### DIFF
--- a/src/controllers/developerDashboardController.ts
+++ b/src/controllers/developerDashboardController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from "express";
+import { DeveloperDashboardService } from "../services/developerDashboardService";
+
+const service = new DeveloperDashboardService();
+
+export class DeveloperDashboardController {
+  /**
+   * GET /api/developer/dashboard
+   * Returns rate limit usage stats for the authenticated partner
+   */
+  static async getDashboard(req: Request, res: Response) {
+    try {
+      const partnerId = (req as any).user?.id;
+      if (!partnerId) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      const stats = await service.getUsageStats(partnerId);
+      return res.json(stats);
+    } catch (error) {
+      console.error("Developer dashboard error:", error);
+      return res.status(500).json({ error: "Failed to fetch dashboard stats" });
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import { validateStellarNetwork, logStellarNetwork } from "./config/stellar";
 import { sessionAnomalyLogger } from "./services/logger";
 import { HealthCheckResponse, ReadinessCheckResponse } from "./types/api";
 import { privacyRoutes } from "./routes/privacy";
+import { developerDashboardRoutes } from "./routes/developerDashboard";
 import { travelRuleRoutes } from "./routes/travelRule";
 import sep31Router from "./stellar/sep31";
 import sep24Router from "./stellar/sep24";
@@ -359,6 +360,7 @@ app.use("/api/stellar", stellarRoutes);
 
 // GDPR
 app.use("/api/gdpr", privacyRoutes);
+app.use("/api/developer", developerDashboardRoutes);
 app.use("/api/admin", requireAuth, adminRoutes);
 app.use("/api/admin/kyc-upgrades", requireAuth, kycTierUpgradeRoutes);
 app.use("/sep10", createSep10Router());

--- a/src/routes/developerDashboard.ts
+++ b/src/routes/developerDashboard.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { DeveloperDashboardController } from "../controllers/developerDashboardController";
+import { requireAuth } from "../middleware/auth";
+
+export const developerDashboardRoutes = Router();
+
+/**
+ * @route   GET /api/developer/dashboard
+ * @desc    Get API rate limit usage stats for the authenticated partner
+ * @access  Private
+ */
+developerDashboardRoutes.get("/dashboard", requireAuth, DeveloperDashboardController.getDashboard);

--- a/src/services/developerDashboardService.ts
+++ b/src/services/developerDashboardService.ts
@@ -1,0 +1,67 @@
+import { redisClient } from "../config/redis";
+import { RATE_LIMIT_CONFIG } from "../middleware/rateLimit";
+
+export interface EndpointUsage {
+  endpoint: string;
+  requests: number;
+  limit: number;
+  remaining: number;
+  windowMs: number;
+  resetTime: string;
+}
+
+export interface DashboardStats {
+  partnerId: string;
+  totalRequests: number;
+  endpoints: EndpointUsage[];
+  generatedAt: string;
+}
+
+const ENDPOINT_CONFIGS: Record<string, { limit: number; windowMs: number }> = {
+  SEP24: { limit: RATE_LIMIT_CONFIG.SEP24_LIMIT, windowMs: RATE_LIMIT_CONFIG.SEP24_WINDOW_MS },
+  SEP31: { limit: RATE_LIMIT_CONFIG.SEP31_LIMIT, windowMs: RATE_LIMIT_CONFIG.SEP31_WINDOW_MS },
+  SEP12: { limit: RATE_LIMIT_CONFIG.SEP12_LIMIT, windowMs: RATE_LIMIT_CONFIG.SEP12_WINDOW_MS },
+  EXPORT: { limit: RATE_LIMIT_CONFIG.EXPORT_LIMIT, windowMs: RATE_LIMIT_CONFIG.EXPORT_WINDOW_MS },
+};
+
+export class DeveloperDashboardService {
+  /**
+   * Get rate limit usage for all endpoints for a given partner/user
+   */
+  async getUsageStats(partnerId: string): Promise<DashboardStats> {
+    const endpoints: EndpointUsage[] = [];
+    let totalRequests = 0;
+
+    for (const [name, config] of Object.entries(ENDPOINT_CONFIGS)) {
+      const key = `ratelimit:${partnerId}:${name}`;
+      const now = Date.now();
+      const windowStart = Math.floor(now / config.windowMs) * config.windowMs;
+      const resetTime = new Date(windowStart + config.windowMs).toISOString();
+
+      let count = 0;
+      try {
+        const raw = await redisClient.get(key);
+        count = raw ? parseInt(raw, 10) : 0;
+      } catch {
+        count = 0;
+      }
+
+      totalRequests += count;
+      endpoints.push({
+        endpoint: name,
+        requests: count,
+        limit: config.limit,
+        remaining: Math.max(0, config.limit - count),
+        windowMs: config.windowMs,
+        resetTime,
+      });
+    }
+
+    return {
+      partnerId,
+      totalRequests,
+      endpoints,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
closes #596 

Partners can now call `GET /api/developer/dashboard` to see their real-time API rate limit usage across all endpoints.

## What's changed
- **DeveloperDashboardService** — reads per-partner rate limit counters directly from Redis (same keys written by the existing rate limit middleware)
- **DeveloperDashboardController** — thin controller wiring the service to the HTTP layer
- **/api/developer/dashboard** — new authenticated route registered in index.ts

## Response shape
{
  "partnerId": "partner-123",
  "totalRequests": 12,
  "endpoints": [
    { "endpoint": "SEP24", "requests": 4, "limit": 10, "remaining": 6, "windowMs": 60000, "resetTime": "..." }
  ],
  "generatedAt": "..."
}

## Endpoints covered
| Endpoint | Limit | Window |
|----------|-------|--------|
| SEP24    | 10    | 1 min  |
| SEP31    | 5     | 1 min  |
| SEP12    | 20    | 1 hr   |
| EXPORT   | 5     | 1 hr   |

## Auth
Requires a valid X-API-Key or Bearer token — same as all other protected routes.
