### PR TITLE
chore: add support for airtel money balance check api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -711,3 +711,5 @@ APQ_TTL_SECONDS=86400
 # JWT_SECRET is required for authenticating WebSocket connections.
 # Clients must pass: connectionParams: { authToken: "<jwt>" }
 JWT_SECRET=replace-with-a-secure-jwt-secret
+# Provider balance cache TTL (seconds)
+PROVIDER_BALANCE_CACHE_TTL=60

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,0 +1,417 @@
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.pool = void 0;
+exports.queryRead = queryRead;
+exports.queryWrite = queryWrite;
+exports.checkReplicaHealth = checkReplicaHealth;
+exports.querySmart = querySmart;
+exports.getPgBouncerStats = getPgBouncerStats;
+var pg_1 = require("pg");
+var readOnlyDetector_1 = require("../utils/readOnlyDetector");
+// Configuration for slow query logging
+var SLOW_QUERY_THRESHOLD_MS = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS || "1000");
+var ENABLE_SLOW_QUERY_LOGGING = process.env.ENABLE_SLOW_QUERY_LOGGING === "true" ||
+    (process.env.NODE_ENV === "development" &&
+        process.env.ENABLE_SLOW_QUERY_LOGGING !== "false");
+/**
+ * Sanitizes a SQL query by removing sensitive data patterns
+ */
+function sanitizeQuery(query) {
+    return (query
+        // Remove potential sensitive values in WHERE clauses
+        .replace(/(WHERE\s+[^=]+\s*=\s*)'[^']*'/gi, "$1***")
+        .replace(/(WHERE\s+[^=]+\s*=\s*)\d+/gi, "$1***")
+        // Remove sensitive data in INSERT/UPDATE values
+        .replace(/(VALUES\s*\([^)]*)'[^']*'([^)]*\))/gi, "$1***$2")
+        .replace(/(SET\s+[^=]+\s*=\s*)'[^']*'/gi, "$1***")
+        .replace(/(SET\s+[^=]+\s*=\s*)\d+/gi, "$1***")
+        // Remove email patterns
+        .replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g, "***@***.***")
+        // Remove phone number patterns
+        .replace(/\b\d{10,}\b/g, "***")
+        // Remove API keys and tokens
+        .replace(/\b[A-Za-z0-9]{20,}\b/g, "***"));
+}
+/**
+ * Sanitizes query parameters to remove sensitive data
+ */
+function sanitizeParams(params) {
+    if (!params || !Array.isArray(params))
+        return params;
+    return params.map(function (param) {
+        if (typeof param === "string") {
+            // Check for email patterns
+            if (/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}$/.test(param)) {
+                return "***@***.***";
+            }
+            // Check for phone numbers (10+ digits)
+            if (/^\d{10,}$/.test(param)) {
+                return "***";
+            }
+            // Check for potential API keys/tokens (20+ chars, alphanumeric)
+            if (/^[A-Za-z0-9]{20,}$/.test(param)) {
+                return "***";
+            }
+            // Check for potential sensitive data in quotes
+            if (param.length > 50) {
+                return "***";
+            }
+            return param;
+        }
+        if (typeof param === "number" && param > 1000000) {
+            return "***";
+        }
+        return param;
+    });
+}
+/**
+ * Logs slow queries with sanitized information
+ */
+function logSlowQuery(query, duration, params) {
+    if (!ENABLE_SLOW_QUERY_LOGGING)
+        return;
+    var logEntry = {
+        type: "slow_query",
+        duration: Math.round(duration),
+        threshold: SLOW_QUERY_THRESHOLD_MS,
+        query: sanitizeQuery(query),
+        params: params ? sanitizeParams(params) : undefined,
+        timestamp: new Date().toISOString(),
+    };
+    console.log(JSON.stringify(logEntry));
+}
+// Enhanced Pool with query timing
+var SlowQueryPool = /** @class */ (function (_super) {
+    __extends(SlowQueryPool, _super);
+    function SlowQueryPool() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    SlowQueryPool.prototype.query = function (queryConfig, values) {
+        return __awaiter(this, void 0, void 0, function () {
+            var startTime, queryString, queryParams, result, endTime, durationMs, error_1, endTime, durationMs;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        startTime = process.hrtime.bigint();
+                        queryString = typeof queryConfig === "string" ? queryConfig : queryConfig.text;
+                        queryParams = typeof queryConfig === "string" ? values : queryConfig.values;
+                        _a.label = 1;
+                    case 1:
+                        _a.trys.push([1, 3, , 4]);
+                        return [4 /*yield*/, _super.prototype.query.call(this, queryConfig, values)];
+                    case 2:
+                        result = (_a.sent());
+                        endTime = process.hrtime.bigint();
+                        durationMs = Number(endTime - startTime) / 1e6;
+                        if (durationMs > SLOW_QUERY_THRESHOLD_MS) {
+                            logSlowQuery(queryString, durationMs, queryParams);
+                        }
+                        return [2 /*return*/, result];
+                    case 3:
+                        error_1 = _a.sent();
+                        endTime = process.hrtime.bigint();
+                        durationMs = Number(endTime - startTime) / 1e6;
+                        if (durationMs > SLOW_QUERY_THRESHOLD_MS) {
+                            logSlowQuery(queryString, durationMs, queryParams);
+                        }
+                        throw error_1;
+                    case 4: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    return SlowQueryPool;
+}(pg_1.Pool));
+/**
+ * Primary connection pool – now routes through PgBouncer for transaction-level pooling
+ * This significantly reduces the number of direct connections to Postgres
+ * (INSERT, UPDATE, DELETE) and read operations when no replica is available.
+ */
+exports.pool = new pg_1.Pool({
+    connectionString: process.env.DATABASE_URL,
+    max: 20,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 2000,
+});
+// Wrap query for slow-query logging while preserving Pool typings.
+var originalPoolQuery = exports.pool.query.bind(exports.pool);
+exports.pool.query = function () {
+    var args = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        args[_i] = arguments[_i];
+    }
+    return __awaiter(void 0, void 0, void 0, function () {
+        var queryConfig, values, startTime, queryString, queryParams, result, endTime, durationMs, error_2, endTime, durationMs;
+        var _a;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    queryConfig = args[0];
+                    values = args[1];
+                    startTime = process.hrtime.bigint();
+                    queryString = typeof queryConfig === "string" ? queryConfig : (_a = queryConfig === null || queryConfig === void 0 ? void 0 : queryConfig.text) !== null && _a !== void 0 ? _a : "";
+                    queryParams = typeof queryConfig === "string" ? values : queryConfig === null || queryConfig === void 0 ? void 0 : queryConfig.values;
+                    _b.label = 1;
+                case 1:
+                    _b.trys.push([1, 3, , 4]);
+                    return [4 /*yield*/, originalPoolQuery.apply(void 0, args)];
+                case 2:
+                    result = _b.sent();
+                    endTime = process.hrtime.bigint();
+                    durationMs = Number(endTime - startTime) / 1e6;
+                    if (durationMs > SLOW_QUERY_THRESHOLD_MS) {
+                        logSlowQuery(queryString, durationMs, queryParams);
+                    }
+                    return [2 /*return*/, result];
+                case 3:
+                    error_2 = _b.sent();
+                    endTime = process.hrtime.bigint();
+                    durationMs = Number(endTime - startTime) / 1e6;
+                    if (durationMs > SLOW_QUERY_THRESHOLD_MS) {
+                        logSlowQuery(queryString, durationMs, queryParams);
+                    }
+                    throw error_2;
+                case 4: return [2 /*return*/];
+            }
+        });
+    });
+};
+/**
+ * Read replica connection pool – handles SELECT queries to take load off the
+ * primary. If READ_REPLICA_URL is not configured, falls back to the primary.
+ *
+ * Multiple replica URLs can be provided as a comma-separated list in
+ * READ_REPLICA_URL. The pool load-balances across all replicas via round-robin.
+ */
+var replicaUrls = process.env.READ_REPLICA_URL
+    ? process.env.READ_REPLICA_URL.split(",").map(function (url) { return url.trim(); })
+    : [];
+// Build an individual Pool for each replica URL
+var replicaPools = replicaUrls.map(function (url) {
+    return new pg_1.Pool({
+        connectionString: url,
+        max: 10,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 2000,
+    });
+});
+// Track which replica to use next for round-robin load balancing
+var replicaIndex = 0;
+/**
+ * Return the next replica pool in round-robin order.
+ * Returns null if no replica pools are configured.
+ */
+function getNextReplicaPool() {
+    if (replicaPools.length === 0)
+        return null;
+    var selected = replicaPools[replicaIndex % replicaPools.length];
+    replicaIndex += 1;
+    return selected;
+}
+/**
+ * Execute a read-only SQL query against a replica pool if available.
+ * If the replica is unreachable (pool error or connection failure) the query
+ * automatically falls over to the primary pool so callers are unaffected.
+ *
+ * @param text   - The parameterised SQL query string
+ * @param params - Optional query parameters
+ */
+function queryRead(text, params) {
+    return __awaiter(this, void 0, void 0, function () {
+        var replicaPool, client, result, err_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    replicaPool = getNextReplicaPool();
+                    if (!replicaPool) return [3 /*break*/, 6];
+                    client = null;
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, 4, 5, 6]);
+                    return [4 /*yield*/, replicaPool.connect()];
+                case 2:
+                    client = _a.sent();
+                    return [4 /*yield*/, client.query(text, params)];
+                case 3:
+                    result = _a.sent();
+                    return [2 /*return*/, result];
+                case 4:
+                    err_1 = _a.sent();
+                    // Log replica failure and fall back to primary
+                    console.warn("Read replica query failed, falling back to primary:", err_1);
+                    return [3 /*break*/, 6];
+                case 5:
+                    client === null || client === void 0 ? void 0 : client.release();
+                    return [7 /*endfinally*/];
+                case 6: 
+                // Fall back: use primary pool (which goes through PgBouncer)
+                return [2 /*return*/, exports.pool.query(text, params)];
+            }
+        });
+    });
+}
+/**
+ * Execute a write SQL query (INSERT / UPDATE / DELETE) against the primary pool.
+ * All writes now route through PgBouncer via the primary pool connection.
+ *
+ * @param text   - The parameterised SQL query string
+ * @param params - Optional query parameters
+ */
+function queryWrite(text, params) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            return [2 /*return*/, exports.pool.query(text, params)];
+        });
+    });
+}
+/**
+ * Health check for all replica pools.
+ * Returns an array of status objects – useful for monitoring endpoints.
+ */
+function checkReplicaHealth() {
+    return __awaiter(this, void 0, void 0, function () {
+        var _this = this;
+        return __generator(this, function (_a) {
+            return [2 /*return*/, Promise.all(replicaUrls.map(function (url, idx) { return __awaiter(_this, void 0, void 0, function () {
+                    var client, _a;
+                    return __generator(this, function (_b) {
+                        switch (_b.label) {
+                            case 0:
+                                client = null;
+                                _b.label = 1;
+                            case 1:
+                                _b.trys.push([1, 4, 5, 6]);
+                                return [4 /*yield*/, replicaPools[idx].connect()];
+                            case 2:
+                                client = _b.sent();
+                                return [4 /*yield*/, client.query("SELECT 1")];
+                            case 3:
+                                _b.sent();
+                                return [2 /*return*/, { url: url, healthy: true }];
+                            case 4:
+                                _a = _b.sent();
+                                return [2 /*return*/, { url: url, healthy: false }];
+                            case 5:
+                                client === null || client === void 0 ? void 0 : client.release();
+                                return [7 /*endfinally*/];
+                            case 6: return [2 /*return*/];
+                        }
+                    });
+                }); }))];
+        });
+    });
+}
+/**
+ * Smart query router: automatically detects read-only (SELECT) queries and
+ * routes them to replica pools, while routing writes (INSERT/UPDATE/DELETE) to primary.
+ * This enables transparent replica usage without changing existing code patterns.
+ *
+ * @param text   - The parameterised SQL query string
+ * @param params - Optional query parameters
+ */
+function querySmart(text, params) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            // Auto-detect if this is a read-only query
+            if ((0, readOnlyDetector_1.isReadOnlyQuery)(text)) {
+                return [2 /*return*/, queryRead(text, params)];
+            }
+            else {
+                return [2 /*return*/, queryWrite(text, params)];
+            }
+            return [2 /*return*/];
+        });
+    });
+}
+/**
+ * Get PgBouncer pool statistics
+ * Queries PgBouncer admin database to get connection pool metrics
+ */
+function getPgBouncerStats() {
+    return __awaiter(this, void 0, void 0, function () {
+        var pgbouncerPool, result, row, err_2;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    _a.trys.push([0, 3, , 4]);
+                    pgbouncerPool = new pg_1.Pool({
+                        connectionString: process.env.PGBOUNCER_ADMIN_URL || "postgresql://user:password@localhost:6432/pgbouncer",
+                    });
+                    return [4 /*yield*/, pgbouncerPool.query("SELECT sum(cl_active) as active, sum(cl_idle) as idle, sum(sv_active) as sv_active, sum(sv_idle) as sv_idle FROM pgbouncer.client_lookup;")];
+                case 1:
+                    result = _a.sent();
+                    return [4 /*yield*/, pgbouncerPool.end()];
+                case 2:
+                    _a.sent();
+                    row = result.rows[0] || {};
+                    return [2 /*return*/, {
+                            activeConnections: parseInt(row.sv_active || 0),
+                            idleConnections: parseInt(row.sv_idle || 0),
+                            totalConnections: (parseInt(row.sv_active || 0) + parseInt(row.sv_idle || 0)),
+                            clientConnections: (parseInt(row.cl_active || 0) + parseInt(row.cl_idle || 0)),
+                        }];
+                case 3:
+                    err_2 = _a.sent();
+                    console.warn("Failed to get PgBouncer stats:", err_2);
+                    return [2 /*return*/, {
+                            activeConnections: 0,
+                            idleConnections: 0,
+                            totalConnections: 0,
+                            clientConnections: 0,
+                        }];
+                case 4: return [2 /*return*/];
+            }
+        });
+    });
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -644,6 +644,17 @@ router.put(
   },
 );
 
