### PR TITLE
feat: build momo-cli admin maintenance tool (#583)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,24 @@
+# momo-cli
+
+Admin maintenance CLI for the mobile-money service.
+
+## Setup
+
+```bash
+cd cli && npm install
+```
+
+Create `cli/.momorc`:
+
+```
+MOMO_API_URL=https://your-production-url
+MOMO_API_KEY=your-admin-api-key
+```
+
+## Commands
+
+```bash
+npm run dev -- auth check                        # verify API key
+npm run dev -- status <transactionId>            # get transaction details
+npm run dev -- retry <transactionId>             # force-retry a failed transaction
+```

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "momo-cli",
+  "version": "1.0.0",
+  "description": "Admin maintenance CLI for mobile-money",
+  "bin": { "momo-cli": "./dist/index.js" },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "axios": "^1.6.2",
+    "commander": "^12.0.0",
+    "dotenv": "^17.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -1,0 +1,68 @@
+import axios, { AxiosInstance } from "axios";
+import { getConfig } from "./config";
+
+export interface Transaction {
+  id: string;
+  referenceNumber: string;
+  type: string;
+  amount: string;
+  phoneNumber: string;
+  provider: string;
+  status: string;
+  retryCount: number;
+  createdAt: string;
+}
+
+function buildClient(): AxiosInstance {
+  const { apiUrl, apiKey } = getConfig();
+  return axios.create({
+    baseURL: apiUrl,
+    headers: { "X-API-Key": apiKey },
+  });
+}
+
+function extractMessage(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    const data = err.response?.data as Record<string, unknown> | undefined;
+    if (data) {
+      if (typeof data["error"] === "string") return data["error"];
+      if (typeof data["message"] === "string") return data["message"];
+    }
+    return err.message;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+export async function getTransaction(id: string): Promise<Transaction> {
+  try {
+    const { data } = await buildClient().get<Transaction>(
+      `/api/admin/transactions/${id}`,
+    );
+    return data;
+  } catch (err) {
+    throw new Error(extractMessage(err));
+  }
+}
+
+export async function retryTransaction(
+  id: string,
+): Promise<{ message: string; transaction: Transaction }> {
+  try {
+    const { data } = await buildClient().put<{
+      message: string;
+      transaction: Transaction;
+    }>(`/api/admin/transactions/${id}`, { status: "pending" });
+    return data;
+  } catch (err) {
+    throw new Error(extractMessage(err));
+  }
+}
+
+export async function checkAuth(): Promise<{ status: string }> {
+  try {
+    const { data } = await buildClient().get<{ status: string }>("/api/stats");
+    return data;
+  } catch (err) {
+    throw new Error(extractMessage(err));
+  }
+}

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,0 +1,22 @@
+import { Command } from "commander";
+import { checkAuth } from "../api";
+import { getConfig } from "../config";
+
+export function registerAuthCommand(program: Command): void {
+  const auth = program.command("auth").description("Authentication commands");
+
+  auth
+    .command("check")
+    .description("Verify the API key is valid")
+    .action(async () => {
+      try {
+        await checkAuth();
+        const { apiUrl } = getConfig();
+        console.log(`✓ API key valid — connected to ${apiUrl}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`✗ Auth failed: ${msg}`);
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/commands/retry.ts
+++ b/cli/src/commands/retry.ts
@@ -1,0 +1,29 @@
+import { Command } from "commander";
+import { getTransaction, retryTransaction } from "../api";
+
+export function registerRetryCommand(program: Command): void {
+  program
+    .command("retry <transactionId>")
+    .description("Force-retry a failed transaction")
+    .action(async (transactionId: string) => {
+      try {
+        const tx = await getTransaction(transactionId);
+
+        if (tx.status === "pending" || tx.status === "completed") {
+          console.log(
+            `⚠ Transaction ${transactionId} is already ${tx.status} — no action taken.`,
+          );
+          process.exit(0);
+        }
+
+        await retryTransaction(transactionId);
+        console.log(
+          `✓ Transaction ${transactionId} reset to pending — worker will pick it up shortly.`,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`✗ ${msg}`);
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -1,0 +1,26 @@
+import { Command } from "commander";
+import { getTransaction } from "../api";
+
+export function registerStatusCommand(program: Command): void {
+  program
+    .command("status <transactionId>")
+    .description("Get transaction details")
+    .action(async (transactionId: string) => {
+      try {
+        const tx = await getTransaction(transactionId);
+        console.log(`Transaction: ${tx.id}`);
+        console.log(`Reference:   ${tx.referenceNumber}`);
+        console.log(`Type:        ${tx.type}`);
+        console.log(`Amount:      ${tx.amount}`);
+        console.log(`Phone:       ${tx.phoneNumber}`);
+        console.log(`Provider:    ${tx.provider}`);
+        console.log(`Status:      ${tx.status}`);
+        console.log(`Retries:     ${tx.retryCount}`);
+        console.log(`Created:     ${tx.createdAt}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`✗ ${msg}`);
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,0 +1,23 @@
+import dotenv from "dotenv";
+import path from "path";
+
+// Load .momorc from the cli/ directory, fall back to process.env
+dotenv.config({ path: path.resolve(__dirname, "..", ".momorc") });
+
+export interface CliConfig {
+  apiUrl: string;
+  apiKey: string;
+}
+
+export function getConfig(): CliConfig {
+  const apiKey = process.env.MOMO_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MOMO_API_KEY is required. Set it in cli/.momorc or as an environment variable.",
+    );
+  }
+  return {
+    apiUrl: process.env.MOMO_API_URL ?? "http://localhost:3000",
+    apiKey,
+  };
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { registerAuthCommand } from "./commands/auth";
+import { registerStatusCommand } from "./commands/status";
+import { registerRetryCommand } from "./commands/retry";
+
+const program = new Command("momo-cli")
+  .version("1.0.0")
+  .description("Admin maintenance CLI for mobile-money");
+
+registerAuthCommand(program);
+registerStatusCommand(program);
+registerRetryCommand(program);
+
+program.parseAsync(process.argv).catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+});

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Closes #583

## What

A standalone `momo-cli` tool in `cli/` that lets support fix issues without DB access.

## Commands

```bash
# Verify API key
momo-cli auth check

# Inspect a transaction
momo-cli status <transactionId>

# Force-retry a failed transaction
momo-cli retry <transactionId>
```

## Setup

```bash
cd cli && npm install
```

Create `cli/.momorc`:
```
MOMO_API_URL=https://your-production-url
MOMO_API_KEY=your-admin-api-key
```

## Implementation

- `src/config.ts` — loads `.momorc` / env vars, validates `MOMO_API_KEY` is present
- `src/api.ts` — axios client with `X-API-Key` header; `getTransaction`, `retryTransaction`, `checkAuth`
- `src/commands/auth.ts` — `auth check` hits `/api/stats` to validate the key
- `src/commands/status.ts` — `status <id>` fetches and pretty-prints transaction fields
- `src/commands/retry.ts` — `retry <id>` guards against retrying pending/completed transactions, then resets to pending
- TypeScript strict mode; runs via `tsx` in dev or compiled `dist/` in prod