### PR TITLE
feat: add internal provider status page (#559)

### DIFF
--- a/migrations/20260424_create_provider_api_calls.sql
+++ b/migrations/20260424_create_provider_api_calls.sql
@@ -1,0 +1,32 @@
+-- Track last 100 API calls per provider for the internal status page
+CREATE TABLE IF NOT EXISTS provider_api_calls (
+  id          BIGSERIAL PRIMARY KEY,
+  provider    VARCHAR(20)  NOT NULL CHECK (provider IN ('mtn', 'airtel', 'orange')),
+  success     BOOLEAN      NOT NULL,
+  duration_ms INTEGER,
+  error_code  VARCHAR(100),
+  called_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pac_provider_called_at
+  ON provider_api_calls (provider, called_at DESC);
+
+-- Keep only the last 100 rows per provider automatically
+CREATE OR REPLACE FUNCTION trim_provider_api_calls()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  DELETE FROM provider_api_calls
+  WHERE provider = NEW.provider
+    AND id NOT IN (
+      SELECT id FROM provider_api_calls
+      WHERE provider = NEW.provider
+      ORDER BY called_at DESC
+      LIMIT 100
+    );
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER trg_trim_provider_api_calls
+AFTER INSERT ON provider_api_calls
+FOR EACH ROW EXECUTE FUNCTION trim_provider_api_calls();

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ import { createSep10Router } from "./stellar/sep10";
 import tomlRouter from "./routes/toml";
 import feesRouter from "./routes/fees";
 import feeStrategiesRouter from "./routes/feeStrategies";
+import providerStatusRouter from "./routes/providerStatus";
 
 // 1. Import Sentry Middleware
 import { initSentry, sentryBreadcrumbMiddleware } from "./middleware/sentry";
@@ -366,6 +367,7 @@ app.use("/api/fee-strategies", feeStrategiesRouter);
 app.use("/api/gdpr", privacyRoutes);
 app.use("/api/developer", developerDashboardRoutes);
 app.use("/api/admin", requireAuth, adminRoutes);
+app.use("/api/admin/providers/status", requireAuth, providerStatusRouter);
 app.use("/api/admin/kyc-upgrades", requireAuth, kycTierUpgradeRoutes);
 app.use("/sep10", createSep10Router());
 app.use("/sep31", sep31Router);

--- a/src/routes/providerStatus.ts
+++ b/src/routes/providerStatus.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from "express";
+import { getProvidersStatus } from "../services/providerStatusService";
+
+const router = Router();
+
+/**
+ * GET /api/admin/providers/status
+ *
+ * Returns Green/Yellow/Red status for each mobile money provider
+ * based on the last 100 recorded API calls.
+ *
+ * Green  : success rate >= 95%
+ * Yellow : success rate >= 80%
+ * Red    : success rate <  80% (or no data)
+ */
+router.get("/", async (_req: Request, res: Response) => {
+  try {
+    const result = await getProvidersStatus();
+    res.json(result);
+  } catch (err) {
+    console.error("[provider-status] Failed to fetch provider status", err);
+    res.status(500).json({ error: "Failed to fetch provider status" });
+  }
+});
+
+export default router;

--- a/src/services/providerStatusService.ts
+++ b/src/services/providerStatusService.ts
@@ -1,0 +1,96 @@
+import { pool } from "../config/database";
+
+export type ProviderName = "mtn" | "airtel" | "orange";
+export type StatusColor = "green" | "yellow" | "red";
+
+export interface ProviderStatusSummary {
+  provider: ProviderName;
+  status: StatusColor;
+  successRate: number;   // 0–1
+  totalCalls: number;
+  avgDurationMs: number | null;
+  lastCalledAt: string | null;
+}
+
+export interface ProvidersStatusResult {
+  providers: ProviderStatusSummary[];
+  generatedAt: string;
+}
+
+// Green  : success rate >= 95%
+// Yellow : success rate >= 80%
+// Red    : success rate <  80%
+function toStatusColor(successRate: number): StatusColor {
+  if (successRate >= 0.95) return "green";
+  if (successRate >= 0.80) return "yellow";
+  return "red";
+}
+
+export async function getProvidersStatus(): Promise<ProvidersStatusResult> {
+  const { rows } = await pool.query<{
+    provider: ProviderName;
+    total: string;
+    successes: string;
+    avg_duration_ms: string | null;
+    last_called_at: Date | null;
+  }>(`
+    SELECT
+      provider,
+      COUNT(*)                          AS total,
+      COUNT(*) FILTER (WHERE success)   AS successes,
+      AVG(duration_ms)                  AS avg_duration_ms,
+      MAX(called_at)                    AS last_called_at
+    FROM provider_api_calls
+    GROUP BY provider
+  `);
+
+  const PROVIDERS: ProviderName[] = ["mtn", "airtel", "orange"];
+
+  const byProvider = new Map(rows.map((r) => [r.provider, r]));
+
+  const providers: ProviderStatusSummary[] = PROVIDERS.map((name) => {
+    const row = byProvider.get(name);
+    if (!row || Number(row.total) === 0) {
+      return {
+        provider: name,
+        status: "red" as StatusColor,
+        successRate: 0,
+        totalCalls: 0,
+        avgDurationMs: null,
+        lastCalledAt: null,
+      };
+    }
+
+    const total = Number(row.total);
+    const successes = Number(row.successes);
+    const successRate = successes / total;
+
+    return {
+      provider: name,
+      status: toStatusColor(successRate),
+      successRate: Math.round(successRate * 1000) / 1000,
+      totalCalls: total,
+      avgDurationMs: row.avg_duration_ms != null ? Math.round(Number(row.avg_duration_ms)) : null,
+      lastCalledAt: row.last_called_at ? row.last_called_at.toISOString() : null,
+    };
+  });
+
+  return { providers, generatedAt: new Date().toISOString() };
+}
+
+/**
+ * Record a single API call outcome for a provider.
+ * Call this from mobile money service wrappers after each provider interaction.
+ */
+export async function recordProviderApiCall(
+  provider: ProviderName,
+  success: boolean,
+  durationMs?: number,
+  errorCode?: string,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO provider_api_calls (provider, success, duration_ms, error_code)
+     VALUES ($1, $2, $3, $4)`,
+    [provider, success, durationMs ?? null, errorCode ?? null],
+  );
+}


### PR DESCRIPTION
closes #559 

feat: internal provider status page (#559)                                                    
                                                                                                
  Adds GET /api/admin/providers/status — an auth-protected endpoint that shows Green/Yellow/Red 
  uptime status for MTN, Airtel, and Orange based on their last 100 API calls.                  
                                                                                                
  Status thresholds                                                                             
                                                                                                
  ┌───────┬──────────────┐                                                                      
  │ Color    │ Success rate │                                                                   
  ├───────────┼──────────────┤                                                                  
  │ 🟢 Green  │ ≥ 95%        │                                                                  
  │ 🟡 Yellow │ ≥ 80%            │                                                              
  │ 🔴 Red    │ < 80% or no data │                                                              
  └───────────┴──────────────────┘                                                              
                                                                                                
  Files changed                                                                                 
                                                                                                
  - migrations/20260424_create_provider_api_calls.sql — new table, auto-trims to last 100 rows  
  per provider via DB trigger                                                                   
  - src/services/providerStatusService.ts — aggregates call history, computes status color      
  - src/routes/providerStatus.ts — route handler                                                
  - src/index.ts — registers route behind requireAuth                                           
                                                                                                
  To wire up data collection, call record ProviderApiCall (provider, success, durationMs?) from   
  Mobile Money Service after each provider interaction.                                           
                                                                                                
  