### PR TITLE
feat: multi-region Postgres replication for disaster recovery (#550)

### DIFF
--- a/docs/DR_FAILOVER_RUNBOOK.md
+++ b/docs/DR_FAILOVER_RUNBOOK.md
@@ -1,0 +1,187 @@
+# Disaster Recovery Runbook — Multi-Region Database Failover
+
+## Overview
+
+The primary database runs in **us-east-1** (RDS PostgreSQL 16, Multi-AZ).  
+A cross-region read replica streams WAL continuously to **eu-west-1**.  
+RTO target: **< 15 minutes** | RPO target: **< 30 seconds** (WAL lag).
+
+---
+
+## Architecture
+
+```
+us-east-1 (primary)          eu-west-1 (DR)
+┌─────────────────┐           ┌──────────────────────┐
+│  RDS Primary    │──WAL──▶  │  RDS Read Replica    │
+│  (Multi-AZ)     │           │  (cross-region)      │
+└─────────────────┘           └──────────────────────┘
+        ▲                              ▲
+        │                              │ (after promotion)
+┌─────────────────┐           ┌──────────────────────┐
+│  ECS App        │           │  ECS App (DR)        │
+│  DATABASE_URL   │           │  DR_DATABASE_URL     │
+└─────────────────┘           └──────────────────────┘
+```
+
+---
+
+## Normal Operations
+
+### Check replication lag
+
+```bash
+# On the primary — shows bytes behind for each replica
+aws rds describe-db-instances \
+  --db-instance-identifier mobile-money-production-postgres \
+  --query 'DBInstances[0].StatusInfos'
+
+# Or via psql on the primary
+psql $DATABASE_URL -c "SELECT * FROM pg_stat_replication;"
+```
+
+### Check replica health via app
+
+```bash
+curl https://api.yourdomain.com/ready | jq '.checks | {dr_replica, dr_mode}'
+```
+
+---
+
+## Failover Procedure (Region Outage)
+
+> **Declare incident first.** Page the on-call engineer via PagerDuty before proceeding.
+
+### Step 1 — Confirm primary is unreachable
+
+```bash
+# Should time out or return an error
+psql $DATABASE_URL -c "SELECT 1" --connect-timeout=5
+```
+
+### Step 2 — Promote the DR replica
+
+```bash
+# Get the replica identifier from Terraform output
+REPLICA_ID=$(terraform -chdir=terraform output -raw dr_replica_arn | cut -d: -f7)
+
+aws rds promote-read-replica \
+  --db-instance-identifier "$REPLICA_ID" \
+  --region eu-west-1
+
+# Wait for promotion to complete (typically 1–3 minutes)
+aws rds wait db-instance-available \
+  --db-instance-identifier "$REPLICA_ID" \
+  --region eu-west-1
+
+echo "Replica promoted. New endpoint:"
+aws rds describe-db-instances \
+  --db-instance-identifier "$REPLICA_ID" \
+  --region eu-west-1 \
+  --query 'DBInstances[0].Endpoint.Address' \
+  --output text
+```
+
+### Step 3 — Update application configuration
+
+Set `DR_DATABASE_URL` to the promoted replica's connection string and redeploy:
+
+```bash
+# ECS parameter store update
+aws ssm put-parameter \
+  --name "/mobile-money/production/DR_DATABASE_URL" \
+  --value "postgresql://mobilemoney:<password>@<promoted-endpoint>:5432/mobilemoney_stellar" \
+  --type SecureString \
+  --overwrite \
+  --region eu-west-1
+
+# Force new ECS deployment to pick up the new env var
+aws ecs update-service \
+  --cluster mobile-money-production \
+  --service mobile-money-production \
+  --force-new-deployment \
+  --region eu-west-1
+```
+
+### Step 4 — Verify
+
+```bash
+# App should report dr_mode: active
+curl https://api.yourdomain.com/ready | jq .
+
+# Smoke test a write
+curl -X POST https://api.yourdomain.com/api/transactions/deposit \
+  -H "Authorization: Bearer $TEST_TOKEN" \
+  -d '{"amount":"100","phoneNumber":"+237670000000","provider":"mock"}'
+```
+
+### Step 5 — Update DNS (if using Route 53 failover routing)
+
+```bash
+# Point the CNAME / alias to the eu-west-1 ALB
+aws route53 change-resource-record-sets \
+  --hosted-zone-id $HOSTED_ZONE_ID \
+  --change-batch file://dns-failover-eu-west-1.json
+```
+
+---
+
+## Failback Procedure (Primary Region Restored)
+
+1. Provision a new primary in us-east-1 from the latest snapshot of the promoted replica:
+   ```bash
+   aws rds restore-db-instance-to-point-in-time \
+     --source-db-instance-identifier "$REPLICA_ID" \
+     --target-db-instance-identifier mobile-money-production-postgres \
+     --restore-time $(date -u +%Y-%m-%dT%H:%M:%SZ) \
+     --region us-east-1
+   ```
+2. Once the new primary is available, set up a new read replica in eu-west-1 pointing to it.
+3. Unset `DR_DATABASE_URL` and redeploy the app to route writes back to us-east-1.
+4. Update DNS back to the us-east-1 ALB.
+
+---
+
+## Latency Impact on Writes
+
+Run the write latency test before and after enabling the DR replica:
+
+```bash
+# Primary only
+DATABASE_URL=$PRIMARY_URL npm run test:write-latency
+
+# Primary + promoted DR replica
+DATABASE_URL=$PRIMARY_URL DR_DATABASE_URL=$DR_URL npm run test:write-latency
+```
+
+Expected cross-region overhead (us-east-1 → eu-west-1): **80–120 ms** additional mean latency on writes when routing to the DR replica. Normal operations against the primary are unaffected — the replica is read-only and receives WAL asynchronously.
+
+---
+
+## Terraform: Enabling the DR Replica
+
+```bash
+cd terraform
+
+terraform apply \
+  -var-file=environments/production.tfvars \
+  -var-file=environments/dr.tfvars
+```
+
+To disable (saves cost in non-production):
+
+```bash
+terraform apply \
+  -var-file=environments/production.tfvars \
+  -var 'dr_replica_enabled=false'
+```
+
+---
+
+## Contacts
+
+| Role            | Contact                  |
+|-----------------|--------------------------|
+| On-call DBA     | PagerDuty — `db-oncall`  |
+| Platform Lead   | PagerDuty — `platform`   |
+| Incident Bridge | Slack `#incidents`       |

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:load:transactions": "k6 run -e SCENARIO=transactions tests/load/api.js",
     "test:load:breakpoint": "k6 run -e SCENARIO=breakpoint tests/load/api.js",
     "test:load:legacy": "k6 run tests/load/k6/load_test_scenarios.js",
+    "test:write-latency": "ts-node scripts/test-write-latency.ts",
     "test:bench": "node tests/load/autocannon/benchmark.js",
     "sdk:generate": "openapi-generator-cli generate -i openapi.yaml -c sdk-config.yaml -o sdk",
     "sdk:build": "cd sdk && ./gradlew build"

--- a/scripts/test-write-latency.ts
+++ b/scripts/test-write-latency.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env ts-node
+/**
+ * scripts/test-write-latency.ts
+ *
+ * Measures write latency against the primary and (optionally) the DR replica
+ * to quantify the cross-region replication lag and write overhead.
+ *
+ * Usage:
+ *   # Against primary only
+ *   DATABASE_URL=postgresql://... npx ts-node scripts/test-write-latency.ts
+ *
+ *   # Against primary + DR replica (replica must be promoted first)
+ *   DATABASE_URL=postgresql://... DR_DATABASE_URL=postgresql://... \
+ *     npx ts-node scripts/test-write-latency.ts
+ *
+ * Options (env vars):
+ *   LATENCY_ITERATIONS  Number of write iterations (default: 100)
+ *   LATENCY_CONCURRENCY Parallel writers (default: 5)
+ */
+
+import { Pool } from "pg";
+
+const ITERATIONS  = parseInt(process.env.LATENCY_ITERATIONS  || "100", 10);
+const CONCURRENCY = parseInt(process.env.LATENCY_CONCURRENCY || "5",   10);
+
+interface LatencyResult {
+  label:   string;
+  p50:     number;
+  p95:     number;
+  p99:     number;
+  mean:    number;
+  min:     number;
+  max:     number;
+  errors:  number;
+}
+
+function percentile(sorted: number[], p: number): number {
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+async function runLatencyTest(label: string, pool: Pool): Promise<LatencyResult> {
+  // Create a temporary table for the test
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS _dr_latency_test (
+      id      SERIAL PRIMARY KEY,
+      payload TEXT,
+      ts      TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+
+  const latencies: number[] = [];
+  let errors = 0;
+
+  // Run ITERATIONS writes with CONCURRENCY parallel workers
+  const batches = Math.ceil(ITERATIONS / CONCURRENCY);
+  for (let b = 0; b < batches; b++) {
+    const batchSize = Math.min(CONCURRENCY, ITERATIONS - b * CONCURRENCY);
+    await Promise.all(
+      Array.from({ length: batchSize }, async (_, i) => {
+        const start = process.hrtime.bigint();
+        try {
+          await pool.query(
+            "INSERT INTO _dr_latency_test (payload) VALUES ($1)",
+            [`batch-${b}-item-${i}-${Date.now()}`],
+          );
+          const ms = Number(process.hrtime.bigint() - start) / 1e6;
+          latencies.push(ms);
+        } catch {
+          errors++;
+        }
+      }),
+    );
+  }
+
+  // Cleanup
+  await pool.query("DROP TABLE IF EXISTS _dr_latency_test");
+
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const mean   = sorted.reduce((s, v) => s + v, 0) / (sorted.length || 1);
+
+  return {
+    label,
+    p50:    percentile(sorted, 50),
+    p95:    percentile(sorted, 95),
+    p99:    percentile(sorted, 99),
+    mean:   Math.round(mean * 100) / 100,
+    min:    sorted[0]             ?? 0,
+    max:    sorted[sorted.length - 1] ?? 0,
+    errors,
+  };
+}
+
+function printResult(r: LatencyResult) {
+  console.log(`\n── ${r.label} ──`);
+  console.log(`  Iterations : ${ITERATIONS} (concurrency ${CONCURRENCY})`);
+  console.log(`  Errors     : ${r.errors}`);
+  console.log(`  Mean       : ${r.mean} ms`);
+  console.log(`  Min        : ${r.min.toFixed(2)} ms`);
+  console.log(`  p50        : ${r.p50.toFixed(2)} ms`);
+  console.log(`  p95        : ${r.p95.toFixed(2)} ms`);
+  console.log(`  p99        : ${r.p99.toFixed(2)} ms`);
+  console.log(`  Max        : ${r.max.toFixed(2)} ms`);
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error("ERROR: DATABASE_URL is required");
+    process.exit(1);
+  }
+
+  const primaryPool = new Pool({ connectionString: process.env.DATABASE_URL, max: CONCURRENCY });
+  const results: LatencyResult[] = [];
+
+  console.log(`\nWrite latency test — ${ITERATIONS} iterations, concurrency ${CONCURRENCY}`);
+  console.log("=".repeat(60));
+
+  results.push(await runLatencyTest("Primary (us-east-1)", primaryPool));
+  await primaryPool.end();
+
+  if (process.env.DR_DATABASE_URL) {
+    const drPool = new Pool({ connectionString: process.env.DR_DATABASE_URL, max: CONCURRENCY });
+    results.push(await runLatencyTest("DR Replica / Promoted (eu-west-1)", drPool));
+    await drPool.end();
+  }
+
+  results.forEach(printResult);
+
+  if (results.length === 2) {
+    const overhead = results[1].mean - results[0].mean;
+    console.log(`\n  Cross-region write overhead (mean): ${overhead.toFixed(2)} ms`);
+  }
+
+  console.log("\nDone.\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -242,6 +242,7 @@ export async function queryRead<T extends import("pg").QueryResultRow = any>(
 /**
  * Execute a write SQL query (INSERT / UPDATE / DELETE) against the primary pool.
  * All writes now route through PgBouncer via the primary pool connection.
+ * In DR failover mode (DR_DATABASE_URL set) writes go to the promoted replica.
  *
  * @param text   - The parameterised SQL query string
  * @param params - Optional query parameters
@@ -250,7 +251,61 @@ export async function queryWrite<T extends import("pg").QueryResultRow = any>(
   text: string,
   params?: unknown[],
 ): Promise<import("pg").QueryResult<T>> {
-  return pool.query<T>(text, params);
+  return getWritePool().query<T>(text, params);
+}
+// When DR_DATABASE_URL is set the app is running in failover mode against the
+// promoted DR replica. All writes are redirected there automatically.
+// To activate: set DR_DATABASE_URL=<promoted-replica-url> and restart the app.
+// To deactivate: unset DR_DATABASE_URL and restart.
+
+const DR_DATABASE_URL = process.env.DR_DATABASE_URL;
+
+const drPool: Pool | null = DR_DATABASE_URL
+  ? new Pool({
+      connectionString: DR_DATABASE_URL,
+      max: 20,
+      idleTimeoutMillis: 30000,
+      connectionTimeoutMillis: 2000,
+    })
+  : null;
+
+if (drPool) {
+  console.warn(
+    "[DR] DR_DATABASE_URL is set — all writes are routed to the DR replica. " +
+    "Ensure the replica has been promoted before accepting traffic.",
+  );
+}
+
+/**
+ * Returns true when the application is running in DR failover mode.
+ */
+export function isDRMode(): boolean {
+  return drPool !== null;
+}
+
+/**
+ * Health-check the DR pool. Returns null when DR mode is not active.
+ */
+export async function checkDRHealth(): Promise<{ healthy: boolean; url: string } | null> {
+  if (!drPool || !DR_DATABASE_URL) return null;
+  let client: PoolClient | null = null;
+  try {
+    client = await drPool.connect();
+    await client.query("SELECT 1");
+    return { healthy: true, url: DR_DATABASE_URL };
+  } catch {
+    return { healthy: false, url: DR_DATABASE_URL };
+  } finally {
+    client?.release();
+  }
+}
+
+/**
+ * Active write pool — returns the DR pool when in failover mode, otherwise primary.
+ * Use this for all write operations so failover is transparent.
+ */
+export function getWritePool(): Pool {
+  return drPool ?? pool;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ import {
 } from "./config/redis";
 import { createOAuthRouter } from "./auth/oauth";
 import { applySecurityMiddleware } from "./config/express";
-import { pool } from "./config/database";
+import { pool, checkDRHealth, isDRMode } from "./config/database";
 import {
   globalTimeout,
   haltOnTimedout,
@@ -247,6 +247,13 @@ app.get("/ready", async (_req: Request, res: Response) => {
   } catch (err) {
     console.error("Redis check failed", err);
     allReady = false;
+  }
+
+  // DR replica health (informational — does not affect readiness)
+  const drHealth = await checkDRHealth();
+  if (drHealth !== null) {
+    checks.dr_replica = drHealth.healthy ? "ok" : "degraded";
+    checks.dr_mode = isDRMode() ? "active" : "standby";
   }
 
   const body: ReadinessCheckResponse = {

--- a/terraform/environments/dr.tfvars
+++ b/terraform/environments/dr.tfvars
@@ -1,0 +1,22 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Production + DR Environment
+# Extends production.tfvars with a cross-region read replica in eu-west-1.
+# Apply with:
+#   terraform apply -var-file=environments/production.tfvars \
+#                   -var-file=environments/dr.tfvars
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Primary region stays us-east-1 (set in production.tfvars)
+
+# ── Disaster Recovery ──────────────────────────────────────────────────────
+dr_replica_enabled        = true
+dr_region                 = "eu-west-1"
+dr_replica_instance_class = "db.t3.small"
+
+# Pre-provisioned VPC in eu-west-1 — replace with real subnet/sg IDs
+# Run `terraform output` after provisioning the DR VPC to get these values.
+dr_private_subnet_ids = [
+  "subnet-REPLACE_EU_WEST_1A",
+  "subnet-REPLACE_EU_WEST_1B",
+]
+dr_security_group_id = "sg-REPLACE_EU_WEST_1_DB_SG"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,21 @@ provider "aws" {
   }
 }
 
+# DR provider — second region for cross-region replica
+provider "aws" {
+  alias  = "dr"
+  region = var.dr_region
+
+  default_tags {
+    tags = {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Role        = "dr"
+    }
+  }
+}
+
 # ── 1. Networking ──────────────────────────────────────────────────────────
 module "vpc" {
   source = "./modules/vpc"
@@ -60,6 +75,11 @@ module "security" {
 module "database" {
   source = "./modules/database"
 
+  providers = {
+    aws    = aws
+    aws.dr = aws.dr
+  }
+
   project              = var.project
   environment          = var.environment
   private_subnet_ids   = module.vpc.private_subnet_ids
@@ -70,6 +90,13 @@ module "database" {
   db_username          = var.db_username
   db_password          = var.db_password
   db_multi_az          = var.db_multi_az
+
+  # DR
+  dr_replica_enabled        = var.dr_replica_enabled
+  dr_region                 = var.dr_region
+  dr_replica_instance_class = var.dr_replica_instance_class
+  dr_private_subnet_ids     = var.dr_private_subnet_ids
+  dr_security_group_id      = var.dr_security_group_id
 }
 
 # ── 4. Managed Redis (ElastiCache) ────────────────────────────────────────

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -60,8 +60,8 @@ resource "aws_db_instance" "main" {
   publicly_accessible    = false
   multi_az               = var.db_multi_az
 
-  # Backup & Maintenance
-  backup_retention_period = var.db_backup_retention_days
+  # Backup & Maintenance — retention must be ≥1 for cross-region replica
+  backup_retention_period = max(var.db_backup_retention_days, var.dr_replica_enabled ? 7 : var.db_backup_retention_days)
   backup_window           = "03:00-04:00"
   maintenance_window      = "sun:04:30-sun:05:30"
 
@@ -72,6 +72,64 @@ resource "aws_db_instance" "main" {
 
   tags = {
     Name        = "${var.project}-${var.environment}-postgres"
+    Environment = var.environment
+  }
+}
+
+# ── Cross-Region DR Read Replica ──────────────────────────────────────────
+# Streams WAL from the primary via logical/physical replication.
+# Promoted to primary during a regional failover.
+resource "aws_db_instance" "dr_replica" {
+  count = var.dr_replica_enabled ? 1 : 0
+
+  provider   = aws.dr
+  identifier = "${var.project}-${var.environment}-postgres-dr"
+
+  # Replica source — must use the ARN for cross-region
+  replicate_source_db = aws_db_instance.main.arn
+
+  # Engine — must match primary
+  engine         = "postgres"
+  engine_version = "16"
+  instance_class = var.dr_replica_instance_class
+
+  # Storage — inherited from source, encryption required
+  storage_encrypted = true
+  storage_type      = "gp3"
+
+  # Network — deployed into the DR VPC/subnets
+  db_subnet_group_name   = aws_db_subnet_group.dr[0].name
+  vpc_security_group_ids = [var.dr_security_group_id]
+  publicly_accessible    = false
+
+  # Keep replica read-only until promoted
+  # No db_name / username / password — inherited from source
+
+  # Backup — keep snapshots on the replica too
+  backup_retention_period = var.db_backup_retention_days
+  backup_window           = "04:00-05:00"
+  maintenance_window      = "sun:05:30-sun:06:30"
+
+  skip_final_snapshot = var.environment != "production"
+  deletion_protection = var.environment == "production"
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-postgres-dr"
+    Environment = var.environment
+    Role        = "dr-replica"
+    DRRegion    = var.dr_region
+  }
+}
+
+resource "aws_db_subnet_group" "dr" {
+  count    = var.dr_replica_enabled ? 1 : 0
+  provider = aws.dr
+
+  name       = "${var.project}-${var.environment}-db-subnet-dr"
+  subnet_ids = var.dr_private_subnet_ids
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-db-subnet-dr"
     Environment = var.environment
   }
 }

--- a/terraform/modules/database/outputs.tf
+++ b/terraform/modules/database/outputs.tf
@@ -23,3 +23,13 @@ output "db_connection_url" {
   value       = "postgresql://${aws_db_instance.main.username}:${var.db_password}@${aws_db_instance.main.endpoint}/${aws_db_instance.main.db_name}"
   sensitive   = true
 }
+
+output "dr_replica_endpoint" {
+  description = "DR replica endpoint (empty when dr_replica_enabled = false)"
+  value       = var.dr_replica_enabled ? aws_db_instance.dr_replica[0].endpoint : ""
+}
+
+output "dr_replica_arn" {
+  description = "DR replica ARN — used to promote via aws rds promote-read-replica"
+  value       = var.dr_replica_enabled ? aws_db_instance.dr_replica[0].arn : ""
+}

--- a/terraform/modules/database/variables.tf
+++ b/terraform/modules/database/variables.tf
@@ -66,3 +66,34 @@ variable "db_backup_retention_days" {
   type        = number
   default     = 7
 }
+
+# ── Disaster Recovery ──────────────────────────────────────────────────────
+variable "dr_replica_enabled" {
+  description = "Create a cross-region read replica for disaster recovery"
+  type        = bool
+  default     = false
+}
+
+variable "dr_region" {
+  description = "AWS region for the DR replica (e.g. eu-west-1)"
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "dr_replica_instance_class" {
+  description = "RDS instance class for the DR replica"
+  type        = string
+  default     = "db.t3.small"
+}
+
+variable "dr_private_subnet_ids" {
+  description = "Private subnet IDs in the DR region for the replica subnet group"
+  type        = list(string)
+  default     = []
+}
+
+variable "dr_security_group_id" {
+  description = "Security group ID in the DR region for the replica"
+  type        = string
+  default     = ""
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -26,6 +26,16 @@ output "db_connection_url" {
   sensitive   = true
 }
 
+output "dr_replica_endpoint" {
+  description = "DR replica endpoint — set as DR_DATABASE_URL during failover"
+  value       = module.database.dr_replica_endpoint
+}
+
+output "dr_replica_arn" {
+  description = "DR replica ARN — pass to aws rds promote-read-replica during failover"
+  value       = module.database.dr_replica_arn
+}
+
 # ── Redis ──────────────────────────────────────────────────────────────────
 output "redis_endpoint" {
   description = "ElastiCache Redis primary endpoint"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -132,3 +132,34 @@ variable "s3_bucket_name" {
   type        = string
   default     = "mobile-money-kyc-documents"
 }
+
+# ── Disaster Recovery ──────────────────────────────────────────────────────
+variable "dr_replica_enabled" {
+  description = "Create a cross-region RDS read replica for disaster recovery"
+  type        = bool
+  default     = false
+}
+
+variable "dr_region" {
+  description = "AWS region for the DR replica"
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "dr_replica_instance_class" {
+  description = "RDS instance class for the DR replica"
+  type        = string
+  default     = "db.t3.small"
+}
+
+variable "dr_private_subnet_ids" {
+  description = "Private subnet IDs in the DR region (pre-provisioned VPC)"
+  type        = list(string)
+  default     = []
+}
+
+variable "dr_security_group_id" {
+  description = "Security group ID in the DR region for the replica"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
- Add cross-region RDS read replica (WAL streaming) to Terraform database module
- Add aws.dr provider alias and DR variables/outputs to root Terraform config
- Add terraform/environments/dr.tfvars (eu-west-1 replica config)
- Add DR failover pool to database.ts (DR_DATABASE_URL env var activates failover)
- queryWrite() transparently routes to DR pool when DR_DATABASE_URL is set
- Expose isDRMode() and checkDRHealth() in /ready health endpoint
- Add scripts/test-write-latency.ts to measure p50/p95/p99 write overhead
- Add docs/DR_FAILOVER_RUNBOOK.md with step-by-step failover/failback procedure

Brief description of changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

How did you test these changes?

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Closes
Closes #550 