+// provider balance route
+router.get("/providers/balances", requireAdmin, async (req, res) => {
+  const mobileMoneyService = new MobileMoneyService();
+  const balances = await mobileMoneyService.getAllProviderBalances();
+
+  return res.json({
+    success: true,
+    data: balances,
+  });
+});
+
 /**
  * =========================
  * TRANSACTIONS

--- a/src/services/mobilemoney/mobileMoneyService.js
+++ b/src/services/mobilemoney/mobileMoneyService.js
@@ -1,0 +1,313 @@
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MobileMoneyService = void 0;
+var metrics_1 = require("../../utils/metrics");
+var circuitBreaker_1 = require("../../utils/circuitBreaker");
+var MobileMoneyError = /** @class */ (function (_super) {
+    __extends(MobileMoneyError, _super);
+    function MobileMoneyError(code, message, originalError) {
+        var _this = _super.call(this, message) || this;
+        _this.code = code;
+        _this.originalError = originalError;
+        _this.name = "MobileMoneyError";
+        return _this;
+    }
+    return MobileMoneyError;
+}(Error));
+/**
+ * Lazy provider factory
+ * Heavy modules are loaded ONLY when needed
+ */
+function loadProvider(key) {
+    return __awaiter(this, void 0, void 0, function () {
+        var _a, mod, mod, mod;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    _a = key;
+                    switch (_a) {
+                        case "mtn": return [3 /*break*/, 1];
+                        case "airtel": return [3 /*break*/, 3];
+                        case "orange": return [3 /*break*/, 5];
+                    }
+                    return [3 /*break*/, 7];
+                case 1: return [4 /*yield*/, Promise.resolve().then(function () { return require("./providers/mtn"); })];
+                case 2:
+                    mod = _b.sent();
+                    return [2 /*return*/, new mod.MTNProvider()];
+                case 3: return [4 /*yield*/, Promise.resolve().then(function () { return require("./providers/airtel"); })];
+                case 4:
+                    mod = _b.sent();
+                    return [2 /*return*/, new mod.AirtelService()];
+                case 5: return [4 /*yield*/, Promise.resolve().then(function () { return require("./providers/orange"); })];
+                case 6:
+                    mod = _b.sent();
+                    return [2 /*return*/, new mod.OrangeProvider()];
+                case 7: throw new Error("Unknown provider: ".concat(key));
+            }
+        });
+    });
+}
+var MobileMoneyService = /** @class */ (function () {
+    function MobileMoneyService(providers) {
+        this.failoverHistory = new Map();
+        this.providers = new Map();
+        // Allow dependency injection for tests; otherwise use lazy loading
+        if (providers) {
+            this.providers = providers;
+        }
+    }
+    MobileMoneyService.prototype.failoverEnabled = function () {
+        return (String(process.env.PROVIDER_FAILOVER_ENABLED || "false").toLowerCase() ===
+            "true");
+    };
+    MobileMoneyService.prototype.getBackupProviderKey = function (primary) {
+        var envKey = "PROVIDER_BACKUP_".concat(primary.toUpperCase());
+        var val = process.env[envKey];
+        return val ? val.toLowerCase() : null;
+    };
+    MobileMoneyService.prototype.recordFailover = function (provider) {
+        var _a;
+        var now = Date.now();
+        var arr = (_a = this.failoverHistory.get(provider)) !== null && _a !== void 0 ? _a : [];
+        arr.push(now);
+        this.failoverHistory.set(provider, arr.slice(-100));
+    };
+    MobileMoneyService.prototype.checkRepeatedFailovers = function (provider) {
+        var _a;
+        var WINDOW_MS = 60 * 60 * 1000;
+        var THRESHOLD = 3;
+        var now = Date.now();
+        var arr = (_a = this.failoverHistory.get(provider)) !== null && _a !== void 0 ? _a : [];
+        var recent = arr.filter(function (t) { return now - t <= WINDOW_MS; });
+        return recent.length >= THRESHOLD;
+    };
+    MobileMoneyService.prototype.notifyRepeatedFailovers = function (provider) {
+        console.error("Failover alert: provider=".concat(provider, " experienced repeated failovers"));
+        metrics_1.providerFailoverAlerts.inc({ provider: provider });
+    };
+    MobileMoneyService.prototype.getProviderOrThrow = function (providerKey) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, loadProvider(providerKey)];
+                    case 1: return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
+    };
+    MobileMoneyService.prototype.callProvider = function (provider, op, phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (op === "requestPayment") {
+                    return [2 /*return*/, provider.requestPayment(phoneNumber, amount)];
+                }
+                return [2 /*return*/, provider.sendPayout(phoneNumber, amount)];
+            });
+        });
+    };
+    MobileMoneyService.prototype.getOperationType = function (op) {
+        return op === "requestPayment" ? "payment" : "payout";
+    };
+    MobileMoneyService.prototype.buildProviderFailureMessage = function (providerKey, error, phase) {
+        var reason = error instanceof Error && error.message
+            ? error.message
+            : "provider operation failed";
+        return "".concat(phase, " provider '").concat(providerKey, "' failed: ").concat(reason);
+    };
+    MobileMoneyService.prototype.executeProviderOperation = function (op, providerKey, phoneNumber, amount, allowFailover) {
+        return __awaiter(this, void 0, void 0, function () {
+            var provider, operationType, backupKey, error_1;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.getProviderOrThrow(providerKey)];
+                    case 1:
+                        provider = _a.sent();
+                        operationType = this.getOperationType(op);
+                        backupKey = allowFailover && this.failoverEnabled()
+                            ? this.getBackupProviderKey(providerKey)
+                            : null;
+                        _a.label = 2;
+                    case 2:
+                        _a.trys.push([2, 4, , 5]);
+                        return [4 /*yield*/, (0, circuitBreaker_1.executeWithCircuitBreaker)({
+                                provider: providerKey,
+                                operation: op,
+                                execute: function () { return __awaiter(_this, void 0, void 0, function () {
+                                    var result;
+                                    return __generator(this, function (_a) {
+                                        switch (_a.label) {
+                                            case 0: return [4 /*yield*/, this.callProvider(provider, op, phoneNumber, amount)];
+                                            case 1:
+                                                result = _a.sent();
+                                                return [2 /*return*/, result.success
+                                                        ? {
+                                                            success: true,
+                                                            provider: providerKey,
+                                                            data: result.data,
+                                                        }
+                                                        : {
+                                                            success: false,
+                                                            provider: providerKey,
+                                                            error: result.error,
+                                                        }];
+                                        }
+                                    });
+                                }); },
+                                fallback: backupKey
+                                    ? function (error) { return __awaiter(_this, void 0, void 0, function () {
+                                        return __generator(this, function (_a) {
+                                            if (backupKey === providerKey) {
+                                                return [2 /*return*/, {
+                                                        success: false,
+                                                        provider: providerKey,
+                                                        error: error,
+                                                    }];
+                                            }
+                                            console.warn("Failing over from ".concat(providerKey, " to ").concat(backupKey, " for ").concat(op));
+                                            metrics_1.providerFailoverTotal.inc({
+                                                type: operationType,
+                                                from_provider: providerKey,
+                                                to_provider: backupKey,
+                                                reason: String(error).slice(0, 100),
+                                            });
+                                            this.recordFailover(providerKey);
+                                            if (this.checkRepeatedFailovers(providerKey)) {
+                                                this.notifyRepeatedFailovers(providerKey);
+                                            }
+                                            return [2 /*return*/, this.executeProviderOperation(op, backupKey, phoneNumber, amount, false)];
+                                        });
+                                    }); }
+                                    : undefined,
+                            })];
+                    case 3: return [2 /*return*/, _a.sent()];
+                    case 4:
+                        error_1 = _a.sent();
+                        metrics_1.transactionTotal.inc({
+                            type: operationType,
+                            provider: providerKey,
+                            status: "failure",
+                        });
+                        metrics_1.transactionErrorsTotal.inc({
+                            type: operationType,
+                            provider: providerKey,
+                            error_type: allowFailover ? "provider_or_exception" : "backup_failure",
+                        });
+                        throw new MobileMoneyError("PROVIDER_ERROR", this.buildProviderFailureMessage(providerKey, error_1, allowFailover ? "primary" : "backup"), error_1);
+                    case 5: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    MobileMoneyService.prototype.initiatePayment = function (provider, phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            var providerKey, result;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        providerKey = provider.toLowerCase();
+                        return [4 /*yield*/, this.executeProviderOperation("requestPayment", providerKey, phoneNumber, amount, true)];
+                    case 1:
+                        result = _a.sent();
+                        if (result.success) {
+                            metrics_1.transactionTotal.inc({
+                                type: "payment",
+                                provider: result.provider,
+                                status: "success",
+                            });
+                            return [2 /*return*/, { success: true, data: result.data, providerResponseTimeMs: result.providerResponseTimeMs }];
+                        }
+                        throw new MobileMoneyError("PROVIDER_ERROR", "Payment failed for provider '".concat(providerKey, "'"), result.error);
+                }
+            });
+        });
+    };
+    MobileMoneyService.prototype.sendPayout = function (provider, phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            var providerKey, result;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        providerKey = provider.toLowerCase();
+                        return [4 /*yield*/, this.executeProviderOperation("sendPayout", providerKey, phoneNumber, amount, true)];
+                    case 1:
+                        result = _a.sent();
+                        if (result.success) {
+                            metrics_1.transactionTotal.inc({
+                                type: "payout",
+                                provider: result.provider,
+                                status: "success",
+                            });
+                            return [2 /*return*/, { success: true, data: result.data, providerResponseTimeMs: result.providerResponseTimeMs }];
+                        }
+                        throw new MobileMoneyError("PROVIDER_ERROR", "Payout failed for provider '".concat(providerKey, "'"), result.error);
+                }
+            });
+        });
+    };
+    MobileMoneyService.prototype.getFailoverStats = function () {
+        var stats = {};
+        for (var _i = 0, _a = this.failoverHistory.entries(); _i < _a.length; _i++) {
+            var _b = _a[_i], provider = _b[0], history_1 = _b[1];
+            stats[provider] = {
+                failover_count: history_1.length,
+                last_failover: history_1.at(-1),
+            };
+        }
+        return stats;
+    };
+    return MobileMoneyService;
+}());
+exports.MobileMoneyService = MobileMoneyService;

--- a/src/services/mobilemoney/mobileMoneyService.ts
+++ b/src/services/mobilemoney/mobileMoneyService.ts
@@ -7,6 +7,7 @@ import {
 import { executeWithCircuitBreaker } from "../../utils/circuitBreaker";
 import { pool } from "../../config/database";
 import { MonitoringService } from "../monitoringService";
+import { redisClient } from "../../config/redis";
 
 export type ProviderTransactionStatus =
   | "completed"
@@ -19,14 +20,27 @@ interface MobileMoneyProvider {
     phoneNumber: string,
     amount: string,
   ): Promise<{ success: boolean; data?: unknown; error?: unknown }>;
+
   sendPayout(
     phoneNumber: string,
     amount: string,
   ): Promise<{ success: boolean; data?: unknown; error?: unknown }>;
+
   getTransactionStatus?(
     referenceId: string,
   ): Promise<{ status: ProviderTransactionStatus }>;
+
+ 
+  getOperationalBalance?(): Promise<{
+    success: boolean;
+    data?: {
+      availableBalance: number;
+      currency: string;
+    };
+    error?: unknown;
+  }>;
 }
+
 
 interface ProviderExecutionResult {
   success: boolean;
@@ -330,4 +344,92 @@ export class MobileMoneyService {
 
     return stats;
   }
+
+  async getAllProviderBalances(): Promise<
+  {
+    provider: string;
+    balance: number | null;
+    currency: string | null;
+    status: "healthy" | "down";
+    lastUpdated: string;
+  }[]
+> {
+  const CACHE_TTL = parseInt(process.env.PROVIDER_BALANCE_CACHE_TTL || "60"); // seconds
+  const CACHE_KEY = "provider:balances";
+
+  // Try to get from cache first
+  try {
+    if (redisClient && redisClient.isOpen) {
+      const cached = await redisClient.get(CACHE_KEY);
+      if (cached) {
+        return JSON.parse(cached as string);
+      }
+    }
+  } catch (error) {
+    console.warn("Redis cache read failed, falling back to direct fetch:", error);
+  }
+
+  const providerKeys = ["mtn", "airtel", "orange"];
+
+  const results = await Promise.all(
+    providerKeys.map(async (key) => {
+      try {
+        const provider = await loadProvider(key);
+
+        // If provider does not support balance
+        if (!provider.getOperationalBalance) {
+          return {
+            provider: key,
+            balance: null,
+            currency: null,
+            status: "down" as const,
+            lastUpdated: new Date().toISOString(),
+          };
+        }
+
+        const res = await provider.getOperationalBalance();
+
+        // Handle the success/error response format
+        if (!res.success || !res.data) {
+          return {
+            provider: key,
+            balance: null,
+            currency: null,
+            status: "down" as const,
+            lastUpdated: new Date().toISOString(),
+          };
+        }
+
+        return {
+          provider: key,
+          balance: res.data.availableBalance,
+          currency: res.data.currency,
+          status: "healthy" as const,
+          lastUpdated: new Date().toISOString(),
+        };
+      } catch {
+        return {
+          provider: key,
+          balance: null,
+          currency: null,
+          status: "down" as const,
+          lastUpdated: new Date().toISOString(),
+        };
+      }
+    })
+  );
+
+  // Cache the results
+  try {
+    if (redisClient && redisClient.isOpen) {
+      await redisClient.setex(CACHE_KEY, CACHE_TTL, JSON.stringify(results));
+    }
+  } catch (error) {
+    console.warn("Redis cache write failed:", error);
+  }
+
+  return results;
+}
+
+
 }

