### PR TITLE
MEDIUM] Implement Circuit Breaker for Flat-lining Providers #509

### DIFF
--- a/src/jobs/providerHealthCheck.ts
+++ b/src/jobs/providerHealthCheck.ts
@@ -1,4 +1,5 @@
 import { checkMobileMoneyHealth } from "../services/mobilemoney/providers/healthCheck";
+import { checkAndResetCircuitBreaker } from "../utils/circuitBreaker";
 
 interface ProviderHealthAlert {
   alertType: "provider_health_status";
@@ -54,6 +55,19 @@ export async function runProviderHealthCheckJob(): Promise<void> {
 
       if (health.status === "down") {
         downProviders.push(providerName);
+      } else {
+        // Provider is up, try to reset circuit breakers
+        const operations = ["requestPayment", "sendPayout"];
+        for (const operation of operations) {
+          try {
+            const reset = await checkAndResetCircuitBreaker(providerName, operation);
+            if (reset) {
+              console.log(`[provider-health] Reset circuit breaker for ${providerName}:${operation}`);
+            }
+          } catch (error) {
+            console.error(`[provider-health] Failed to reset breaker for ${providerName}:${operation}: ${toErrorMessage(error)}`);
+          }
+        }
       }
     }
 

--- a/src/utils/circuitBreaker.ts
+++ b/src/utils/circuitBreaker.ts
@@ -3,6 +3,7 @@ import {
   providerCircuitBreakerState,
   providerCircuitBreakerTransitionsTotal,
 } from "./metrics";
+import { checkMobileMoneyHealth } from "../services/mobilemoney/providers/healthCheck";
 
 export interface CircuitBreakerActionResult<T> {
   success: boolean;
@@ -50,7 +51,7 @@ function getBreakerOptions(name: string): CircuitBreakerOptions {
       process.env.PROVIDER_CIRCUIT_BREAKER_RESET_TIMEOUT_MS ?? 30_000,
     ),
     rollingCountTimeout: Number(
-      process.env.PROVIDER_CIRCUIT_BREAKER_ROLLING_WINDOW_MS ?? 10_000,
+      process.env.PROVIDER_CIRCUIT_BREAKER_ROLLING_WINDOW_MS ?? 300_000, // 5 minutes
     ),
     rollingCountBuckets: Number(
       process.env.PROVIDER_CIRCUIT_BREAKER_ROLLING_BUCKETS ?? 10,
@@ -128,12 +129,15 @@ function getOrCreateCircuitBreaker<T>(
   });
 
   breaker.on("open", () => {
+    console.error(`Circuit breaker opened for ${provider}:${operation} due to high error rate`);
     emitStateTransitionMetric(provider, operation, "open");
   });
   breaker.on("halfOpen", () => {
+    console.log(`Circuit breaker half-open for ${provider}:${operation}, testing recovery`);
     emitStateTransitionMetric(provider, operation, "half_open");
   });
   breaker.on("close", () => {
+    console.log(`Circuit breaker closed for ${provider}:${operation}, service recovered`);
     emitStateTransitionMetric(provider, operation, "closed");
   });
 
@@ -166,6 +170,30 @@ export function resetCircuitBreakers(): void {
     breaker.shutdown();
   }
   circuitBreakers.clear();
+}
+
+export async function checkAndResetCircuitBreaker(provider: string, operation: string): Promise<boolean> {
+  const key = getCircuitKey(provider, operation);
+  const breaker = circuitBreakers.get(key);
+  if (!breaker) {
+    return false;
+  }
+
+  // Only reset if open
+  if (breaker.opened) {
+    try {
+      const healthResult = await checkMobileMoneyHealth();
+      const providerHealth = healthResult.providers[provider as keyof typeof healthResult.providers];
+      if (providerHealth && providerHealth.status === "up") {
+        breaker.close();
+        console.log(`Circuit breaker for ${provider}:${operation} reset due to health check`);
+        return true;
+      }
+    } catch (error) {
+      console.error(`Failed to check health for ${provider}: ${error}`);
+    }
+  }
+  return false;
 }
 
 export function getCircuitBreakerCount(): number {

--- a/tests/utils/circuitBreaker.test.ts
+++ b/tests/utils/circuitBreaker.test.ts
@@ -7,15 +7,21 @@ jest.mock("../../src/utils/metrics", () => ({
   },
 }));
 
+jest.mock("../../src/services/mobilemoney/providers/healthCheck", () => ({
+  checkMobileMoneyHealth: jest.fn(),
+}));
+
 import {
   executeWithCircuitBreaker,
   getCircuitBreakerCount,
   resetCircuitBreakers,
+  checkAndResetCircuitBreaker,
 } from "../../src/utils/circuitBreaker";
 import {
   providerCircuitBreakerState,
   providerCircuitBreakerTransitionsTotal,
 } from "../../src/utils/metrics";
+import { checkMobileMoneyHealth } from "../../src/services/mobilemoney/providers/healthCheck";
 
 describe("executeWithCircuitBreaker", () => {
   beforeEach(() => {
@@ -109,5 +115,73 @@ describe("executeWithCircuitBreaker", () => {
     resetCircuitBreakers();
 
     expect(getCircuitBreakerCount()).toBe(0);
+  });
+
+  describe("checkAndResetCircuitBreaker", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("resets open breaker when provider is healthy", async () => {
+      // First open the breaker
+      await expect(
+        executeWithCircuitBreaker({
+          provider: "mtn",
+          operation: "requestPayment",
+          execute: async () => ({
+            success: false,
+            error: new Error("provider-down"),
+          }),
+        }),
+      ).rejects.toThrow("provider-down");
+
+      // Mock health check as up
+      (checkMobileMoneyHealth as jest.Mock).mockResolvedValue({
+        providers: {
+          mtn: { status: "up", responseTime: 100 },
+        },
+      });
+
+      const reset = await checkAndResetCircuitBreaker("mtn", "requestPayment");
+      expect(reset).toBe(true);
+      expect(checkMobileMoneyHealth).toHaveBeenCalled();
+    });
+
+    it("does not reset if breaker is not open", async () => {
+      (checkMobileMoneyHealth as jest.Mock).mockResolvedValue({
+        providers: {
+          mtn: { status: "up", responseTime: 100 },
+        },
+      });
+
+      const reset = await checkAndResetCircuitBreaker("mtn", "requestPayment");
+      expect(reset).toBe(false);
+      expect(checkMobileMoneyHealth).not.toHaveBeenCalled();
+    });
+
+    it("does not reset if provider is down", async () => {
+      // First open the breaker
+      await expect(
+        executeWithCircuitBreaker({
+          provider: "mtn",
+          operation: "requestPayment",
+          execute: async () => ({
+            success: false,
+            error: new Error("provider-down"),
+          }),
+        }),
+      ).rejects.toThrow("provider-down");
+
+      // Mock health check as down
+      (checkMobileMoneyHealth as jest.Mock).mockResolvedValue({
+        providers: {
+          mtn: { status: "down", responseTime: null },
+        },
+      });
+
+      const reset = await checkAndResetCircuitBreaker("mtn", "requestPayment");
+      expect(reset).toBe(false);
+      expect(checkMobileMoneyHealth).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Automatically stop sending traffic to a provider if error rates exceed 50% in 5 minutes.

Tasks:
-  Implement CircuitBreaker pattern
-  Emit alerts on state change  
-  Implement health-check polling for recovery

Acceptance Criteria:
-  System fails fast instead of hanging

## Changes Made
- Modified `src/utils/circuitBreaker.ts` to use a 5-minute rolling window for error rate monitoring
- Added alert logging on circuit breaker state changes
- Implemented `checkAndResetCircuitBreaker` function for health-check based recovery
- Integrated health-check polling in `src/jobs/providerHealthCheck.ts` to reset breakers when providers are healthy
- Added comprehensive tests in `tests/utils/circuitBreaker.test.ts`

Closes #509