### PR TITLE
feat: implement cross-chain asset monitoring (#589)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -718,3 +718,13 @@ APQ_TTL_SECONDS=86400
 # JWT_SECRET is required for authenticating WebSocket connections.
 # Clients must pass: connectionParams: { authToken: "<jwt>" }
 JWT_SECRET=replace-with-a-secure-jwt-secret
+
+# ---------------------------------------------------------------------------
+# Cross-Chain Asset Monitoring
+# ---------------------------------------------------------------------------
+# Cron schedule for the cross-chain balance snapshot job (default: every 5 minutes)
+CROSS_CHAIN_MONITOR_CRON=*/5 * * * *
+# Percentage drop in balance that triggers an anomaly warning (default: 20)
+CROSS_CHAIN_DROP_THRESHOLD_PCT=20
+# Comma-separated Stellar public keys to monitor (in addition to HOT_WALLET_PUBLIC_KEYS)
+CROSS_CHAIN_STELLAR_ADDRESSES=

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,7 @@ import { createSep10Router } from "./stellar/sep10";
 import tomlRouter from "./routes/toml";
 import feesRouter from "./routes/fees";
 import feeStrategiesRouter from "./routes/feeStrategies";
+import crossChainRouter from "./routes/crossChain";
 
 // 1. Import Sentry Middleware
 import { initSentry, sentryBreadcrumbMiddleware } from "./middleware/sentry";
@@ -361,6 +362,7 @@ app.use("/api/users", userRoutes);
 app.use("/api/kyc", createKYCRoutes(pool));
 app.use("/api/fees", feesRouter);
 app.use("/api/fee-strategies", feeStrategiesRouter);
+app.use("/api/cross-chain", crossChainRouter);
 
 // GDPR
 app.use("/api/gdpr", privacyRoutes);

--- a/src/jobs/crossChainMonitorJob.ts
+++ b/src/jobs/crossChainMonitorJob.ts
@@ -1,0 +1,8 @@
+import { CrossChainMonitorService } from "../services/crossChainMonitorService";
+
+export async function runCrossChainMonitorJob(): Promise<void> {
+  const snapshots = await CrossChainMonitorService.getInstance().snapshot();
+  console.log(
+    `[cross-chain-monitor] Captured ${snapshots.length} asset snapshot(s)`,
+  );
+}

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -13,6 +13,7 @@ import { runProviderBalanceAlertJob } from "./balances";
 import { runProviderHealthCheckJob } from "./providerHealthCheck";
 import { runKycTierUpgradeJob } from "./kycTierUpgradeJob";
 import { runLiquidityRebalanceJob } from "./liquidityRebalanceJob";
+import { runCrossChainMonitorJob } from "./crossChainMonitorJob";
 
 interface JobConfig {
   name: string;
@@ -86,6 +87,12 @@ const JOBS: JobConfig[] = [
     // Every 15 minutes - auto-transfers between providers when one runs low
     schedule: process.env.LIQUIDITY_REBALANCE_CRON || "*/15 * * * *",
     handler: runLiquidityRebalanceJob,
+  },
+  {
+    name: "cross-chain-monitor",
+    // Every 5 minutes - tracks asset balances across Stellar and mobile money providers
+    schedule: process.env.CROSS_CHAIN_MONITOR_CRON || "*/5 * * * *",
+    handler: runCrossChainMonitorJob,
   },
 ];
 

--- a/src/routes/crossChain.ts
+++ b/src/routes/crossChain.ts
@@ -1,0 +1,16 @@
+import { Router, Response } from "express";
+import { requireAuth, AuthRequest } from "../middleware/auth";
+import { CrossChainMonitorService } from "../services/crossChainMonitorService";
+
+const router = Router();
+
+router.get(
+  "/balances",
+  requireAuth,
+  (_req: AuthRequest, res: Response) => {
+    const snapshots = CrossChainMonitorService.getInstance().getLastSnapshot();
+    res.json(snapshots);
+  },
+);
+
+export default router;

--- a/src/services/crossChainMonitorService.ts
+++ b/src/services/crossChainMonitorService.ts
@@ -1,0 +1,163 @@
+import { getStellarServer } from "../config/stellar";
+import { MobileMoneyProvider } from "../config/providers";
+import {
+  crossChainBalanceGauge,
+  crossChainAnomalyTotal,
+} from "../utils/metrics";
+
+export interface ChainAssetSnapshot {
+  chain: "stellar" | "mtn" | "airtel" | "orange";
+  asset: string;
+  address: string;
+  balance: string;
+  capturedAt: Date;
+}
+
+// TODO: Wire real provider balance APIs when available
+async function getProviderBalance(
+  provider: MobileMoneyProvider,
+  currency: string,
+): Promise<string> {
+  console.log(
+    `[cross-chain-monitor] TODO: fetch real balance for ${provider}/${currency}`,
+  );
+  return "0";
+}
+
+function getStellarAddresses(): string[] {
+  const extra = process.env.CROSS_CHAIN_STELLAR_ADDRESSES || "";
+  const hot = process.env.HOT_WALLET_PUBLIC_KEYS || "";
+  return [...extra.split(","), ...hot.split(",")]
+    .map((k) => k.trim())
+    .filter(Boolean);
+}
+
+function getDropThreshold(): number {
+  const val = parseFloat(
+    process.env.CROSS_CHAIN_DROP_THRESHOLD_PCT || "20",
+  );
+  return isNaN(val) ? 20 : val;
+}
+
+export class CrossChainMonitorService {
+  private static instance: CrossChainMonitorService;
+  private lastSnapshot: ChainAssetSnapshot[] = [];
+
+  static getInstance(): CrossChainMonitorService {
+    if (!CrossChainMonitorService.instance) {
+      CrossChainMonitorService.instance = new CrossChainMonitorService();
+    }
+    return CrossChainMonitorService.instance;
+  }
+
+  async snapshot(): Promise<ChainAssetSnapshot[]> {
+    const capturedAt = new Date();
+    const results: ChainAssetSnapshot[] = [];
+
+    // --- Stellar balances ---
+    const server = getStellarServer();
+    const addresses = getStellarAddresses();
+
+    for (const address of addresses) {
+      try {
+        const account = await server.loadAccount(address);
+        for (const bal of account.balances) {
+          const asset =
+            bal.asset_type === "native"
+              ? "XLM"
+              : // cast: non-native balances always have asset_code
+                (bal as { asset_code: string }).asset_code;
+          results.push({
+            chain: "stellar",
+            asset,
+            address,
+            balance: bal.balance,
+            capturedAt,
+          });
+        }
+      } catch (err) {
+        console.error(
+          `[cross-chain-monitor] Failed to load Stellar account ${address}:`,
+          err,
+        );
+      }
+    }
+
+    // --- Mobile money provider balances ---
+    const providerCurrencyMap: Array<{
+      provider: MobileMoneyProvider;
+      chain: ChainAssetSnapshot["chain"];
+      currency: string;
+    }> = [
+      { provider: MobileMoneyProvider.MTN, chain: "mtn", currency: "XAF" },
+      { provider: MobileMoneyProvider.AIRTEL, chain: "airtel", currency: "XAF" },
+      { provider: MobileMoneyProvider.ORANGE, chain: "orange", currency: "XAF" },
+    ];
+
+    for (const { provider, chain, currency } of providerCurrencyMap) {
+      const balance = await getProviderBalance(provider, currency);
+      results.push({
+        chain,
+        asset: currency,
+        address: provider,
+        balance,
+        capturedAt,
+      });
+    }
+
+    // --- Update Prometheus gauges & detect anomalies ---
+    const threshold = getDropThreshold();
+
+    for (const snap of results) {
+      crossChainBalanceGauge.set(
+        { chain: snap.chain, asset: snap.asset, address: snap.address },
+        parseFloat(snap.balance),
+      );
+
+      const prev = this.lastSnapshot.find(
+        (s) =>
+          s.chain === snap.chain &&
+          s.asset === snap.asset &&
+          s.address === snap.address,
+      );
+
+      if (prev) {
+        const prevBal = parseFloat(prev.balance);
+        const curBal = parseFloat(snap.balance);
+        if (prevBal > 0) {
+          const dropPct = ((prevBal - curBal) / prevBal) * 100;
+          if (dropPct > threshold) {
+            const reason = "balance_drop";
+            crossChainAnomalyTotal.inc({
+              chain: snap.chain,
+              asset: snap.asset,
+              reason,
+            });
+            console.warn(
+              JSON.stringify({
+                level: "WARN",
+                timestamp: capturedAt.toISOString(),
+                message: "Cross-chain balance anomaly detected",
+                chain: snap.chain,
+                asset: snap.asset,
+                address: snap.address,
+                previousBalance: prev.balance,
+                currentBalance: snap.balance,
+                dropPct: dropPct.toFixed(2),
+                thresholdPct: threshold,
+                reason,
+              }),
+            );
+          }
+        }
+      }
+    }
+
+    this.lastSnapshot = results;
+    return results;
+  }
+
+  getLastSnapshot(): ChainAssetSnapshot[] {
+    return this.lastSnapshot;
+  }
+}

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -127,3 +127,18 @@ export const cacheHitRatio = new Gauge({
   labelNames: ["route"],
   registers: [register],
 });
+
+// Cross-Chain Asset Monitoring Metrics
+export const crossChainBalanceGauge = new Gauge({
+  name: "cross_chain_balance",
+  help: "Current asset balance per chain/address",
+  labelNames: ["chain", "asset", "address"],
+  registers: [register],
+});
+
+export const crossChainAnomalyTotal = new Counter({
+  name: "cross_chain_anomaly_total",
+  help: "Number of cross-chain balance anomalies detected",
+  labelNames: ["chain", "asset", "reason"],
+  registers: [register],
+});

--- a/tests/jobs/crossChainMonitorJob.test.ts
+++ b/tests/jobs/crossChainMonitorJob.test.ts
@@ -1,0 +1,67 @@
+import { runCrossChainMonitorJob } from "../../src/jobs/crossChainMonitorJob";
+import { CrossChainMonitorService } from "../../src/services/crossChainMonitorService";
+
+jest.mock("../../src/services/crossChainMonitorService");
+jest.mock("../../src/config/stellar");
+jest.mock("../../src/utils/metrics", () => ({
+  crossChainBalanceGauge: { set: jest.fn() },
+  crossChainAnomalyTotal: { inc: jest.fn() },
+}));
+
+const mockSnapshot = jest.fn();
+jest.mocked(CrossChainMonitorService.getInstance).mockReturnValue({
+  snapshot: mockSnapshot,
+  getLastSnapshot: jest.fn().mockReturnValue([]),
+} as any);
+
+describe("runCrossChainMonitorJob", () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("calls CrossChainMonitorService.getInstance().snapshot()", async () => {
+    mockSnapshot.mockResolvedValue([]);
+    await runCrossChainMonitorJob();
+    expect(mockSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs the number of snapshots captured", async () => {
+    const fakeSnapshots = [
+      { chain: "stellar", asset: "XLM", address: "GABC", balance: "10", capturedAt: new Date() },
+      { chain: "mtn", asset: "XAF", address: "mtn", balance: "0", capturedAt: new Date() },
+    ];
+    mockSnapshot.mockResolvedValue(fakeSnapshots);
+
+    await runCrossChainMonitorJob();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "[cross-chain-monitor] Captured 2 asset snapshot(s)",
+    );
+  });
+
+  it("logs zero snapshots when service returns empty array", async () => {
+    mockSnapshot.mockResolvedValue([]);
+
+    await runCrossChainMonitorJob();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "[cross-chain-monitor] Captured 0 asset snapshot(s)",
+    );
+  });
+
+  it("propagates errors thrown by snapshot()", async () => {
+    mockSnapshot.mockRejectedValue(new Error("Stellar network error"));
+
+    await expect(runCrossChainMonitorJob()).rejects.toThrow("Stellar network error");
+  });
+});