--- a/src/services/mobilemoney/providers/airtel.js
+++ b/src/services/mobilemoney/providers/airtel.js
@@ -1,0 +1,375 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AirtelService = void 0;
+var axios_1 = require("axios");
+var AirtelService = /** @class */ (function () {
+    function AirtelService() {
+        this.token = null;
+        this.tokenExpiry = 0;
+        this.client = axios_1.default.create({
+            baseURL: process.env.AIRTEL_BASE_URL,
+            timeout: 10000,
+        });
+    }
+    AirtelService.prototype.authenticate = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var response, response_1, error_1;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        if (this.token && Date.now() < this.tokenExpiry) {
+                            return [2 /*return*/, this.token];
+                        }
+                        return [4 /*yield*/, this.client.post("/auth/oauth2/token", null, {
+                                headers: {
+                                    "Content-Type": "application/json",
+                                    Authorization: "Basic " +
+                                        Buffer.from("".concat(process.env.AIRTEL_API_KEY, ":").concat(process.env.AIRTEL_API_SECRET)).toString("base64"),
+                                },
+                            })];
+                    case 1:
+                        response = _a.sent();
+                        _a.label = 2;
+                    case 2:
+                        _a.trys.push([2, 4, , 5]);
+                        return [4 /*yield*/, this.client.post("/auth/oauth2/token", null, {
+                                headers: {
+                                    "Content-Type": "application/json",
+                                    Authorization: "Basic " +
+                                        Buffer.from("".concat(process.env.AIRTEL_API_KEY, ":").concat(process.env.AIRTEL_API_SECRET)).toString("base64"),
+                                },
+                            })];
+                    case 3:
+                        response_1 = _a.sent();
+                        this.token = response_1.data.access_token;
+                        this.tokenExpiry = Date.now() + response_1.data.expires_in * 1000;
+                        return [2 /*return*/, this.token];
+                    case 4:
+                        error_1 = _a.sent();
+                        console.error("Airtel auth failed", error_1);
+                        throw new Error("Airtel authentication failed");
+                    case 5: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    AirtelService.prototype.withRetry = function (fn_1) {
+        return __awaiter(this, arguments, void 0, function (fn, retries) {
+            var lastError, _loop_1, this_1, i, state_1;
+            var _a, _b;
+            if (retries === void 0) { retries = 3; }
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        _loop_1 = function (i) {
+                            var _d, err_1, axiosError;
+                            return __generator(this, function (_e) {
+                                switch (_e.label) {
+                                    case 0:
+                                        _e.trys.push([0, 2, , 5]);
+                                        _d = {};
+                                        return [4 /*yield*/, fn()];
+                                    case 1: return [2 /*return*/, (_d.value = _e.sent(), _d)];
+                                    case 2:
+                                        err_1 = _e.sent();
+                                        lastError = err_1;
+                                        axiosError = err_1;
+                                        if (((_a = axiosError.response) === null || _a === void 0 ? void 0 : _a.status) === 401) {
+                                            this_1.token = null;
+                                        }
+                                        if (!((((_b = err_1.response) === null || _b === void 0 ? void 0 : _b.status) &&
+                                            err_1.response.status >= 500) ||
+                                            err_1.code === "ECONNABORTED")) return [3 /*break*/, 4];
+                                        console.warn("Retrying Airtel request (".concat(i + 1, ")"));
+                                        return [4 /*yield*/, new Promise(function (res) { return setTimeout(res, 1000 * (i + 1)); })];
+                                    case 3:
+                                        _e.sent();
+                                        return [2 /*return*/, "continue"];
+                                    case 4: throw err_1;
+                                    case 5: return [2 /*return*/];
+                                }
+                            });
+                        };
+                        this_1 = this;
+                        i = 0;
+                        _c.label = 1;
+                    case 1:
+                        if (!(i < retries)) return [3 /*break*/, 4];
+                        return [5 /*yield**/, _loop_1(i)];
+                    case 2:
+                        state_1 = _c.sent();
+                        if (typeof state_1 === "object")
+                            return [2 /*return*/, state_1.value];
+                        _c.label = 3;
+                    case 3:
+                        i++;
+                        return [3 /*break*/, 1];
+                    case 4: throw lastError;
+                }
+            });
+        });
+    };
+    /**
+     * =========================
+     * REQUEST PAYMENT (COLLECTION)
+     * =========================
+     */
+    AirtelService.prototype.requestPayment = function (phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            var token, reference;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.authenticate()];
+                    case 1:
+                        token = _a.sent();
+                        reference = "AIRTEL-".concat(Date.now());
+                        return [2 /*return*/, this.withRetry(function () { return __awaiter(_this, void 0, void 0, function () {
+                                var response, error_2;
+                                return __generator(this, function (_a) {
+                                    switch (_a.label) {
+                                        case 0:
+                                            _a.trys.push([0, 2, , 3]);
+                                            return [4 /*yield*/, this.client.post("/merchant/v1/payments/", {
+                                                    reference: reference,
+                                                    subscriber: {
+                                                        country: "NG",
+                                                        currency: "NGN",
+                                                        msisdn: phoneNumber,
+                                                    },
+                                                    transaction: {
+                                                        amount: parseFloat(amount),
+                                                        country: "NG",
+                                                        currency: "NGN",
+                                                        id: reference,
+                                                    },
+                                                }, {
+                                                    headers: {
+                                                        Authorization: "Bearer ".concat(token),
+                                                        "X-Country": "NG",
+                                                        "X-Currency": "NGN",
+                                                    },
+                                                })];
+                                        case 1:
+                                            response = _a.sent();
+                                            return [2 /*return*/, { success: true, data: response.data }];
+                                        case 2:
+                                            error_2 = _a.sent();
+                                            return [2 /*return*/, { success: false, error: error_2 }];
+                                        case 3: return [2 /*return*/];
+                                    }
+                                });
+                            }); })];
+                }
+            });
+        });
+    };
+    AirtelService.prototype.getTransactionStatus = function (reference) {
+        return __awaiter(this, void 0, void 0, function () {
+            var result, txStatus, _a;
+            var _b, _c, _d, _e;
+            return __generator(this, function (_f) {
+                switch (_f.label) {
+                    case 0:
+                        _f.trys.push([0, 2, , 3]);
+                        return [4 /*yield*/, this.checkStatus(reference)];
+                    case 1:
+                        result = _f.sent();
+                        if (!result.success)
+                            return [2 /*return*/, { status: "unknown" }];
+                        txStatus = String((_e = (_d = (_c = (_b = result.data) === null || _b === void 0 ? void 0 : _b.data) === null || _c === void 0 ? void 0 : _c.transaction) === null || _d === void 0 ? void 0 : _d.status) !== null && _e !== void 0 ? _e : "").toUpperCase();
+                        // Airtel status codes: TS = success, TF = failed, TP = pending
+                        if (txStatus === "TS")
+                            return [2 /*return*/, { status: "completed" }];
+                        if (txStatus === "TF")
+                            return [2 /*return*/, { status: "failed" }];
+                        if (txStatus === "TP")
+                            return [2 /*return*/, { status: "pending" }];
+                        return [2 /*return*/, { status: "unknown" }];
+                    case 2:
+                        _a = _f.sent();
+                        return [2 /*return*/, { status: "unknown" }];
+                    case 3: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    AirtelService.prototype.checkStatus = function (reference) {
+        return __awaiter(this, void 0, void 0, function () {
+            var token;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.authenticate()];
+                    case 1:
+                        token = _a.sent();
+                        return [2 /*return*/, this.withRetry(function () { return __awaiter(_this, void 0, void 0, function () {
+                                var response, error_3;
+                                return __generator(this, function (_a) {
+                                    switch (_a.label) {
+                                        case 0:
+                                            _a.trys.push([0, 2, , 3]);
+                                            return [4 /*yield*/, this.client.get("/standard/v1/payments/".concat(reference), {
+                                                    headers: {
+                                                        Authorization: "Bearer ".concat(token),
+                                                        "X-Country": "NG",
+                                                        "X-Currency": "NGN",
+                                                    },
+                                                })];
+                                        case 1:
+                                            response = _a.sent();
+                                            return [2 /*return*/, { success: true, data: response.data }];
+                                        case 2:
+                                            error_3 = _a.sent();
+                                            return [2 /*return*/, { success: false, error: error_3 }];
+                                        case 3: return [2 /*return*/];
+                                    }
+                                });
+                            }); })];
+                }
+            });
+        });
+    };
+    AirtelService.prototype.getOperationalBalance = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var token;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.authenticate()];
+                    case 1:
+                        token = _a.sent();
+                        return [2 /*return*/, this.withRetry(function () { return __awaiter(_this, void 0, void 0, function () {
+                                var response, rawBalance, availableBalance, error_4;
+                                var _a, _b, _c, _d, _e, _f, _g;
+                                return __generator(this, function (_h) {
+                                    switch (_h.label) {
+                                        case 0:
+                                            _h.trys.push([0, 2, , 3]);
+                                            return [4 /*yield*/, this.client.get("/standard/v1/users/balance", {
+                                                    headers: {
+                                                        Authorization: "Bearer ".concat(token),
+                                                        "X-Country": process.env.AIRTEL_COUNTRY || "NG",
+                                                        "X-Currency": process.env.AIRTEL_CURRENCY || "NGN",
+                                                    },
+                                                })];
+                                        case 1:
+                                            response = _h.sent();
+                                            rawBalance = (_f = (_e = (_d = (_b = (_a = response.data.data) === null || _a === void 0 ? void 0 : _a.availableBalance) !== null && _b !== void 0 ? _b : (_c = response.data.data) === null || _c === void 0 ? void 0 : _c.balance) !== null && _d !== void 0 ? _d : response.data.availableBalance) !== null && _e !== void 0 ? _e : response.data.balance) !== null && _f !== void 0 ? _f : 0;
+                                            availableBalance = typeof rawBalance === "number"
+                                                ? rawBalance
+                                                : Number.parseFloat(String(rawBalance));
+                                            if (!Number.isFinite(availableBalance)) {
+                                                throw new Error("Invalid Airtel balance response");
+                                            }
+                                            return [2 /*return*/, {
+                                                    success: true,
+                                                    data: {
+                                                        availableBalance: availableBalance,
+                                                        currency: ((_g = response.data.data) === null || _g === void 0 ? void 0 : _g.currency) ||
+                                                            response.data.currency ||
+                                                            process.env.AIRTEL_CURRENCY ||
+                                                            "NGN",
+                                                    },
+                                                }];
+                                        case 2:
+                                            error_4 = _h.sent();
+                                            return [2 /*return*/, { success: false, error: error_4 }];
+                                        case 3: return [2 /*return*/];
+                                    }
+                                });
+                            }); })];
+                }
+            });
+        });
+    };
+    /**
+     * =========================
+     * PAYOUT (DISBURSEMENT)
+     * =========================
+     */
+    AirtelService.prototype.sendPayout = function (phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            var token, reference;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.authenticate()];
+                    case 1:
+                        token = _a.sent();
+                        reference = "AIRTEL-PAYOUT-".concat(Date.now());
+                        return [2 /*return*/, this.withRetry(function () { return __awaiter(_this, void 0, void 0, function () {
+                                var response, error_5;
+                                return __generator(this, function (_a) {
+                                    switch (_a.label) {
+                                        case 0:
+                                            _a.trys.push([0, 2, , 3]);
+                                            return [4 /*yield*/, this.client.post("/standard/v1/disbursements/", {
+                                                    reference: reference,
+                                                    payee: {
+                                                        msisdn: phoneNumber,
+                                                    },
+                                                    transaction: {
+                                                        amount: parseFloat(amount),
+                                                        id: reference,
+                                                    },
+                                                }, {
+                                                    headers: {
+                                                        Authorization: "Bearer ".concat(token),
+                                                        "X-Country": "NG",
+                                                        "X-Currency": "NGN",
+                                                    },
+                                                })];
+                                        case 1:
+                                            response = _a.sent();
+                                            return [2 /*return*/, { success: true, data: response.data }];
+                                        case 2:
+                                            error_5 = _a.sent();
+                                            return [2 /*return*/, { success: false, error: error_5 }];
+                                        case 3: return [2 /*return*/];
+                                    }
+                                });
+                            }); })];
+                }
+            });
+        });
+    };
+    return AirtelService;
+}());
+exports.AirtelService = AirtelService;

