### PR TITLE
feat(monitoring): build Prometheus exporter for Stellar hot wallet (#551)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import fs from "fs";
 import path from "path";
 import session from "express-session";
 import * as Sentry from "@sentry/node";
+import { register } from "prom-client";
+import { startStellarExporter } from "./services/stellarExporter";
 
 import {
   apiVersionMiddleware,
@@ -362,6 +364,16 @@ app.use("/sep38", sep38Router);
 app.use("/sep12", createSep12Router(pool));
 app.use("/.well-known/stellar.toml", tomlRouter);
 
+// Prometheus Metrics Scraper Endpoint
+app.get("/metrics", async (req: Request, res: Response) => {
+  try {
+    res.set("Content-Type", register.contentType);
+    res.end(await register.metrics());
+  } catch (ex) {
+    res.status(500).end(String(ex));
+  }
+});
+
 app.use(
   (
     err: Error & { type?: string },
@@ -484,6 +496,9 @@ async function initializeRuntime(): Promise<void> {
   // Initialize background jobs and monitoring
   const { startJobs } = await import("./jobs/scheduler");
   startJobs();
+
+  // Initialize Prometheus Horizon Scraper
+  startStellarExporter();
 
   const { getQueueHealth, pauseQueueEndpoint, resumeQueueEndpoint } =
     await import("./queue/health");

--- a/src/services/stellarExporter.ts
+++ b/src/services/stellarExporter.ts
@@ -1,0 +1,53 @@
+import { Gauge, register } from 'prom-client';
+import * as StellarSdk from 'stellar-sdk';
+
+// Use environment variables for network routing to support dev/prod parity
+const HORIZON_URL = process.env.STELLAR_HORIZON_URL || 'https://horizon.stellar.org';
+const server = new StellarSdk.Horizon.Server(HORIZON_URL);
+const HOT_WALLET_PUBLIC_KEY = process.env.STELLAR_HOT_WALLET_PUBLIC_KEY;
+
+// 1. Define the Prometheus Gauge
+export const stellarHotWalletBalance = new Gauge({
+name: 'stellar_hot_wallet_balance',
+help: 'Current balance of the Stellar hot wallet',
+labelNames: ['asset_type', 'asset_code'],
+registers: [register], // Attach to the default global registry
+});
+
+// 2. The Core Scraper Logic
+export async function scrapeStellarBalances(): Promise<void> {
+  if (!HOT_WALLET_PUBLIC_KEY) {
+    console.warn('[Stellar Exporter] STELLAR_HOT_WALLET_PUBLIC_KEY is missing. Skipping metrics export.');
+    return;
+  }
+
+  try {
+    const account = await server.loadAccount(HOT_WALLET_PUBLIC_KEY);
+
+    // Iterate through all trustlines/native balances
+    account.balances.forEach((balance) => {
+      const assetType = balance.asset_type;
+      const assetCode = assetType === 'native' ? 'XLM' : (balance as any).asset_code;
+
+      // Update the Grafana Gauge
+      stellarHotWalletBalance.set(
+        { asset_type: assetType, asset_code: assetCode },
+        parseFloat(balance.balance)
+      );
+    });
+
+  } catch (error) {
+    console.error('[Stellar Exporter] Failed to scrape Horizon balances:', error);
+  }
+}
+
+// 3. The Polling Initializer
+export function startStellarExporter(): void {
+  console.log('[Stellar Exporter] Initializing 60-second background scraper...');
+
+  // Scrape immediately on container boot
+  scrapeStellarBalances();
+
+  // Schedule subsequent scrapes every 60,000 ms (1 minute)
+  setInterval(scrapeStellarBalances, 60 * 1000);
+}


### PR DESCRIPTION
## Description
This PR introduces a background polling service and Prometheus endpoint to expose Stellar hot wallet liquidity. This allows the Ops team to ingest the metrics into Grafana and set up alerting thresholds for wallet balances.

## Related Issue
Fixes #551

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made
- **Prometheus Client Integration:** Installed `prom-client` and initialized a global `Gauge` metric (`stellar_hot_wallet_balance`) labeled by `asset_type` and `asset_code`.
- **Horizon API Scraper:** Created `src/services/stellarExporter.ts` which utilizes the Stellar SDK to fetch account balances and update the Prometheus registry.
- **Background Polling:** Integrated a 60-second polling interval triggered during the `initializeRuntime()` phase.
- **Metrics Endpoint:** Exposed the `/metrics` route in `src/index.ts` to output the formatted scraping payload.
- **Fail-safe Logic:** Added an environment variable check (`STELLAR_HOT_WALLET_PUBLIC_KEY`) to gracefully bypass scraping if credentials are not present in the environment, preventing crash loops.

## Testing
How did you test these changes?
- Verified the application boots successfully without crashing when the public key is omitted (graceful degradation).
- Confirmed the `/metrics` endpoint successfully returns the expected `prom-client` payload format.

## Checklist
- [x] Code follows project style
- [x] Self-reviewed my code
- [x] Commented complex code
- [ ] Updated documentation
- [x] No new warnings
- [ ] Added tests (if applicable)