--- a/tests/routes/crossChain.test.ts
+++ b/tests/routes/crossChain.test.ts
@@ -1,0 +1,129 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import { CrossChainMonitorService, ChainAssetSnapshot } from "../../src/services/crossChainMonitorService";
+
+jest.mock("../../src/services/crossChainMonitorService");
+jest.mock("../../src/config/stellar");
+jest.mock("../../src/utils/metrics", () => ({
+  crossChainBalanceGauge: { set: jest.fn() },
+  crossChainAnomalyTotal: { inc: jest.fn() },
+}));
+
+// Mock auth middleware before importing the router to avoid envalid env validation
+const mockRequireAuth = jest.fn();
+jest.mock("../../src/middleware/auth", () => ({
+  requireAuth: (req: Request, res: Response, next: NextFunction) =>
+    mockRequireAuth(req, res, next),
+}));
+
+// Import router after mocks are set up
+import crossChainRouter from "../../src/routes/crossChain";
+
+const mockGetLastSnapshot = jest.fn();
+jest.mocked(CrossChainMonitorService.getInstance).mockReturnValue({
+  getLastSnapshot: mockGetLastSnapshot,
+  snapshot: jest.fn().mockResolvedValue([]),
+} as any);
+
+function buildApp(authenticated: boolean) {
+  const app = express();
+  app.use(express.json());
+
+  // Configure mockRequireAuth behaviour for this test
+  mockRequireAuth.mockImplementation(
+    (req: Request, res: Response, next: NextFunction) => {
+      if (authenticated) {
+        (req as any).user = { id: "user-1", role: "user" };
+        return next();
+      }
+      res.status(401).json({ error: "Unauthorized" });
+    },
+  );
+
+  app.use("/api/cross-chain", crossChainRouter);
+  return app;
+}
+
+describe("GET /api/cross-chain/balances", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const app = buildApp(false);
+    const res = await request(app).get("/api/cross-chain/balances");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with empty array when no snapshots exist", async () => {
+    mockGetLastSnapshot.mockReturnValue([]);
+    const app = buildApp(true);
+
+    const res = await request(app).get("/api/cross-chain/balances");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("returns the last snapshot from CrossChainMonitorService", async () => {
+    const snapshots: ChainAssetSnapshot[] = [
+      {
+        chain: "stellar",
+        asset: "XLM",
+        address: "GABC123",
+        balance: "100.0000000",
+        capturedAt: new Date("2026-04-24T12:00:00.000Z"),
+      },
+      {
+        chain: "mtn",
+        asset: "XAF",
+        address: "mtn",
+        balance: "0",
+        capturedAt: new Date("2026-04-24T12:00:00.000Z"),
+      },
+    ];
+    mockGetLastSnapshot.mockReturnValue(snapshots);
+    const app = buildApp(true);
+
+    const res = await request(app).get("/api/cross-chain/balances");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].chain).toBe("stellar");
+    expect(res.body[0].asset).toBe("XLM");
+    expect(res.body[0].address).toBe("GABC123");
+    expect(res.body[0].balance).toBe("100.0000000");
+    expect(res.body[1].chain).toBe("mtn");
+  });
+
+  it("calls CrossChainMonitorService.getInstance().getLastSnapshot()", async () => {
+    mockGetLastSnapshot.mockReturnValue([]);
+    const app = buildApp(true);
+
+    await request(app).get("/api/cross-chain/balances");
+
+    expect(CrossChainMonitorService.getInstance).toHaveBeenCalled();
+    expect(mockGetLastSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns all four chains when all are present in snapshot", async () => {
+    const snapshots: ChainAssetSnapshot[] = [
+      { chain: "stellar", asset: "XLM", address: "GABC", balance: "10", capturedAt: new Date() },
+      { chain: "mtn", asset: "XAF", address: "mtn", balance: "0", capturedAt: new Date() },
+      { chain: "airtel", asset: "XAF", address: "airtel", balance: "0", capturedAt: new Date() },
+      { chain: "orange", asset: "XAF", address: "orange", balance: "0", capturedAt: new Date() },
+    ];
+    mockGetLastSnapshot.mockReturnValue(snapshots);
+    const app = buildApp(true);
+
+    const res = await request(app).get("/api/cross-chain/balances");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(4);
+    const chains = res.body.map((s: ChainAssetSnapshot) => s.chain);
+    expect(chains).toContain("stellar");
+    expect(chains).toContain("mtn");
+    expect(chains).toContain("airtel");
+    expect(chains).toContain("orange");
+  });
+});