--- a/src/services/mobilemoney/providers/mtn.js
+++ b/src/services/mobilemoney/providers/mtn.js
@@ -1,0 +1,195 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MTNProvider = void 0;
+var axios_1 = require("axios");
+var crypto_1 = require("crypto");
+var MTNProvider = /** @class */ (function () {
+    function MTNProvider() {
+        this.baseUrl = "https://sandbox.momodeveloper.mtn.com";
+        this.apiKey = process.env.MTN_API_KEY || "";
+        this.apiSecret = process.env.MTN_API_SECRET || "";
+        this.subscriptionKey = process.env.MTN_SUBSCRIPTION_KEY || "";
+        this.environment = process.env.MTN_TARGET_ENVIRONMENT || "sandbox";
+        if (process.env.MTN_BASE_URL) {
+            this.baseUrl = process.env.MTN_BASE_URL;
+        }
+    }
+    MTNProvider.prototype.getAccessToken = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var response, token;
+            var _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, axios_1.default.post("".concat(this.baseUrl, "/collection/token/"), undefined, {
+                            headers: {
+                                Authorization: "Basic " +
+                                    Buffer.from("".concat(this.apiKey, ":").concat(this.apiSecret)).toString("base64"),
+                                "Ocp-Apim-Subscription-Key": this.subscriptionKey,
+                            },
+                        })];
+                    case 1:
+                        response = _b.sent();
+                        token = (_a = response.data) === null || _a === void 0 ? void 0 : _a.access_token;
+                        if (!token || typeof token !== "string") {
+                            throw new Error("MTN token response did not include access_token");
+                        }
+                        return [2 /*return*/, token];
+                }
+            });
+        });
+    };
+    MTNProvider.prototype.getOperationalBalance = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var token, response, availableRaw, availableBalance, error_1;
+            var _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        _c.trys.push([0, 3, , 4]);
+                        return [4 /*yield*/, this.getAccessToken()];
+                    case 1:
+                        token = _c.sent();
+                        return [4 /*yield*/, axios_1.default.get("".concat(this.baseUrl, "/disbursement/v1_0/account/balance"), {
+                                headers: {
+                                    Authorization: "Bearer ".concat(token),
+                                    "Ocp-Apim-Subscription-Key": this.subscriptionKey,
+                                    "X-Target-Environment": this.environment,
+                                },
+                            })];
+                    case 2:
+                        response = _c.sent();
+                        availableRaw = (_b = (_a = response.data.availableBalance) !== null && _a !== void 0 ? _a : response.data.balance) !== null && _b !== void 0 ? _b : 0;
+                        availableBalance = typeof availableRaw === "number"
+                            ? availableRaw
+                            : Number.parseFloat(String(availableRaw));
+                        if (!Number.isFinite(availableBalance)) {
+                            throw new Error("Invalid MTN balance response");
+                        }
+                        return [2 /*return*/, {
+                                success: true,
+                                data: {
+                                    availableBalance: availableBalance,
+                                    currency: response.data.currency || "XAF",
+                                },
+                            }];
+                    case 3:
+                        error_1 = _c.sent();
+                        return [2 /*return*/, { success: false, error: error_1 }];
+                    case 4: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    MTNProvider.prototype.requestPayment = function (phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            var response, error_2;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 2, , 3]);
+                        return [4 /*yield*/, axios_1.default.post("".concat(this.baseUrl, "/collection/v1_0/requesttopay"), {
+                                amount: amount,
+                                currency: "EUR",
+                                externalId: (0, crypto_1.randomUUID)(),
+                                payer: { partyIdType: "MSISDN", partyId: phoneNumber },
+                                payerMessage: "Payment for Stellar deposit",
+                                payeeNote: "Deposit",
+                            }, {
+                                headers: {
+                                    "Ocp-Apim-Subscription-Key": this.subscriptionKey,
+                                    "X-Target-Environment": "sandbox",
+                                },
+                            })];
+                    case 1:
+                        response = _a.sent();
+                        return [2 /*return*/, { success: true, data: response.data }];
+                    case 2:
+                        error_2 = _a.sent();
+                        return [2 /*return*/, { success: false, error: error_2 }];
+                    case 3: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    MTNProvider.prototype.sendPayout = function (_phoneNumber, _amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, { success: true }];
+            });
+        });
+    };
+    MTNProvider.prototype.getTransactionStatus = function (referenceId) {
+        return __awaiter(this, void 0, void 0, function () {
+            var token, response, providerStatus, _a;
+            var _b, _c;
+            return __generator(this, function (_d) {
+                switch (_d.label) {
+                    case 0:
+                        _d.trys.push([0, 3, , 4]);
+                        return [4 /*yield*/, this.getAccessToken()];
+                    case 1:
+                        token = _d.sent();
+                        return [4 /*yield*/, axios_1.default.get("".concat(this.baseUrl, "/collection/v1_0/requesttopay/").concat(encodeURIComponent(referenceId)), {
+                                headers: {
+                                    Authorization: "Bearer ".concat(token),
+                                    "Ocp-Apim-Subscription-Key": this.subscriptionKey,
+                                    "X-Target-Environment": this.environment,
+                                },
+                            })];
+                    case 2:
+                        response = _d.sent();
+                        providerStatus = String((_c = (_b = response.data) === null || _b === void 0 ? void 0 : _b.status) !== null && _c !== void 0 ? _c : "").toUpperCase();
+                        if (providerStatus === "SUCCESSFUL")
+                            return [2 /*return*/, { status: "completed" }];
+                        if (providerStatus === "FAILED")
+                            return [2 /*return*/, { status: "failed" }];
+                        if (providerStatus === "PENDING")
+                            return [2 /*return*/, { status: "pending" }];
+                        return [2 /*return*/, { status: "unknown" }];
+                    case 3:
+                        _a = _d.sent();
+                        return [2 /*return*/, { status: "unknown" }];
+                    case 4: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    return MTNProvider;
+}());
+exports.MTNProvider = MTNProvider;

--- a/src/services/mobilemoney/providers/orange.js
+++ b/src/services/mobilemoney/providers/orange.js
@@ -1,0 +1,789 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.OrangeProvider = void 0;
+var axios_1 = require("axios");
+var fs = require("fs");
+var path = require("path");
+var DEFAULT_SESSION_TTL_MS = 20 * 60 * 1000;
+var DEFAULT_REFRESH_SKEW_MS = 60 * 1000;
+var OrangeProvider = /** @class */ (function () {
+    function OrangeProvider(options) {
+        if (options === void 0) { options = {}; }
+        var _a, _b, _c, _d;
+        this.session = null;
+        this.sessionPromise = null;
+        this.apiToken = null;
+        this.apiTokenExpiry = 0;
+        this.clock = (_a = options.clock) !== null && _a !== void 0 ? _a : Date.now;
+        this.config = this.buildConfig(options);
+        this.mode = this.resolveMode();
+        this.client =
+            (_b = options.httpClient) !== null && _b !== void 0 ? _b : axios_1.default.create({
+                baseURL: this.config.webBaseUrl,
+                timeout: this.config.requestTimeoutMs,
+                maxRedirects: 0,
+                validateStatus: function () { return true; },
+            });
+        this.directClient =
+            (_c = options.directHttpClient) !== null && _c !== void 0 ? _c : axios_1.default.create({
+                baseURL: this.config.directBaseUrl,
+                timeout: this.config.requestTimeoutMs,
+                validateStatus: function () { return true; },
+            });
+        if (this.config.proxyBaseUrl) {
+            this.proxyClient =
+                (_d = options.proxyHttpClient) !== null && _d !== void 0 ? _d : axios_1.default.create({
+                    baseURL: this.config.proxyBaseUrl,
+                    timeout: this.config.requestTimeoutMs,
+                    validateStatus: function () { return true; },
+                });
+        }
+    }
+    OrangeProvider.prototype.requestPayment = function (phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this.executeOperation("payment", phoneNumber, String(amount))];
+            });
+        });
+    };
+    OrangeProvider.prototype.sendPayout = function (phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this.executeOperation("payout", phoneNumber, String(amount))];
+            });
+        });
+    };
+    OrangeProvider.prototype.checkStatus = function (reference) {
+        return __awaiter(this, void 0, void 0, function () {
+            var response_1, response_2, response, error_1;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 6, , 7]);
+                        if (!(this.mode === "proxy")) return [3 /*break*/, 2];
+                        return [4 /*yield*/, this.sendRequest(this.proxyClient, {
+                                method: "GET",
+                                url: this.formatPath(this.config.statusPath, reference),
+                                headers: this.config.proxySecret
+                                    ? { "X-Orange-Proxy-Secret": this.config.proxySecret }
+                                    : undefined,
+                            })];
+                    case 1:
+                        response_1 = _a.sent();
+                        return [2 /*return*/, this.toProviderResult(response_1, reference)];
+                    case 2:
+                        if (!(this.mode === "direct")) return [3 /*break*/, 4];
+                        return [4 /*yield*/, this.requestDirect({
+                                method: "GET",
+                                url: this.formatPath(this.config.directStatusPath, reference),
+                            })];
+                    case 3:
+                        response_2 = _a.sent();
+                        return [2 /*return*/, this.toProviderResult(response_2, reference)];
+                    case 4: return [4 /*yield*/, this.requestWithSession({
+                            method: "GET",
+                            url: this.formatPath(this.config.statusPath, reference),
+                        }, "payment")];
+                    case 5:
+                        response = _a.sent();
+                        return [2 /*return*/, this.toProviderResult(response, reference)];
+                    case 6:
+                        error_1 = _a.sent();
+                        return [2 /*return*/, { success: false, error: error_1, reference: reference }];
+                    case 7: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.buildConfig = function (options) {
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29;
+        return {
+            mode: (_a = options.mode) !== null && _a !== void 0 ? _a : process.env.ORANGE_MODE,
+            webBaseUrl: (_d = (_c = (_b = options.webBaseUrl) !== null && _b !== void 0 ? _b : options.baseUrl) !== null && _c !== void 0 ? _c : process.env.ORANGE_WEB_BASE_URL) !== null && _d !== void 0 ? _d : "",
+            directBaseUrl: (_g = (_f = (_e = options.directBaseUrl) !== null && _e !== void 0 ? _e : options.baseUrl) !== null && _f !== void 0 ? _f : process.env.ORANGE_BASE_URL) !== null && _g !== void 0 ? _g : "https://sandbox.orange.com",
+            loginPath: (_j = (_h = options.loginPath) !== null && _h !== void 0 ? _h : process.env.ORANGE_LOGIN_PATH) !== null && _j !== void 0 ? _j : "/login",
+            refreshPath: (_l = (_k = options.refreshPath) !== null && _k !== void 0 ? _k : process.env.ORANGE_REFRESH_PATH) !== null && _l !== void 0 ? _l : "/session/refresh",
+            paymentPath: (_o = (_m = options.paymentPath) !== null && _m !== void 0 ? _m : process.env.ORANGE_PAYMENT_PATH) !== null && _o !== void 0 ? _o : "/transactions/collections",
+            payoutPath: (_q = (_p = options.payoutPath) !== null && _p !== void 0 ? _p : process.env.ORANGE_PAYOUT_PATH) !== null && _q !== void 0 ? _q : "/transactions/payouts",
+            statusPath: (_s = (_r = options.statusPath) !== null && _r !== void 0 ? _r : process.env.ORANGE_STATUS_PATH) !== null && _s !== void 0 ? _s : "/transactions/:reference",
+            directAuthPath: (_u = (_t = options.directAuthPath) !== null && _t !== void 0 ? _t : process.env.ORANGE_DIRECT_AUTH_PATH) !== null && _u !== void 0 ? _u : "/oauth/token",
+            directPaymentPath: (_w = (_v = options.directPaymentPath) !== null && _v !== void 0 ? _v : process.env.ORANGE_DIRECT_PAYMENT_PATH) !== null && _w !== void 0 ? _w : "/v1/payments/collect",
+            directPayoutPath: (_y = (_x = options.directPayoutPath) !== null && _x !== void 0 ? _x : process.env.ORANGE_DIRECT_PAYOUT_PATH) !== null && _y !== void 0 ? _y : "/v1/payments/disburse",
+            directStatusPath: (_0 = (_z = options.directStatusPath) !== null && _z !== void 0 ? _z : process.env.ORANGE_DIRECT_STATUS_PATH) !== null && _0 !== void 0 ? _0 : "/v1/payments/:reference",
+            username: (_3 = (_2 = (_1 = options.username) !== null && _1 !== void 0 ? _1 : process.env.ORANGE_USERNAME) !== null && _2 !== void 0 ? _2 : process.env.ORANGE_API_KEY) !== null && _3 !== void 0 ? _3 : "",
+            password: (_6 = (_5 = (_4 = options.password) !== null && _4 !== void 0 ? _4 : process.env.ORANGE_PASSWORD) !== null && _5 !== void 0 ? _5 : process.env.ORANGE_API_SECRET) !== null && _6 !== void 0 ? _6 : "",
+            apiKey: (_8 = (_7 = options.apiKey) !== null && _7 !== void 0 ? _7 : process.env.ORANGE_API_KEY) !== null && _8 !== void 0 ? _8 : "",
+            apiSecret: (_10 = (_9 = options.apiSecret) !== null && _9 !== void 0 ? _9 : process.env.ORANGE_API_SECRET) !== null && _10 !== void 0 ? _10 : "",
+            usernameField: (_12 = (_11 = options.usernameField) !== null && _11 !== void 0 ? _11 : process.env.ORANGE_USERNAME_FIELD) !== null && _12 !== void 0 ? _12 : "username",
+            passwordField: (_14 = (_13 = options.passwordField) !== null && _13 !== void 0 ? _13 : process.env.ORANGE_PASSWORD_FIELD) !== null && _14 !== void 0 ? _14 : "password",
+            csrfField: (_16 = (_15 = options.csrfField) !== null && _15 !== void 0 ? _15 : process.env.ORANGE_CSRF_FIELD) !== null && _16 !== void 0 ? _16 : "_csrf",
+            currency: (_18 = (_17 = options.currency) !== null && _17 !== void 0 ? _17 : process.env.ORANGE_CURRENCY) !== null && _18 !== void 0 ? _18 : "XAF",
+            sessionStorePath: (_19 = options.sessionStorePath) !== null && _19 !== void 0 ? _19 : process.env.ORANGE_SESSION_STORE_PATH,
+            sessionTtlMs: Number((_21 = (_20 = options.sessionTtlMs) !== null && _20 !== void 0 ? _20 : process.env.ORANGE_SESSION_TTL_MS) !== null && _21 !== void 0 ? _21 : DEFAULT_SESSION_TTL_MS),
+            refreshSkewMs: Number((_23 = (_22 = options.refreshSkewMs) !== null && _22 !== void 0 ? _22 : process.env.ORANGE_REFRESH_SKEW_MS) !== null && _23 !== void 0 ? _23 : DEFAULT_REFRESH_SKEW_MS),
+            requestTimeoutMs: Number((_25 = (_24 = options.requestTimeoutMs) !== null && _24 !== void 0 ? _24 : process.env.REQUEST_TIMEOUT_MS) !== null && _25 !== void 0 ? _25 : 30000),
+            maxAttempts: Number((_27 = (_26 = options.maxAttempts) !== null && _26 !== void 0 ? _26 : process.env.ORANGE_MAX_ATTEMPTS) !== null && _27 !== void 0 ? _27 : 3),
+            proxyBaseUrl: (_28 = options.proxyBaseUrl) !== null && _28 !== void 0 ? _28 : process.env.ORANGE_PROXY_URL,
+            proxySecret: (_29 = options.proxySecret) !== null && _29 !== void 0 ? _29 : process.env.ORANGE_PROXY_SECRET,
+        };
+    };
+    OrangeProvider.prototype.sendRequest = function (client, request) {
+        return __awaiter(this, void 0, void 0, function () {
+            var method, url, config, data;
+            var _a;
+            return __generator(this, function (_b) {
+                if (client.request) {
+                    return [2 /*return*/, client.request(request)];
+                }
+                method = ((_a = request.method) !== null && _a !== void 0 ? _a : "GET").toUpperCase();
+                url = request.url;
+                if (!url) {
+                    throw new Error("Orange request URL is required");
+                }
+                config = __assign({}, request);
+                delete config.method;
+                delete config.url;
+                if (method === "GET" && client.get) {
+                    delete config.data;
+                    return [2 /*return*/, client.get(url, config)];
+                }
+                if (method === "POST" && client.post) {
+                    data = config.data;
+                    delete config.data;
+                    return [2 /*return*/, client.post(url, data, config)];
+                }
+                throw new Error("Orange HTTP client does not support ".concat(method));
+            });
+        });
+    };
+    OrangeProvider.prototype.resolveMode = function () {
+        if (this.config.proxyBaseUrl) {
+            return "proxy";
+        }
+        if (this.config.mode === "direct" || this.config.mode === "web") {
+            return this.config.mode;
+        }
+        if (this.config.webBaseUrl &&
+            (this.config.username || this.config.sessionStorePath)) {
+            return "web";
+        }
+        return "direct";
+    };
+    OrangeProvider.prototype.executeOperation = function (operation, phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            var reference, response, error_2;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 6, , 7]);
+                        if (!(this.mode === "proxy")) return [3 /*break*/, 2];
+                        return [4 /*yield*/, this.executeViaProxy(operation, phoneNumber, amount)];
+                    case 1: return [2 /*return*/, _a.sent()];
+                    case 2:
+                        if (!(this.mode === "direct")) return [3 /*break*/, 4];
+                        return [4 /*yield*/, this.executeViaDirectApi(operation, phoneNumber, amount)];
+                    case 3: return [2 /*return*/, _a.sent()];
+                    case 4:
+                        this.assertWebConfig();
+                        reference = this.createReference(operation);
+                        return [4 /*yield*/, this.requestWithSession({
+                                method: "POST",
+                                url: operation === "payment"
+                                    ? this.config.paymentPath
+                                    : this.config.payoutPath,
+                                data: {
+                                    amount: amount,
+                                    currency: this.config.currency,
+                                    msisdn: phoneNumber,
+                                    reference: reference,
+                                },
+                            }, operation)];
+                    case 5:
+                        response = _a.sent();
+                        return [2 /*return*/, this.toProviderResult(response, reference)];
+                    case 6:
+                        error_2 = _a.sent();
+                        return [2 /*return*/, { success: false, error: error_2 }];
+                    case 7: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.executeViaProxy = function (operation, phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            var reference, response;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        reference = this.createReference(operation);
+                        return [4 /*yield*/, this.sendRequest(this.proxyClient, {
+                                method: "POST",
+                                url: operation === "payment"
+                                    ? this.config.paymentPath
+                                    : this.config.payoutPath,
+                                headers: this.config.proxySecret
+                                    ? { "X-Orange-Proxy-Secret": this.config.proxySecret }
+                                    : undefined,
+                                data: {
+                                    amount: amount,
+                                    currency: this.config.currency,
+                                    msisdn: phoneNumber,
+                                    reference: reference,
+                                },
+                            })];
+                    case 1:
+                        response = _a.sent();
+                        return [2 /*return*/, this.toProviderResult(response, reference)];
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.executeViaDirectApi = function (operation, phoneNumber, amount) {
+        return __awaiter(this, void 0, void 0, function () {
+            var reference, endpoint, response;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        reference = this.createReference(operation);
+                        endpoint = operation === "payment"
+                            ? this.config.directPaymentPath
+                            : this.config.directPayoutPath;
+                        return [4 /*yield*/, this.requestDirect({
+                                method: "POST",
+                                url: endpoint,
+                                data: operation === "payment"
+                                    ? {
+                                        reference: reference,
+                                        subscriber: { msisdn: phoneNumber },
+                                        transaction: {
+                                            amount: parseFloat(amount),
+                                            currency: this.config.currency,
+                                            id: reference,
+                                        },
+                                    }
+                                    : {
+                                        reference: reference,
+                                        payee: { msisdn: phoneNumber },
+                                        transaction: {
+                                            amount: parseFloat(amount),
+                                            currency: this.config.currency,
+                                            id: reference,
+                                        },
+                                    },
+                            })];
+                    case 1:
+                        response = _a.sent();
+                        return [2 /*return*/, this.toProviderResult(response, reference)];
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.requestDirect = function (request) {
+        return __awaiter(this, void 0, void 0, function () {
+            var lastResponse, lastError, attempt, token, requestHeaders, response, error_3;
+            var _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        lastResponse = null;
+                        attempt = 1;
+                        _c.label = 1;
+                    case 1:
+                        if (!(attempt <= this.config.maxAttempts)) return [3 /*break*/, 10];
+                        _c.label = 2;
+                    case 2:
+                        _c.trys.push([2, 7, , 9]);
+                        return [4 /*yield*/, this.authenticateDirect()];
+                    case 3:
+                        token = _c.sent();
+                        requestHeaders = ((_a = request.headers) !== null && _a !== void 0 ? _a : {});
+                        return [4 /*yield*/, this.sendRequest(this.directClient, __assign(__assign({}, request), { headers: __assign(__assign({}, requestHeaders), { Authorization: "Bearer ".concat(token), "Content-Type": (_b = requestHeaders["Content-Type"]) !== null && _b !== void 0 ? _b : "application/json" }) }))];
+                    case 4:
+                        response = _c.sent();
+                        if (response.status === 401 || response.status === 403) {
+                            this.apiToken = null;
+                            lastResponse = response;
+                            return [3 /*break*/, 9];
+                        }
+                        if (!(response.status >= 500 && attempt < this.config.maxAttempts)) return [3 /*break*/, 6];
+                        lastResponse = response;
+                        return [4 /*yield*/, this.delay(attempt)];
+                    case 5:
+                        _c.sent();
+                        return [3 /*break*/, 9];
+                    case 6: return [2 /*return*/, response];
+                    case 7:
+                        error_3 = _c.sent();
+                        lastError = error_3;
+                        if (attempt >= this.config.maxAttempts) {
+                            throw error_3;
+                        }
+                        return [4 /*yield*/, this.delay(attempt)];
+                    case 8:
+                        _c.sent();
+                        return [3 /*break*/, 9];
+                    case 9:
+                        attempt++;
+                        return [3 /*break*/, 1];
+                    case 10:
+                        if (lastResponse) {
+                            return [2 /*return*/, lastResponse];
+                        }
+                        throw lastError !== null && lastError !== void 0 ? lastError : new Error("Orange direct API request failed");
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.authenticateDirect = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var authHeader, response, data;
+            var _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        if (this.apiToken && this.clock() < this.apiTokenExpiry) {
+                            return [2 /*return*/, this.apiToken];
+                        }
+                        if (this.config.mode === "direct") {
+                            this.assertDirectConfig();
+                        }
+                        authHeader = "Basic " +
+                            Buffer.from("".concat(this.config.apiKey, ":").concat(this.config.apiSecret)).toString("base64");
+                        return [4 /*yield*/, this.sendRequest(this.directClient, {
+                                method: "POST",
+                                url: this.config.directAuthPath,
+                                headers: {
+                                    Authorization: authHeader,
+                                    "Content-Type": "application/x-www-form-urlencoded",
+                                },
+                                data: "grant_type=client_credentials",
+                            })];
+                    case 1:
+                        response = _b.sent();
+                        if (response.status < 200 || response.status >= 300) {
+                            throw new Error("Orange direct auth failed with status ".concat(response.status));
+                        }
+                        data = response.data;
+                        if (!data.access_token) {
+                            throw new Error("Orange direct auth did not return access_token");
+                        }
+                        this.apiToken = data.access_token;
+                        this.apiTokenExpiry =
+                            this.clock() + ((_a = data.expires_in) !== null && _a !== void 0 ? _a : 3600) * 1000 - 5000;
+                        return [2 /*return*/, this.apiToken];
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.requestWithSession = function (request, operation) {
+        return __awaiter(this, void 0, void 0, function () {
+            var lastResponse, lastError, attempt, session, requestHeaders, response, error_4;
+            var _a, _b, _c;
+            return __generator(this, function (_d) {
+                switch (_d.label) {
+                    case 0:
+                        lastResponse = null;
+                        attempt = 1;
+                        _d.label = 1;
+                    case 1:
+                        if (!(attempt <= this.config.maxAttempts)) return [3 /*break*/, 10];
+                        return [4 /*yield*/, this.ensureSession(attempt > 1)];
+                    case 2:
+                        session = _d.sent();
+                        requestHeaders = ((_a = request.headers) !== null && _a !== void 0 ? _a : {});
+                        _d.label = 3;
+                    case 3:
+                        _d.trys.push([3, 7, , 9]);
+                        return [4 /*yield*/, this.sendRequest(this.client, __assign(__assign({}, request), { headers: __assign(__assign({}, requestHeaders), { Cookie: this.serializeCookies(session), "X-CSRF-Token": (_b = session.csrfToken) !== null && _b !== void 0 ? _b : "", "Idempotency-Key": (_c = requestHeaders["Idempotency-Key"]) !== null && _c !== void 0 ? _c : this.getRequestReference(request, operation) }) }))];
+                    case 4:
+                        response = _d.sent();
+                        this.captureSession(response, session);
+                        if (this.isSessionExpiredResponse(response)) {
+                            this.session = null;
+                            lastResponse = response;
+                            return [3 /*break*/, 9];
+                        }
+                        if (!(response.status >= 500 && attempt < this.config.maxAttempts)) return [3 /*break*/, 6];
+                        lastResponse = response;
+                        return [4 /*yield*/, this.delay(attempt)];
+                    case 5:
+                        _d.sent();
+                        return [3 /*break*/, 9];
+                    case 6: return [2 /*return*/, response];
+                    case 7:
+                        error_4 = _d.sent();
+                        lastError = error_4;
+                        if (attempt >= this.config.maxAttempts) {
+                            throw error_4;
+                        }
+                        return [4 /*yield*/, this.delay(attempt)];
+                    case 8:
+                        _d.sent();
+                        return [3 /*break*/, 9];
+                    case 9:
+                        attempt++;
+                        return [3 /*break*/, 1];
+                    case 10:
+                        if (lastResponse) {
+                            return [2 /*return*/, lastResponse];
+                        }
+                        throw lastError !== null && lastError !== void 0 ? lastError : new Error("Orange request failed");
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.ensureSession = function () {
+        return __awaiter(this, arguments, void 0, function (forceLogin) {
+            var cached;
+            var _a;
+            if (forceLogin === void 0) { forceLogin = false; }
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        if (!forceLogin) {
+                            cached = (_a = this.session) !== null && _a !== void 0 ? _a : this.loadSession();
+                            if (cached && !this.isExpired(cached)) {
+                                this.session = cached;
+                                if (this.shouldRefresh(cached)) {
+                                    return [2 /*return*/, this.refreshSession(cached)];
+                                }
+                                return [2 /*return*/, cached];
+                            }
+                        }
+                        if (!this.sessionPromise || forceLogin) {
+                            this.sessionPromise = this.login();
+                        }
+                        _b.label = 1;
+                    case 1:
+                        _b.trys.push([1, , 3, 4]);
+                        return [4 /*yield*/, this.sessionPromise];
+                    case 2: return [2 /*return*/, _b.sent()];
+                    case 3:
+                        this.sessionPromise = null;
+                        return [7 /*endfinally*/];
+                    case 4: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.login = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var loginPage, initialSession, csrfToken, payload, loginResponse, session;
+            var _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0: return [4 /*yield*/, this.sendRequest(this.client, {
+                            method: "GET",
+                            url: this.config.loginPath,
+                        })];
+                    case 1:
+                        loginPage = _c.sent();
+                        initialSession = this.captureSession(loginPage);
+                        csrfToken = (_a = this.extractCsrfToken(loginPage)) !== null && _a !== void 0 ? _a : initialSession.csrfToken;
+                        payload = new URLSearchParams();
+                        payload.set(this.config.usernameField, this.config.username);
+                        payload.set(this.config.passwordField, this.config.password);
+                        if (csrfToken) {
+                            payload.set(this.config.csrfField, csrfToken);
+                        }
+                        return [4 /*yield*/, this.sendRequest(this.client, {
+                                method: "POST",
+                                url: this.config.loginPath,
+                                headers: __assign({ "Content-Type": "application/x-www-form-urlencoded", Cookie: this.serializeCookies(initialSession) }, (csrfToken ? { "X-CSRF-Token": csrfToken } : {})),
+                                data: payload.toString(),
+                            })];
+                    case 2:
+                        loginResponse = _c.sent();
+                        if (loginResponse.status < 200 || loginResponse.status >= 300) {
+                            throw new Error("Orange login failed with status ".concat(loginResponse.status));
+                        }
+                        session = this.captureSession(loginResponse, initialSession);
+                        session.csrfToken = (_b = this.extractCsrfToken(loginResponse)) !== null && _b !== void 0 ? _b : csrfToken;
+                        this.session = this.ensureExpiresAt(session);
+                        this.persistSession(this.session);
+                        return [2 /*return*/, this.session];
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.refreshSession = function (session) {
+        return __awaiter(this, void 0, void 0, function () {
+            var response, _a;
+            var _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        _c.trys.push([0, 2, , 3]);
+                        return [4 /*yield*/, this.sendRequest(this.client, {
+                                method: "POST",
+                                url: this.config.refreshPath,
+                                headers: __assign({ Cookie: this.serializeCookies(session) }, (session.csrfToken ? { "X-CSRF-Token": session.csrfToken } : {})),
+                            })];
+                    case 1:
+                        response = _c.sent();
+                        if (response.status < 200 || response.status >= 300) {
+                            throw new Error("Orange refresh failed with status ".concat(response.status));
+                        }
+                        this.captureSession(response, session);
+                        session.csrfToken = (_b = this.extractCsrfToken(response)) !== null && _b !== void 0 ? _b : session.csrfToken;
+                        this.session = this.ensureExpiresAt(session);
+                        this.persistSession(this.session);
+                        return [2 /*return*/, this.session];
+                    case 2:
+                        _a = _c.sent();
+                        this.session = null;
+                        return [2 /*return*/, this.login()];
+                    case 3: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    OrangeProvider.prototype.captureSession = function (response, existing) {
+        var _a, _b, _c;
+        var session = existing !== null && existing !== void 0 ? existing : {
+            cookies: {},
+            expiresAt: this.clock() + this.config.sessionTtlMs,
+            authenticatedAt: this.clock(),
+        };
+        for (var _i = 0, _d = this.getSetCookieHeaders(response); _i < _d.length; _i++) {
+            var cookie = _d[_i];
+            var parsed = this.parseSetCookie(cookie);
+            if (parsed) {
+                session.cookies[parsed.name] = {
+                    value: parsed.value,
+                    expiresAt: parsed.expiresAt,
+                };
+            }
+        }
+        session.csrfToken = (_a = this.extractCsrfToken(response)) !== null && _a !== void 0 ? _a : session.csrfToken;
+        session.expiresAt =
+            (_c = (_b = this.getEarliestCookieExpiry(session)) !== null && _b !== void 0 ? _b : session.expiresAt) !== null && _c !== void 0 ? _c : this.clock() + this.config.sessionTtlMs;
+        return session;
+    };
+    OrangeProvider.prototype.loadSession = function () {
+        if (!this.config.sessionStorePath) {
+            return null;
+        }
+        try {
+            if (!fs.existsSync(this.config.sessionStorePath)) {
+                return null;
+            }
+            var raw = fs.readFileSync(this.config.sessionStorePath, "utf8");
+            var parsed = JSON.parse(raw);
+            if (!parsed.cookies || !parsed.expiresAt || this.isExpired(parsed)) {
+                return null;
+            }
+            return parsed;
+        }
+        catch (_a) {
+            return null;
+        }
+    };
+    OrangeProvider.prototype.persistSession = function (session) {
+        if (!this.config.sessionStorePath) {
+            return;
+        }
+        var dir = path.dirname(this.config.sessionStorePath);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(this.config.sessionStorePath, JSON.stringify(session), {
+            mode: 384,
+        });
+    };
+    OrangeProvider.prototype.serializeCookies = function (session) {
+        var now = this.clock();
+        return Object.entries(session.cookies)
+            .filter(function (_a) {
+            var cookie = _a[1];
+            return !cookie.expiresAt || cookie.expiresAt > now;
+        })
+            .map(function (_a) {
+            var name = _a[0], cookie = _a[1];
+            return "".concat(name, "=").concat(cookie.value);
+        })
+            .join("; ");
+    };
+    OrangeProvider.prototype.parseSetCookie = function (header) {
+        var _a = header.split(";").map(function (part) { return part.trim(); }), pair = _a[0], attributes = _a.slice(1);
+        var separator = pair.indexOf("=");
+        if (separator <= 0) {
+            return null;
+        }
+        var cookie = {
+            name: pair.slice(0, separator),
+            value: pair.slice(separator + 1),
+        };
+        for (var _i = 0, attributes_1 = attributes; _i < attributes_1.length; _i++) {
+            var attribute = attributes_1[_i];
+            var _b = attribute.split("="), key = _b[0], value = _b[1];
+            if (key.toLowerCase() === "expires" && value) {
+                var expiresAt = Date.parse(value);
+                if (!Number.isNaN(expiresAt)) {
+                    cookie.expiresAt = expiresAt;
+                }
+            }
+            if (key.toLowerCase() === "max-age" && value) {
+                var seconds = Number(value);
+                if (!Number.isNaN(seconds)) {
+                    cookie.expiresAt = this.clock() + seconds * 1000;
+                }
+            }
+        }
+        return cookie;
+    };
+    OrangeProvider.prototype.getSetCookieHeaders = function (response) {
+        var _a;
+        var headers = response.headers;
+        var value = (_a = headers["set-cookie"]) !== null && _a !== void 0 ? _a : headers["Set-Cookie"];
+        if (!value) {
+            return [];
+        }
+        return Array.isArray(value) ? value : [value];
+    };
+    OrangeProvider.prototype.extractCsrfToken = function (response) {
+        var _a, _b, _c;
+        var headers = response.headers;
+        var headerToken = (_a = headers["x-csrf-token"]) !== null && _a !== void 0 ? _a : headers["X-CSRF-Token"];
+        if (headerToken) {
+            return headerToken;
+        }
+        if (typeof response.data !== "string") {
+            return undefined;
+        }
+        var html = response.data;
+        var metaMatch = html.match(/<meta[^>]+name=["']csrf-token["'][^>]+content=["']([^"']+)["']/i);
+        var inputMatch = html.match(/<input[^>]+name=["'](?:_csrf|csrf_token|csrf)["'][^>]+value=["']([^"']+)["']/i);
+        var reversedInputMatch = html.match(/<input[^>]+value=["']([^"']+)["'][^>]+name=["'](?:_csrf|csrf_token|csrf)["']/i);
+        return (_c = (_b = metaMatch === null || metaMatch === void 0 ? void 0 : metaMatch[1]) !== null && _b !== void 0 ? _b : inputMatch === null || inputMatch === void 0 ? void 0 : inputMatch[1]) !== null && _c !== void 0 ? _c : reversedInputMatch === null || reversedInputMatch === void 0 ? void 0 : reversedInputMatch[1];
+    };
+    OrangeProvider.prototype.ensureExpiresAt = function (session) {
+        if (!session.expiresAt || session.expiresAt <= this.clock()) {
+            session.expiresAt = this.clock() + this.config.sessionTtlMs;
+        }
+        return session;
+    };
+    OrangeProvider.prototype.getEarliestCookieExpiry = function (session) {
+        var expiries = Object.values(session.cookies)
+            .map(function (cookie) { return cookie.expiresAt; })
+            .filter(function (expiresAt) { return Boolean(expiresAt); });
+        return expiries.length > 0 ? Math.min.apply(Math, expiries) : undefined;
+    };
+    OrangeProvider.prototype.isExpired = function (session) {
+        return session.expiresAt <= this.clock();
+    };
+    OrangeProvider.prototype.shouldRefresh = function (session) {
+        return session.expiresAt - this.clock() <= this.config.refreshSkewMs;
+    };
+    OrangeProvider.prototype.isSessionExpiredResponse = function (response) {
+        var _a;
+        if ([401, 403, 419, 440].includes(response.status)) {
+            return true;
+        }
+        var headers = response.headers;
+        var location = (_a = headers["location"]) !== null && _a !== void 0 ? _a : headers["Location"];
+        return Boolean(location === null || location === void 0 ? void 0 : location.includes(this.config.loginPath));
+    };
+    OrangeProvider.prototype.toProviderResult = function (response, reference) {
+        var _a;
+        var status = (_a = response.status) !== null && _a !== void 0 ? _a : 200;
+        if (status >= 200 && status < 300) {
+            return { success: true, data: response.data, reference: reference };
+        }
+        return {
+            success: false,
+            reference: reference,
+            error: {
+                status: status,
+                data: response.data,
+            },
+        };
+    };
+    OrangeProvider.prototype.assertWebConfig = function () {
+        if (!this.config.webBaseUrl) {
+            throw new Error("ORANGE_WEB_BASE_URL is required for web session mode");
+        }
+        if (!this.config.username || !this.config.password) {
+            throw new Error("ORANGE_USERNAME/ORANGE_PASSWORD or ORANGE_API_KEY/ORANGE_API_SECRET are required");
+        }
+    };
+    OrangeProvider.prototype.assertDirectConfig = function () {
+        if (!this.config.apiKey || !this.config.apiSecret) {
+            throw new Error("ORANGE_API_KEY and ORANGE_API_SECRET are required");
+        }
+    };
+    OrangeProvider.prototype.createReference = function (operation) {
+        return "ORANGE-".concat(operation.toUpperCase(), "-").concat(this.clock());
+    };
+    OrangeProvider.prototype.getRequestReference = function (request, operation) {
+        var _a;
+        var data = request.data;
+        return (_a = data === null || data === void 0 ? void 0 : data.reference) !== null && _a !== void 0 ? _a : this.createReference(operation);
+    };
+    OrangeProvider.prototype.formatPath = function (template, reference) {
+        return template.includes(":reference")
+            ? template.replace(":reference", encodeURIComponent(reference))
+            : "".concat(template.replace(/\/$/, ""), "/").concat(encodeURIComponent(reference));
+    };
+    OrangeProvider.prototype.delay = function (attempt) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, new Promise(function (resolve) {
+                            return setTimeout(resolve, Math.min(250 * attempt, 1000));
+                        })];
+                    case 1:
+                        _a.sent();
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    return OrangeProvider;
+}());
+exports.OrangeProvider = OrangeProvider;

--- a/src/services/mobilemoney/providers/orange.ts
+++ b/src/services/mobilemoney/providers/orange.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
-import fs from "fs";
-import path from "path";
+import * as fs from "fs";
+import * as path from "path";
 
 type OrangeOperation = "payment" | "payout";
 type OrangeMode = "web" | "direct" | "proxy";

--- a/src/services/monitoringService.js
+++ b/src/services/monitoringService.js
@@ -1,0 +1,289 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MonitoringService = void 0;
+var metrics_1 = require("../utils/metrics");
+var MonitoringService = /** @class */ (function () {
+    function MonitoringService() {
+    }
+    /**
+     * Initialize the monitoring service with PagerDuty integration
+     */
+    MonitoringService.initialize = function (pagerDutyService) {
+        this.pagerDutyService = pagerDutyService || null;
+    };
+    MonitoringService.start = function (intervalMs) {
+        var _this = this;
+        if (intervalMs === void 0) { intervalMs = 30000; }
+        // Default 30 seconds for more frequent error rate checks
+        if (this.checkInterval)
+            return;
+        this.checkInterval = setInterval(function () { return __awaiter(_this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.runChecks()];
+                    case 1:
+                        _a.sent();
+                        return [2 /*return*/];
+                }
+            });
+        }); }, intervalMs);
+        console.log("Monitoring service started with interval ".concat(intervalMs, "ms"));
+    };
+    MonitoringService.stop = function () {
+        if (this.checkInterval) {
+            clearInterval(this.checkInterval);
+            this.checkInterval = null;
+        }
+    };
+    MonitoringService.runChecks = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var metrics, error_1;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 2, , 3]);
+                        return [4 /*yield*/, metrics_1.register.getMetricsAsJSON()];
+                    case 1:
+                        metrics = _a.sent();
+                        // 1. Check performance metrics (P95)
+                        this.checkPerformanceMetrics(metrics);
+                        // 2. Check provider error rates (new PagerDuty integration)
+                        this.checkProviderErrorRates(metrics);
+                        return [3 /*break*/, 3];
+                    case 2:
+                        error_1 = _a.sent();
+                        console.error("Error in monitoring service checks", error_1);
+                        return [3 /*break*/, 3];
+                    case 3: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    /**
+     * Check performance metrics and alert on degradation
+     */
+    MonitoringService.checkPerformanceMetrics = function (metrics) {
+        // 1. Check for slow average responses in Histogram
+        var histogram = metrics.find(function (m) { return m.name === "provider_response_time_seconds"; });
+        if (histogram && Array.isArray(histogram.values)) {
+            // We look at the sum / count for each label set
+            // But prom-client JSON output is a bit complex.
+            // For simplicity, we can also just use the Summary quantiles.
+        }
+        // 2. Check P95 from Summary
+        var summary = metrics.find(function (m) { return m.name === "provider_response_time_summary"; });
+        if (summary && Array.isArray(summary.values)) {
+            for (var _i = 0, _a = summary.values; _i < _a.length; _i++) {
+                var val = _a[_i];
+                if (val.labels.quantile === 0.95 &&
+                    val.value > this.P95_THRESHOLD_S) {
+                    console.error(JSON.stringify({
+                        timestamp: new Date().toISOString(),
+                        level: "CRITICAL",
+                        message: "Degraded performance: P95 response time too high",
+                        provider: val.labels.provider,
+                        operation: val.labels.operation,
+                        p95_seconds: val.value,
+                        threshold_seconds: this.P95_THRESHOLD_S,
+                    }));
+                }
+            }
+        }
+    };
+    /**
+     * Check provider error rates within the 5-minute sliding window
+     * Triggers PagerDuty incidents when error rate exceeds 15%
+     */
+    MonitoringService.checkProviderErrorRates = function (metrics) {
+        if (!this.pagerDutyService)
+            return;
+        var now = Date.now();
+        var windowStart = now - this.WINDOW_MS;
+        // Get transaction metrics
+        var errorMetric = metrics.find(function (m) { return m.name === "transaction_errors_total"; });
+        var totalMetric = metrics.find(function (m) { return m.name === "transaction_total"; });
+        var providerErrors = new Map();
+        var providerTotals = new Map();
+        // Aggregate errors by provider
+        if (errorMetric && Array.isArray(errorMetric.values)) {
+            for (var _i = 0, _a = errorMetric.values; _i < _a.length; _i++) {
+                var val = _a[_i];
+                var provider = val.labels.provider;
+                var currentCount = providerErrors.get(provider) || 0;
+                providerErrors.set(provider, currentCount + val.value);
+            }
+        }
+        // Aggregate totals by provider
+        if (totalMetric && Array.isArray(totalMetric.values)) {
+            for (var _b = 0, _c = totalMetric.values; _b < _c.length; _b++) {
+                var val = _c[_b];
+                var provider = val.labels.provider;
+                var currentCount = providerTotals.get(provider) || 0;
+                providerTotals.set(provider, currentCount + val.value);
+            }
+        }
+        // Calculate error rates and trigger/resolve incidents
+        var providers = new Set(__spreadArray(__spreadArray([], providerErrors.keys(), true), providerTotals.keys(), true));
+        for (var _d = 0, providers_1 = providers; _d < providers_1.length; _d++) {
+            var provider = providers_1[_d];
+            var errorCount = providerErrors.get(provider) || 0;
+            var totalCount = providerTotals.get(provider) || 0;
+            // Record metrics in history for sliding window calculation
+            this.recordMetricHistory(provider, errorCount, totalCount);
+            // Calculate error rate within the sliding window
+            var windowMetrics = this.getMetricsInWindow(provider, windowStart);
+            var errorRate = this.calculateErrorRate(windowMetrics);
+            // Update current metrics
+            var metrics_2 = {
+                provider: provider,
+                errorCount: windowMetrics.totalErrors,
+                totalCount: windowMetrics.totalCount,
+                errorRate: errorRate,
+                lastUpdated: new Date(),
+            };
+            this.providerMetricsWindow.set(provider, metrics_2);
+            // Decision logic for PagerDuty
+            if (errorRate > this.ERROR_RATE_THRESHOLD) {
+                this.pagerDutyService.recordProviderError(provider, now);
+                console.warn(JSON.stringify({
+                    timestamp: new Date().toISOString(),
+                    level: "WARNING",
+                    message: "Provider error rate exceeded threshold",
+                    provider: provider,
+                    errorRate: (errorRate * 100).toFixed(2) + "%",
+                    threshold: "15%",
+                    window: "5 minutes",
+                    errorCount: windowMetrics.totalErrors,
+                    totalCount: windowMetrics.totalCount,
+                }));
+            }
+            else if (errorRate <= this.ERROR_RATE_THRESHOLD) {
+                this.pagerDutyService.recordProviderSuccess(provider);
+            }
+        }
+    };
+    /**
+     * Record metric data point in history for sliding window calculation
+     */
+    MonitoringService.recordMetricHistory = function (provider, errorCount, totalCount) {
+        if (!this.metricsHistory.has(provider)) {
+            this.metricsHistory.set(provider, []);
+        }
+        var history = this.metricsHistory.get(provider);
+        history.push({
+            timestamp: Date.now(),
+            errorCount: errorCount,
+            totalCount: totalCount,
+        });
+        // Keep only the last 5 minutes of data
+        var fiveMinutesAgo = Date.now() - this.WINDOW_MS;
+        var filtered = history.filter(function (h) { return h.timestamp >= fiveMinutesAgo; });
+        this.metricsHistory.set(provider, filtered);
+    };
+    /**
+     * Get aggregated metrics for a provider within the sliding window
+     */
+    MonitoringService.getMetricsInWindow = function (provider, windowStart) {
+        var history = this.metricsHistory.get(provider) || [];
+        var totalErrors = 0;
+        var totalCount = 0;
+        for (var _i = 0, history_1 = history; _i < history_1.length; _i++) {
+            var entry = history_1[_i];
+            if (entry.timestamp >= windowStart) {
+                totalErrors += entry.errorCount;
+                totalCount += entry.totalCount;
+            }
+        }
+        return {
+            totalErrors: totalErrors,
+            totalCount: totalCount,
+        };
+    };
+    /**
+     * Calculate error rate from window metrics
+     */
+    MonitoringService.calculateErrorRate = function (windowMetrics) {
+        if (windowMetrics.totalCount === 0) {
+            return 0;
+        }
+        return windowMetrics.totalErrors / windowMetrics.totalCount;
+    };
+    /**
+     * Manual check for specific provider/operation.
+     * Can be called after a batch of requests.
+     */
+    MonitoringService.checkPerformance = function (provider, operation) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/];
+            });
+        });
+    };
+    /**
+     * Get current metrics for all providers
+     */
+    MonitoringService.getProviderMetrics = function () {
+        return Array.from(this.providerMetricsWindow.values());
+    };
+    /**
+     * Get metrics for a specific provider
+     */
+    MonitoringService.getProviderMetricsFor = function (provider) {
+        return this.providerMetricsWindow.get(provider);
+    };
+    MonitoringService.checkInterval = null;
+    MonitoringService.SLOW_RESPONSE_THRESHOLD_S = 10;
+    MonitoringService.P95_THRESHOLD_S = 20;
+    MonitoringService.ERROR_RATE_THRESHOLD = 0.15; // 15%
+    MonitoringService.WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+    MonitoringService.pagerDutyService = null;
+    MonitoringService.providerMetricsWindow = new Map();
+    MonitoringService.metricsHistory = new Map();
+    return MonitoringService;
+}());
+exports.MonitoringService = MonitoringService;

--- a/src/services/pagerDutyService.js
+++ b/src/services/pagerDutyService.js
@@ -1,0 +1,364 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.PagerDutyService = void 0;
+exports.createPagerDutyService = createPagerDutyService;
+var axios_1 = require("axios");
+/**
+ * PagerDuty Events API V2 Integration
+ * Sends CRITICAL incidents when provider error rates exceed 15% in 5 minutes
+ * Automatically resolves incidents when error rates drop below threshold
+ */
+var PagerDutyService = /** @class */ (function () {
+    function PagerDutyService(config) {
+        this.activeIncidents = new Map();
+        this.checkInterval = null;
+        this.config = config;
+        this.client = axios_1.default.create({
+            baseURL: PagerDutyService.API_URL,
+            timeout: 5000,
+        });
+    }
+    /**
+     * Start monitoring for error rate spikes
+     * Runs periodic checks to evaluate error rates and trigger/resolve incidents
+     */
+    PagerDutyService.prototype.start = function () {
+        var _this = this;
+        if (!this.config.enabled) {
+            console.log("PagerDuty service is disabled");
+            return;
+        }
+        if (this.checkInterval)
+            return;
+        this.checkInterval = setInterval(function () {
+            _this.evaluateErrorRates().catch(function (error) {
+                console.error("Error in PagerDuty evaluation cycle:", error);
+            });
+        }, PagerDutyService.CHECK_INTERVAL_MS);
+        console.log("PagerDuty monitoring service started");
+    };
+    /**
+     * Stop monitoring
+     */
+    PagerDutyService.prototype.stop = function () {
+        if (this.checkInterval) {
+            clearInterval(this.checkInterval);
+            this.checkInterval = null;
+        }
+    };
+    /**
+     * Record a provider error for tracking in the sliding window
+     * Called when a provider operation fails
+     */
+    PagerDutyService.prototype.recordProviderError = function (provider, timestamp) {
+        if (!this.config.enabled)
+            return;
+        var errorKey = "".concat(provider, "_errors");
+        var requestKey = "".concat(provider, "_total_requests");
+        // Get or initialize error list and request count
+        if (!this.activeIncidents.has(errorKey)) {
+            this.activeIncidents.set(errorKey, {
+                provider: provider,
+                errorRate: 0,
+                errorCount: 0,
+                totalRequests: 0,
+                timestamp: new Date().toISOString(),
+            });
+        }
+        var incident = this.activeIncidents.get(errorKey);
+        incident.errorCount++;
+        // Clean old errors outside the sliding window
+        this.cleanupOldMetrics(provider);
+    };
+    /**
+     * Record a successful provider request
+     * Called when a provider operation succeeds
+     */
+    PagerDutyService.prototype.recordProviderSuccess = function (provider) {
+        if (!this.config.enabled)
+            return;
+        var requestKey = "".concat(provider, "_total_requests");
+        if (!this.activeIncidents.has(requestKey)) {
+            this.activeIncidents.set(requestKey, {
+                provider: provider,
+                errorRate: 0,
+                errorCount: 0,
+                totalRequests: 0,
+                timestamp: new Date().toISOString(),
+            });
+        }
+        var incident = this.activeIncidents.get(requestKey);
+        incident.totalRequests++;
+    };
+    /**
+     * Evaluate error rates for all providers and trigger/resolve incidents as needed
+     * This is called periodically by the monitoring loop
+     */
+    PagerDutyService.prototype.evaluateErrorRates = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var providers, _i, providers_1, provider, errorRate, isIncidentActive;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        providers = this.getTrackedProviders();
+                        _i = 0, providers_1 = providers;
+                        _a.label = 1;
+                    case 1:
+                        if (!(_i < providers_1.length)) return [3 /*break*/, 6];
+                        provider = providers_1[_i];
+                        errorRate = this.calculateErrorRate(provider);
+                        isIncidentActive = this.activeIncidents.has("incident_".concat(provider));
+                        if (!(errorRate > PagerDutyService.ERROR_RATE_THRESHOLD && !isIncidentActive)) return [3 /*break*/, 3];
+                        // Trigger new incident
+                        return [4 /*yield*/, this.triggerIncident(provider, errorRate)];
+                    case 2:
+                        // Trigger new incident
+                        _a.sent();
+                        return [3 /*break*/, 5];
+                    case 3:
+                        if (!(errorRate <= PagerDutyService.ERROR_RATE_THRESHOLD &&
+                            isIncidentActive)) return [3 /*break*/, 5];
+                        // Resolve incident
+                        return [4 /*yield*/, this.resolveIncident(provider, errorRate)];
+                    case 4:
+                        // Resolve incident
+                        _a.sent();
+                        _a.label = 5;
+                    case 5:
+                        _i++;
+                        return [3 /*break*/, 1];
+                    case 6: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    /**
+     * Calculate error rate for a provider based on metrics in the sliding window
+     */
+    PagerDutyService.prototype.calculateErrorRate = function (provider) {
+        var _a;
+        var errorKey = "".concat(provider, "_errors");
+        var requestKey = "".concat(provider, "_total_requests");
+        var errorData = this.activeIncidents.get(errorKey);
+        var requestData = this.activeIncidents.get(requestKey);
+        if (!requestData || requestData.totalRequests === 0) {
+            return 0;
+        }
+        var errorCount = (_a = errorData === null || errorData === void 0 ? void 0 : errorData.errorCount) !== null && _a !== void 0 ? _a : 0;
+        return errorCount / requestData.totalRequests;
+    };
+    /**
+     * Get list of providers being tracked
+     */
+    PagerDutyService.prototype.getTrackedProviders = function () {
+        var providers = new Set();
+        for (var _i = 0, _a = this.activeIncidents.keys(); _i < _a.length; _i++) {
+            var key = _a[_i];
+            var match = key.match(/^(.+?)_(errors|total_requests)$/);
+            if (match) {
+                providers.add(match[1]);
+            }
+        }
+        return providers;
+    };
+    /**
+     * Clean up old error metrics outside the 5-minute window
+     */
+    PagerDutyService.prototype.cleanupOldMetrics = function (provider) {
+        var now = Date.now();
+        var windowStart = now - PagerDutyService.WINDOW_MS;
+        // Keep data within the window by resetting periodically
+        // In a production system, you might want to use a more sophisticated
+        // time-series approach (e.g., storing timestamps with each error)
+    };
+    /**
+     * Trigger a CRITICAL incident in PagerDuty
+     */
+    PagerDutyService.prototype.triggerIncident = function (provider, errorRate) {
+        return __awaiter(this, void 0, void 0, function () {
+            var event_1, response, error_1;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 2, , 3]);
+                        event_1 = this.buildIncidentEvent(provider, errorRate, "trigger");
+                        return [4 /*yield*/, this.client.post("", event_1)];
+                    case 1:
+                        response = _a.sent();
+                        if (response.status === 202 || response.status === 200) {
+                            // Mark incident as active
+                            this.activeIncidents.set("incident_".concat(provider), {
+                                provider: provider,
+                                errorRate: errorRate,
+                                errorCount: 0,
+                                totalRequests: 0,
+                                timestamp: new Date().toISOString(),
+                            });
+                            console.log(JSON.stringify({
+                                timestamp: new Date().toISOString(),
+                                level: "CRITICAL",
+                                message: "PagerDuty incident triggered",
+                                provider: provider,
+                                errorRate: (errorRate * 100).toFixed(2) + "%",
+                                threshold: "15%",
+                                dedup_key: this.getDedupeKey(provider),
+                            }));
+                        }
+                        return [3 /*break*/, 3];
+                    case 2:
+                        error_1 = _a.sent();
+                        console.error("Failed to trigger PagerDuty incident for provider ".concat(provider, ":"), error_1);
+                        return [3 /*break*/, 3];
+                    case 3: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    /**
+     * Resolve an active incident in PagerDuty
+     */
+    PagerDutyService.prototype.resolveIncident = function (provider, errorRate) {
+        return __awaiter(this, void 0, void 0, function () {
+            var event_2, response, error_2;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 2, , 3]);
+                        event_2 = this.buildIncidentEvent(provider, errorRate, "resolve");
+                        return [4 /*yield*/, this.client.post("", event_2)];
+                    case 1:
+                        response = _a.sent();
+                        if (response.status === 202 || response.status === 200) {
+                            // Mark incident as resolved
+                            this.activeIncidents.delete("incident_".concat(provider));
+                            console.log(JSON.stringify({
+                                timestamp: new Date().toISOString(),
+                                level: "INFO",
+                                message: "PagerDuty incident resolved",
+                                provider: provider,
+                                errorRate: (errorRate * 100).toFixed(2) + "%",
+                                dedup_key: this.getDedupeKey(provider),
+                            }));
+                        }
+                        return [3 /*break*/, 3];
+                    case 2:
+                        error_2 = _a.sent();
+                        console.error("Failed to resolve PagerDuty incident for provider ".concat(provider, ":"), error_2);
+                        return [3 /*break*/, 3];
+                    case 3: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    /**
+     * Build a PagerDuty event payload
+     */
+    PagerDutyService.prototype.buildIncidentEvent = function (provider, errorRate, action) {
+        var dedupeKey = this.getDedupeKey(provider);
+        var errorPercentage = (errorRate * 100).toFixed(2);
+        return {
+            routing_key: this.config.integrationKey,
+            event_action: action,
+            dedup_key: dedupeKey,
+            payload: {
+                summary: action === "trigger"
+                    ? "[CRITICAL] Provider ".concat(provider, " error rate at ").concat(errorPercentage, "% (threshold: 15%)")
+                    : "[RESOLVED] Provider ".concat(provider, " error rate recovered to ").concat(errorPercentage, "%"),
+                timestamp: new Date().toISOString(),
+                severity: action === "trigger" ? "critical" : "info",
+                source: "mobile-money-api",
+                custom_details: {
+                    provider: provider,
+                    errorRatePercentage: errorPercentage,
+                    threshold: "15%",
+                    window: "5 minutes",
+                    action: action,
+                    environment: process.env.NODE_ENV || "development",
+                },
+            },
+        };
+    };
+    /**
+     * Generate a deduplication key for PagerDuty
+     * Ensures that multiple events for the same provider are treated as the same incident
+     */
+    PagerDutyService.prototype.getDedupeKey = function (provider) {
+        return "".concat(this.config.dedupKey, "-").concat(provider, "-error-rate");
+    };
+    /**
+     * Get current error rate for a specific provider (for debugging/monitoring)
+     */
+    PagerDutyService.prototype.getErrorRate = function (provider) {
+        return this.calculateErrorRate(provider);
+    };
+    /**
+     * Get all active incidents
+     */
+    PagerDutyService.prototype.getActiveIncidents = function () {
+        return new Map(this.activeIncidents);
+    };
+    /**
+     * Reset metrics (useful for testing or manual reset)
+     */
+    PagerDutyService.prototype.reset = function () {
+        this.activeIncidents.clear();
+    };
+    PagerDutyService.API_URL = "https://events.pagerduty.com/v2/enqueue";
+    PagerDutyService.ERROR_RATE_THRESHOLD = 0.15; // 15%
+    PagerDutyService.WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+    PagerDutyService.CHECK_INTERVAL_MS = 30 * 1000; // 30 seconds
+    return PagerDutyService;
+}());
+exports.PagerDutyService = PagerDutyService;
+/**
+ * Factory function to create and initialize PagerDuty service
+ */
+function createPagerDutyService(enabled) {
+    if (enabled === void 0) { enabled = true; }
+    var config = {
+        integrationKey: process.env.PAGERDUTY_INTEGRATION_KEY || "",
+        dedupKey: process.env.PAGERDUTY_DEDUP_KEY || "mobile-money",
+        enabled: enabled && !!process.env.PAGERDUTY_INTEGRATION_KEY,
+    };
+    var service = new PagerDutyService(config);
+    if (config.enabled) {
+        service.start();
+    }
+    return service;
+}

--- a/src/utils/circuitBreaker.js
+++ b/src/utils/circuitBreaker.js
@@ -1,0 +1,152 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.executeWithCircuitBreaker = executeWithCircuitBreaker;
+exports.isCircuitBreakerOpenError = isCircuitBreakerOpenError;
+exports.resetCircuitBreakers = resetCircuitBreakers;
+exports.getCircuitBreakerCount = getCircuitBreakerCount;
+var opossum_1 = require("opossum");
+var metrics_1 = require("./metrics");
+var circuitBreakers = new Map();
+var CIRCUIT_STATE_VALUES = {
+    closed: 0,
+    half_open: 0.5,
+    open: 1,
+};
+function getCircuitKey(provider, operation) {
+    return "".concat(provider, ":").concat(operation);
+}
+function getBreakerOptions(name) {
+    var _a, _b, _c, _d, _e, _f, _g;
+    return {
+        name: name,
+        timeout: Number((_a = process.env.PROVIDER_CIRCUIT_BREAKER_TIMEOUT_MS) !== null && _a !== void 0 ? _a : 5000),
+        resetTimeout: Number((_b = process.env.PROVIDER_CIRCUIT_BREAKER_RESET_TIMEOUT_MS) !== null && _b !== void 0 ? _b : 30000),
+        rollingCountTimeout: Number((_c = process.env.PROVIDER_CIRCUIT_BREAKER_ROLLING_WINDOW_MS) !== null && _c !== void 0 ? _c : 10000),
+        rollingCountBuckets: Number((_d = process.env.PROVIDER_CIRCUIT_BREAKER_ROLLING_BUCKETS) !== null && _d !== void 0 ? _d : 10),
+        volumeThreshold: Number((_e = process.env.PROVIDER_CIRCUIT_BREAKER_VOLUME_THRESHOLD) !== null && _e !== void 0 ? _e : 3),
+        errorThresholdPercentage: Number((_f = process.env.PROVIDER_CIRCUIT_BREAKER_ERROR_THRESHOLD_PERCENTAGE) !== null && _f !== void 0 ? _f : 50),
+        capacity: Number((_g = process.env.PROVIDER_CIRCUIT_BREAKER_CAPACITY) !== null && _g !== void 0 ? _g : 100),
+        enableSnapshots: false,
+    };
+}
+function setCircuitStateMetric(provider, operation, state) {
+    metrics_1.providerCircuitBreakerState.set({ provider: provider, operation: operation }, CIRCUIT_STATE_VALUES[state]);
+}
+function emitStateTransitionMetric(provider, operation, state) {
+    metrics_1.providerCircuitBreakerTransitionsTotal.inc({ provider: provider, operation: operation, state: state });
+    setCircuitStateMetric(provider, operation, state);
+}
+function toExecutionError(error) {
+    if (error instanceof Error) {
+        return error;
+    }
+    return new Error(typeof error === "string" ? error : "Provider call failed");
+}
+function normalizeResult(result) {
+    if (result.success) {
+        return result;
+    }
+    throw toExecutionError(result.error);
+}
+function getOrCreateCircuitBreaker(provider, operation) {
+    var _this = this;
+    var key = getCircuitKey(provider, operation);
+    var existing = circuitBreakers.get(key);
+    if (existing) {
+        return existing;
+    }
+    var breaker = new opossum_1.default(function (execute) { return __awaiter(_this, void 0, void 0, function () { var _a; return __generator(this, function (_b) {
+        switch (_b.label) {
+            case 0:
+                _a = normalizeResult;
+                return [4 /*yield*/, execute()];
+            case 1: return [2 /*return*/, _a.apply(void 0, [_b.sent()])];
+        }
+    }); }); }, getBreakerOptions(key));
+    breaker.fallback(function (_execute, fallback, error) { return __awaiter(_this, void 0, void 0, function () {
+        var _a;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    if (!fallback) {
+                        throw toExecutionError(error);
+                    }
+                    _a = normalizeResult;
+                    return [4 /*yield*/, fallback(error)];
+                case 1: return [2 /*return*/, _a.apply(void 0, [_b.sent()])];
+            }
+        });
+    }); });
+    breaker.on("open", function () {
+        emitStateTransitionMetric(provider, operation, "open");
+    });
+    breaker.on("halfOpen", function () {
+        emitStateTransitionMetric(provider, operation, "half_open");
+    });
+    breaker.on("close", function () {
+        emitStateTransitionMetric(provider, operation, "closed");
+    });
+    setCircuitStateMetric(provider, operation, "closed");
+    circuitBreakers.set(key, breaker);
+    return breaker;
+}
+function executeWithCircuitBreaker(options) {
+    return __awaiter(this, void 0, void 0, function () {
+        var breaker;
+        return __generator(this, function (_a) {
+            breaker = getOrCreateCircuitBreaker(options.provider, options.operation);
+            return [2 /*return*/, breaker.fire(options.execute, options.fallback)];
+        });
+    });
+}
+function isCircuitBreakerOpenError(error) {
+    return (error instanceof Error &&
+        "code" in error &&
+        error.code === "EOPENBREAKER");
+}
+function resetCircuitBreakers() {
+    for (var _i = 0, _a = circuitBreakers.values(); _i < _a.length; _i++) {
+        var breaker = _a[_i];
+        breaker.shutdown();
+    }
+    circuitBreakers.clear();
+}
+function getCircuitBreakerCount() {
+    return circuitBreakers.size;
+}

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -1,0 +1,107 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cacheHitRatio = exports.cacheMissesTotal = exports.cacheHitsTotal = exports.register = exports.activeConnections = exports.healthCheckResponseTimeSeconds = exports.providerCircuitBreakerState = exports.providerCircuitBreakerTransitionsTotal = exports.providerFailoverAlerts = exports.providerFailoverTotal = exports.providerResponseTimeSummary = exports.providerResponseTimeSeconds = exports.transactionErrorsTotal = exports.transactionTotal = exports.httpRequestDurationSeconds = exports.httpRequestsTotal = void 0;
+var prom_client_1 = require("prom-client");
+var register = new prom_client_1.Registry();
+exports.register = register;
+// Add default metrics (CPU, Memory, etc.)
+(0, prom_client_1.collectDefaultMetrics)({ register: register });
+// HTTP Metrics
+exports.httpRequestsTotal = new prom_client_1.Counter({
+    name: "http_requests_total",
+    help: "Total number of HTTP requests",
+    labelNames: ["method", "route", "status_code"],
+    registers: [register],
+});
+exports.httpRequestDurationSeconds = new prom_client_1.Histogram({
+    name: "http_request_duration_seconds",
+    help: "Duration of HTTP requests in seconds",
+    labelNames: ["method", "route", "status_code"],
+    buckets: [0.1, 0.3, 0.5, 0.7, 1, 3, 5, 7, 10], // standard buckets
+    registers: [register],
+});
+// Business Logic Metrics
+exports.transactionTotal = new prom_client_1.Counter({
+    name: "transaction_total",
+    help: "Total number of transactions processed",
+    labelNames: ["type", "provider", "status"], // type: payment/payout
+    registers: [register],
+});
+exports.transactionErrorsTotal = new prom_client_1.Counter({
+    name: "transaction_errors_total",
+    help: "Total number of transaction errors",
+    labelNames: ["type", "provider", "error_type"],
+    registers: [register],
+});
+exports.providerResponseTimeSeconds = new prom_client_1.Histogram({
+    name: "provider_response_time_seconds",
+    help: "Duration of provider operations in seconds",
+    labelNames: ["provider", "operation", "status"],
+    buckets: [0.1, 0.3, 0.5, 1, 3, 5, 10, 30],
+    registers: [register],
+});
+exports.providerResponseTimeSummary = new prom_client_1.Summary({
+    name: "provider_response_time_summary",
+    help: "Summary of provider operation durations in seconds",
+    labelNames: ["provider", "operation"],
+    percentiles: [0.5, 0.9, 0.95, 0.99],
+    registers: [register],
+});
+// Failover metrics
+exports.providerFailoverTotal = new prom_client_1.Counter({
+    name: "provider_failover_total",
+    help: "Total number of automatic provider failovers",
+    labelNames: ["type", "from_provider", "to_provider", "reason"],
+    registers: [register],
+});
+exports.providerFailoverAlerts = new prom_client_1.Counter({
+    name: "provider_failover_alerts_total",
+    help: "Number of failover alert notifications emitted",
+    labelNames: ["provider"],
+    registers: [register],
+});
+exports.providerCircuitBreakerTransitionsTotal = new prom_client_1.Counter({
+    name: "provider_circuit_breaker_transitions_total",
+    help: "Total number of provider circuit breaker state transitions",
+    labelNames: ["provider", "operation", "state"],
+    registers: [register],
+});
+exports.providerCircuitBreakerState = new prom_client_1.Gauge({
+    name: "provider_circuit_breaker_state",
+    help: "Current provider circuit breaker state (0=closed, 0.5=half_open, 1=open)",
+    labelNames: ["provider", "operation"],
+    registers: [register],
+});
+exports.healthCheckResponseTimeSeconds = new prom_client_1.Histogram({
+    name: "health_check_response_time_seconds",
+    help: "Duration of provider health checks in seconds",
+    labelNames: ["provider", "status"],
+    buckets: [0.05, 0.1, 0.3, 0.5, 1, 3, 5, 10],
+    registers: [register],
+});
+// Connection Metrics
+exports.activeConnections = new prom_client_1.Gauge({
+    name: "active_connections",
+    help: "Number of active HTTP connections",
+    registers: [register],
+});
+// Cache Metrics
+exports.cacheHitsTotal = new prom_client_1.Counter({
+    name: "cache_hits_total",
+    help: "Total number of cache hits",
+    labelNames: ["route"],
+    registers: [register],
+});
+exports.cacheMissesTotal = new prom_client_1.Counter({
+    name: "cache_misses_total",
+    help: "Total number of cache misses",
+    labelNames: ["route"],
+    registers: [register],
+});
+// A gauge that mirrors the hit ratio for easier scraping; updated on each hit/miss
+exports.cacheHitRatio = new prom_client_1.Gauge({
+    name: "cache_hit_ratio",
+    help: "Cache hit ratio (hits / (hits+misses))",
+    labelNames: ["route"],
+    registers: [register],
+});

--- a/src/utils/readOnlyDetector.js
+++ b/src/utils/readOnlyDetector.js
@@ -1,0 +1,53 @@
+"use strict";
+/**
+ * Detects whether a SQL query is read-only (SELECT) or write-capable (INSERT/UPDATE/DELETE).
+ * This enables automatic routing to read replicas for SELECT queries.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isReadOnlyQuery = isReadOnlyQuery;
+exports.getQueryCommand = getQueryCommand;
+/**
+ * Check if a SQL query is a read-only SELECT statement.
+ * Returns true for pure SELECT queries, false for write operations (INSERT/UPDATE/DELETE) or mixed.
+ *
+ * @param query - The SQL query string
+ * @returns true if the query is a read-only SELECT, false otherwise
+ */
+function isReadOnlyQuery(query) {
+    if (!query || typeof query !== 'string') {
+        return false;
+    }
+    // Trim and normalize the query
+    var normalized = query.trim().toUpperCase();
+    // If it doesn't start with SELECT or WITH, it's not read-only
+    if (!normalized.startsWith('SELECT') && !normalized.startsWith('WITH')) {
+        return false;
+    }
+    // Check for write operations in the query (case-insensitive)
+    // This catches queries that might have INSERT/UPDATE/DELETE in subqueries or CTEs
+    var writePattern = /\b(INSERT|UPDATE|DELETE|CREATE|DROP|ALTER|TRUNCATE)\b/i;
+    if (writePattern.test(query)) {
+        return false;
+    }
+    // Check for transaction control statements
+    var transactionPattern = /\b(BEGIN|COMMIT|ROLLBACK|START\s+TRANSACTION)\b/i;
+    if (transactionPattern.test(query)) {
+        return false;
+    }
+    // It's safe to route to replica
+    return true;
+}
+/**
+ * Extracts the main SQL command from a query string.
+ * Useful for logging and debugging purposes.
+ *
+ * @param query - The SQL query string
+ * @returns The main command (SELECT, INSERT, UPDATE, etc.)
+ */
+function getQueryCommand(query) {
+    if (!query || typeof query !== 'string') {
+        return 'UNKNOWN';
+    }
+    var match = query.trim().match(/^(\w+)/i);
+    return match ? match[1].toUpperCase() : 'UNKNOWN';
+}


### PR DESCRIPTION
PR Title: feat: Add provider balance API endpoint for dashboard

Summary:
Implements #503 by exposing provider balances (MTN, Airtel, Orange) via a new admin endpoint with Redis caching for performance.

Changes:
- Added GET /api/admin/providers/balances (admin-only)
- Implemented getAllProviderBalances() in MobileMoneyService
- Added Redis caching (TTL configurable, default 60s)
- Standardized response format with status + timestamps
- Fixed TypeScript type compatibility issues

Result:
Enables dashboard to display near real-time provider balances. Closes #503