--- a/tests/services/crossChainMonitorService.test.ts
+++ b/tests/services/crossChainMonitorService.test.ts
@@ -1,0 +1,329 @@
+import { CrossChainMonitorService, ChainAssetSnapshot } from "../../src/services/crossChainMonitorService";
+import * as stellarConfig from "../../src/config/stellar";
+import * as metrics from "../../src/utils/metrics";
+
+jest.mock("../../src/config/stellar");
+jest.mock("../../src/utils/metrics", () => ({
+  crossChainBalanceGauge: { set: jest.fn() },
+  crossChainAnomalyTotal: { inc: jest.fn() },
+}));
+
+const mockLoadAccount = jest.fn();
+jest.mocked(stellarConfig.getStellarServer).mockReturnValue({
+  loadAccount: mockLoadAccount,
+} as any);
+
+describe("CrossChainMonitorService", () => {
+  let service: CrossChainMonitorService;
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset singleton
+    (CrossChainMonitorService as any).instance = undefined;
+    service = CrossChainMonitorService.getInstance();
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+    delete process.env.CROSS_CHAIN_STELLAR_ADDRESSES;
+    delete process.env.HOT_WALLET_PUBLIC_KEYS;
+    delete process.env.CROSS_CHAIN_DROP_THRESHOLD_PCT;
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe("getInstance", () => {
+    it("returns the same instance on repeated calls", () => {
+      const a = CrossChainMonitorService.getInstance();
+      const b = CrossChainMonitorService.getInstance();
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("getLastSnapshot", () => {
+    it("returns empty array before any snapshot", () => {
+      expect(service.getLastSnapshot()).toEqual([]);
+    });
+  });
+
+  describe("snapshot - mobile money providers", () => {
+    it("includes MTN, Airtel, and Orange balances with zero balance stubs", async () => {
+      const snapshots = await service.snapshot();
+
+      const chains = snapshots.map((s) => s.chain);
+      expect(chains).toContain("mtn");
+      expect(chains).toContain("airtel");
+      expect(chains).toContain("orange");
+    });
+
+    it("sets balance to '0' for provider stubs", async () => {
+      const snapshots = await service.snapshot();
+      const providerSnaps = snapshots.filter((s) =>
+        ["mtn", "airtel", "orange"].includes(s.chain),
+      );
+      for (const snap of providerSnaps) {
+        expect(snap.balance).toBe("0");
+        expect(snap.asset).toBe("XAF");
+      }
+    });
+
+    it("sets capturedAt to a recent date", async () => {
+      const before = new Date();
+      const snapshots = await service.snapshot();
+      const after = new Date();
+      for (const snap of snapshots) {
+        expect(snap.capturedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+        expect(snap.capturedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+      }
+    });
+  });
+
+  describe("snapshot - Stellar balances", () => {
+    it("fetches XLM and custom asset balances for configured addresses", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC123";
+      mockLoadAccount.mockResolvedValue({
+        balances: [
+          { asset_type: "native", balance: "100.5000000" },
+          { asset_type: "credit_alphanum4", asset_code: "USDC", balance: "50.0000000" },
+        ],
+      });
+
+      const snapshots = await service.snapshot();
+      const stellarSnaps = snapshots.filter((s) => s.chain === "stellar");
+
+      expect(stellarSnaps).toHaveLength(2);
+      expect(stellarSnaps.find((s) => s.asset === "XLM")).toBeDefined();
+      expect(stellarSnaps.find((s) => s.asset === "USDC")).toBeDefined();
+      expect(stellarSnaps[0].address).toBe("GABC123");
+    });
+
+    it("reads addresses from HOT_WALLET_PUBLIC_KEYS env var", async () => {
+      process.env.HOT_WALLET_PUBLIC_KEYS = "GHOT1,GHOT2";
+      mockLoadAccount.mockResolvedValue({
+        balances: [{ asset_type: "native", balance: "10.0000000" }],
+      });
+
+      const snapshots = await service.snapshot();
+      const stellarSnaps = snapshots.filter((s) => s.chain === "stellar");
+
+      expect(stellarSnaps).toHaveLength(2);
+      expect(stellarSnaps.map((s) => s.address)).toEqual(
+        expect.arrayContaining(["GHOT1", "GHOT2"]),
+      );
+    });
+
+    it("merges CROSS_CHAIN_STELLAR_ADDRESSES and HOT_WALLET_PUBLIC_KEYS", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GEXTRA";
+      process.env.HOT_WALLET_PUBLIC_KEYS = "GHOT";
+      mockLoadAccount.mockResolvedValue({
+        balances: [{ asset_type: "native", balance: "1.0000000" }],
+      });
+
+      const snapshots = await service.snapshot();
+      const addresses = snapshots
+        .filter((s) => s.chain === "stellar")
+        .map((s) => s.address);
+
+      expect(addresses).toContain("GEXTRA");
+      expect(addresses).toContain("GHOT");
+    });
+
+    it("skips failed Stellar account loads and logs error", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GBAD";
+      mockLoadAccount.mockRejectedValue(new Error("Account not found"));
+
+      const snapshots = await service.snapshot();
+      const stellarSnaps = snapshots.filter((s) => s.chain === "stellar");
+
+      expect(stellarSnaps).toHaveLength(0);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[cross-chain-monitor]"),
+        expect.any(Error),
+      );
+    });
+
+    it("returns only provider snapshots when no Stellar addresses configured", async () => {
+      const snapshots = await service.snapshot();
+      const stellarSnaps = snapshots.filter((s) => s.chain === "stellar");
+      expect(stellarSnaps).toHaveLength(0);
+    });
+  });
+
+  describe("snapshot - Prometheus metrics", () => {
+    it("calls crossChainBalanceGauge.set for each snapshot", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC";
+      mockLoadAccount.mockResolvedValue({
+        balances: [{ asset_type: "native", balance: "42.0000000" }],
+      });
+
+      const snapshots = await service.snapshot();
+
+      expect(metrics.crossChainBalanceGauge.set).toHaveBeenCalledTimes(
+        snapshots.length,
+      );
+      expect(metrics.crossChainBalanceGauge.set).toHaveBeenCalledWith(
+        { chain: "stellar", asset: "XLM", address: "GABC" },
+        42,
+      );
+    });
+  });
+
+  describe("snapshot - anomaly detection", () => {
+    it("increments anomaly counter when balance drops beyond threshold", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC";
+      process.env.CROSS_CHAIN_DROP_THRESHOLD_PCT = "20";
+
+      // First snapshot: balance 100
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "100.0000000" }],
+      });
+      await service.snapshot();
+
+      // Second snapshot: balance 70 (30% drop > 20% threshold)
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "70.0000000" }],
+      });
+      await service.snapshot();
+
+      expect(metrics.crossChainAnomalyTotal.inc).toHaveBeenCalledWith({
+        chain: "stellar",
+        asset: "XLM",
+        reason: "balance_drop",
+      });
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Cross-chain balance anomaly detected"),
+      );
+    });
+
+    it("does not flag anomaly when drop is within threshold", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC";
+      process.env.CROSS_CHAIN_DROP_THRESHOLD_PCT = "20";
+
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "100.0000000" }],
+      });
+      await service.snapshot();
+
+      // 10% drop — below 20% threshold
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "90.0000000" }],
+      });
+      await service.snapshot();
+
+      expect(metrics.crossChainAnomalyTotal.inc).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not flag anomaly on first snapshot (no previous data)", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC";
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "100.0000000" }],
+      });
+
+      await service.snapshot();
+
+      expect(metrics.crossChainAnomalyTotal.inc).not.toHaveBeenCalled();
+    });
+
+    it("does not flag anomaly when previous balance was zero", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC";
+
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "0.0000000" }],
+      });
+      await service.snapshot();
+
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "0.0000000" }],
+      });
+      await service.snapshot();
+
+      expect(metrics.crossChainAnomalyTotal.inc).not.toHaveBeenCalled();
+    });
+
+    it("uses default threshold of 20% when env var is not set", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC";
+
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "100.0000000" }],
+      });
+      await service.snapshot();
+
+      // 19% drop — should NOT trigger with default 20% threshold
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "81.0000000" }],
+      });
+      await service.snapshot();
+
+      expect(metrics.crossChainAnomalyTotal.inc).not.toHaveBeenCalled();
+    });
+
+    it("uses custom threshold from CROSS_CHAIN_DROP_THRESHOLD_PCT", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC";
+      process.env.CROSS_CHAIN_DROP_THRESHOLD_PCT = "10";
+
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "100.0000000" }],
+      });
+      await service.snapshot();
+
+      // 15% drop — triggers with 10% threshold
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "85.0000000" }],
+      });
+      await service.snapshot();
+
+      expect(metrics.crossChainAnomalyTotal.inc).toHaveBeenCalledWith({
+        chain: "stellar",
+        asset: "XLM",
+        reason: "balance_drop",
+      });
+    });
+
+    it("falls back to 20% threshold when CROSS_CHAIN_DROP_THRESHOLD_PCT is invalid", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC";
+      process.env.CROSS_CHAIN_DROP_THRESHOLD_PCT = "not-a-number";
+
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "100.0000000" }],
+      });
+      await service.snapshot();
+
+      // 19% drop — should NOT trigger with fallback 20% threshold
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: "native", balance: "81.0000000" }],
+      });
+      await service.snapshot();
+
+      expect(metrics.crossChainAnomalyTotal.inc).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("snapshot - state persistence", () => {
+    it("updates getLastSnapshot after each call", async () => {
+      process.env.CROSS_CHAIN_STELLAR_ADDRESSES = "GABC";
+      mockLoadAccount.mockResolvedValue({
+        balances: [{ asset_type: "native", balance: "5.0000000" }],
+      });
+
+      expect(service.getLastSnapshot()).toHaveLength(0);
+      const snapshots = await service.snapshot();
+      expect(service.getLastSnapshot()).toEqual(snapshots);
+    });
+
+    it("returns snapshot data with correct shape", async () => {
+      const snapshots = await service.snapshot();
+      for (const snap of snapshots) {
+        expect(snap).toHaveProperty("chain");
+        expect(snap).toHaveProperty("asset");
+        expect(snap).toHaveProperty("address");
+        expect(snap).toHaveProperty("balance");
+        expect(snap).toHaveProperty("capturedAt");
+        expect(snap.capturedAt).toBeInstanceOf(Date);
+      }
+    });
+  });
+});


### PR DESCRIPTION
close #589 

- Add CrossChainMonitorService with snapshot(), anomaly detection, and in-memory caching
- Track Stellar (XLM + custom assets) and mobile money provider (MTN, Airtel, Orange) balances
- Detect balance drops > CROSS_CHAIN_DROP_THRESHOLD_PCT (default 20%) with structured WARN logs
- Add Prometheus metrics: cross_chain_balance gauge and cross_chain_anomaly_total counter
- Register cross-chain-monitor cron job in scheduler (every 5 min via CROSS_CHAIN_MONITOR_CRON)
- Add GET /api/cross-chain/balances endpoint protected by requireAuth
- Append env vars to .env.example

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement


## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes

 Implements cross-chain asset monitoring to track balances across Stellar and mobile money providers (MTN, Airtel, Orange) with anomaly detection and    
  alerting.                                                                                                                                               
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  ### New Files                                                                                                                                           
  - `src/services/crossChainMonitorService.ts` — Singleton service that snapshots balances across all configured Stellar wallets and mobile money         
  providers. Detects balance drops exceeding a configurable threshold and emits structured WARN logs + Prometheus metrics.                                
  - `src/jobs/crossChainMonitorJob.ts` — Thin cron job wrapper that calls the monitor service every 5 minutes.                                            
  - `src/routes/crossChain.ts` — Authenticated REST endpoint `GET /api/cross-chain/balances` returning the latest snapshot.                               
                                                                                                                                                          
  ### Modified Files                                                                                                                                      
  - `src/utils/metrics.ts` — Added `cross_chain_balance` Gauge and `cross_chain_anomaly_total` Counter.                                                   
  - `src/jobs/scheduler.ts` — Registered `cross-chain-monitor` job (configurable via `CROSS_CHAIN_MONITOR_CRON`).                                         
  - `src/index.ts` — Mounted cross-chain router at `/api/cross-chain`.                                                                                    
  - `.env.example` — Documented `CROSS_CHAIN_MONITOR_CRON`, `CROSS_CHAIN_DROP_THRESHOLD_PCT`, `CROSS_CHAIN_STELLAR_ADDRESSES`.                            
                                                                                                                                                          
  ## How It Works                                                                                                                                         
                                                                                                                                                          
  1. Every 5 minutes the job calls `CrossChainMonitorService.snapshot()`                                                                                  
  2. It loads all Stellar account balances via Horizon for addresses in `CROSS_CHAIN_STELLAR_ADDRESSES` + `HOT_WALLET_PUBLIC_KEYS`                        
  3. It fetches mobile money provider balances (stubbed — returns `"0"` with a TODO log until real provider APIs are wired)                               
  4. Each balance is set on the `cross_chain_balance` Prometheus gauge                                                                                    
  5. If any balance drops more than `CROSS_CHAIN_DROP_THRESHOLD_PCT` (default: 20%) vs the previous snapshot, a structured JSON WARN log is emitted and   
  `cross_chain_anomaly_total` is incremented                                                                                                              
  6. The latest snapshot is accessible via `GET /api/cross-chain/balances` (requires auth)                                                                
                                                                                                                                                          
  ## Environment Variables                                                                                                                                
                                                                                                                                                          
  | Variable | Default | Description |                                                                                                                    
  |---|---|---|                                                                                                                                           
  | `CROSS_CHAIN_MONITOR_CRON` | `*/5 * * * *` | Cron schedule for the job |                                                                              
  | `CROSS_CHAIN_DROP_THRESHOLD_PCT` | `20` | % drop that triggers an anomaly |                                                                           
  | `CROSS_CHAIN_STELLAR_ADDRESSES` | _(empty)_ | Extra Stellar public keys to monitor |                                                                  
                                                                                                                                                          
  ## Notes                                                                                                                                                
                                                                                                                                                          
  - Mobile money provider balance fetching is stubbed pending real API integration                                                                        
  - No new npm packages added                                                                                                                             
  - No existing tests modified                                                                                                                            
                                                                  