### PR TITLE
feat: generate OpenAPI spec at runtime from Zod schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,52 @@ npm run test:load:transactions
 npm run test:mutation
 ```
 
-## 📚 API Documentation
+## API Documentation
+
+### Interactive docs (Swagger UI)
+
+The API spec is generated at runtime directly from the Zod validation schemas — there is no manually maintained YAML or JSON file to keep in sync.
+
+**Accessing the docs locally**
+
+1. Start the server in development mode:
+   ```bash
+   npm run dev
+   ```
+2. Open your browser at:
+   ```
+   http://localhost:3000/docs
+   ```
+   Swagger UI loads with the full spec, including request/response shapes, examples, and a "Try it out" button for every endpoint.
+
+3. The raw OpenAPI 3.0 JSON is also available at:
+   ```
+   http://localhost:3000/docs/openapi.json
+   ```
+
+**Docs are not available in production** — both `/docs` and `/docs/openapi.json` return `404` when `NODE_ENV !== 'development'`.
+
+### How the spec stays in sync
+
+The source of truth is **`src/openapi/schemas/`**, not `openapi.yaml`.
+
+| File / folder | Purpose |
+|---|---|
+| `src/openapi/registry.ts` | Calls `extendZodWithOpenApi(z)` once; exports the shared registry |
+| `src/openapi/schemas/*.ts` | One file per domain — Zod schemas annotated with `.openapi({ description, example })` |
+| `src/openapi/paths/*.ts` | Route registrations (`registry.registerPath(...)`) per domain |
+| `src/openapi/generator.ts` | Assembles the spec via `OpenApiGeneratorV3` on every server start |
+| `src/routes/docs.ts` | Mounts Swagger UI and the JSON endpoint, dev-only |
+
+**To update the docs:** edit or add a schema in `src/openapi/schemas/`, then restart the server (`npm run dev` uses `tsx watch` so it restarts automatically). The change appears in `/docs` immediately — no manual sync step.
+
+> `openapi.yaml` in the repo root is a legacy file kept only for the SDK generator script (`npm run sdk:generate`). It is no longer the source of truth and will be removed in a future cleanup.
+>
+> **Backlog:** point `sdk:generate` at `http://localhost:3000/docs/openapi.json` instead of `openapi.yaml`. The dev server would need to be running during SDK generation, but it would mean the SDK always reflects the live Zod schemas with no manual sync. Once that's done, `openapi.yaml` can be deleted entirely.
+
+---
+
+## 📚 API Reference
 
 ### Base URL
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,3 +1,14 @@
+# LEGACY — this file is no longer the source of truth.
+# API docs are now generated at runtime from Zod schemas in src/openapi/schemas/.
+# See /docs (dev only) or run the server and visit http://localhost:<PORT>/docs.
+# This file is kept only for reference and may be removed in a future cleanup.
+#
+# TODO: Point the SDK generator at the live spec instead of this file.
+#   Current:  openapi-generator-cli generate -i openapi.yaml ...
+#   Target:   start the dev server, then use -i http://localhost:<PORT>/docs/openapi.json
+#   Once that's done this file can be deleted and sdk:generate will always
+#   reflect the Zod schemas without any manual sync step.
+
 openapi: 3.0.3
 info:
   title: Mobile Money Bridge API

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "8.5.0",
         "@aws-sdk/client-s3": "^3.1017.0",
         "@aws-sdk/lib-storage": "^3.1017.0",
         "@bull-board/api": "^6.20.6",
@@ -19,6 +20,7 @@
         "@sentry/node": "^10.47.0",
         "@types/passport": "^1.0.17",
         "@types/speakeasy": "^2.0.10",
+        "@types/swagger-ui-express": "4.1.8",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^0.10.9",
         "apollo-server-core": "^3.13.0",
@@ -77,6 +79,7 @@
         "spdy": "^4.0.2",
         "speakeasy": "^2.0.0",
         "stellar-sdk": "^12.3.0",
+        "swagger-ui-express": "5.0.1",
         "twilio": "^5.13.1",
         "ua-parser-js": "^2.0.9",
         "uuid": "^9.0.0",
@@ -86,6 +89,7 @@
       },
       "devDependencies": {
         "@aws-sdk/client-kms": "^3.1036.0",
+        "@cloudflare/workers-types": "4.20250422.0",
         "@playwright/test": "^1.59.1",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/jest-runner": "^9.6.1",
@@ -301,6 +305,18 @@
       "license": "MIT",
       "dependencies": {
         "xss": "^1.0.8"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz",
+      "integrity": "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -561,6 +577,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1019.0.tgz",
       "integrity": "sha512-0pb9x7PPhS4oEi4c0rL3vzQQoXA4cWKtPuGga/UfVYLZ68yrqdq0NDKg0fr55qzdhNvWFCpmGx73g9Iyy03kkA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1260,6 +1277,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2270,6 +2288,7 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-6.20.6.tgz",
       "integrity": "sha512-nEXRgMHHd48ssINgvDqT7b4p/+57XRf3CUcTGQ7UIJb4F7n/kRRj8+ZQvQmMFsYGdNmbNU2eNheQ05vXSYiqdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bull-board/api": "6.20.6"
       }
@@ -2282,6 +2301,13 @@
       "dependencies": {
         "jsep": "^0.3.0"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20250422.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250422.0.tgz",
+      "integrity": "sha512-rCeGeyYkIfZXKUNt8x5BOqMYm7W3X8Xj5yBMENR/OzPa9RDWtgHg3B77chPVHVYafSNbVEWc52XdtZTst/DZbA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@datadog/flagging-core": {
       "version": "1.1.0",
@@ -2458,10 +2484,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5380,6 +5406,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.207.0"
       },
@@ -5445,6 +5472,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
       "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -5457,6 +5485,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
       "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -5876,6 +5905,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
       "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -5892,6 +5922,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -5909,6 +5940,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6306,6 +6338,18 @@
         "@opentelemetry/api": "^1.8"
       }
     },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
       "version": "0.207.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
@@ -6321,6 +6365,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -6404,6 +6460,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -6454,6 +6511,13 @@
       "peerDependencies": {
         "@redis/client": "^5.11.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -7481,6 +7545,7 @@
       "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.0.0",
         "@stryker-mutator/api": "9.6.1",
@@ -8287,6 +8352,16 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
@@ -8404,6 +8479,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -8650,6 +8726,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8723,6 +8800,7 @@
       "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.9.tgz",
       "integrity": "sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-more-ints": "~1.0.0",
         "url-parse": "~1.5.10"
@@ -9365,6 +9443,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -9721,6 +9800,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11365,6 +11445,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -11963,6 +12044,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -12027,6 +12109,7 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
       "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "~0.7.2",
         "cookie-signature": "~1.0.7",
@@ -13165,6 +13248,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
       "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -13222,6 +13306,7 @@
       "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-3.0.0.tgz",
       "integrity": "sha512-kZCdevgmzDjGAOqH7GlDmQXYAkuHoKpMlJrqF40HMPhUhM5ZWSFSxCwD/nSi6AkaijmMfsFhoJRGJ27UseCvRA==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "graphql": "^15.7.2 || ^16.0.0"
       }
@@ -14069,6 +14154,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -15500,6 +15586,7 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -16820,6 +16907,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/opossum": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/opossum/-/opossum-9.0.0.tgz",
@@ -17168,6 +17264,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -19373,6 +19470,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
@@ -19591,6 +19712,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19956,6 +20078,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20570,6 +20693,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -20742,7 +20866,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -20905,6 +21028,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "8.5.0",
     "@aws-sdk/client-s3": "^3.1017.0",
     "@aws-sdk/lib-storage": "^3.1017.0",
     "@bull-board/api": "^6.20.6",
@@ -58,6 +59,7 @@
     "@sentry/node": "^10.47.0",
     "@types/passport": "^1.0.17",
     "@types/speakeasy": "^2.0.10",
+    "@types/swagger-ui-express": "4.1.8",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^0.10.9",
     "apollo-server-core": "^3.13.0",
@@ -116,6 +118,7 @@
     "spdy": "^4.0.2",
     "speakeasy": "^2.0.0",
     "stellar-sdk": "^12.3.0",
+    "swagger-ui-express": "5.0.1",
     "twilio": "^5.13.1",
     "ua-parser-js": "^2.0.9",
     "uuid": "^9.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 // Initialize centralized configuration first
 import './config/init';
 
+// Extend Zod with .openapi() — must run before any Zod schema is imported.
+import './openapi/registry';
+
 import "./tracer";
 import path from "path";
 import express, { NextFunction, Request, Response } from "express";
@@ -84,6 +87,7 @@ import tomlRouter from "./routes/toml";
 import feesRouter from "./routes/fees";
 import feeStrategiesRouter from "./routes/feeStrategies";
 import crossChainRouter from "./routes/crossChain";
+import { docsRouter } from "./routes/docs";
 
 // 1. Import Sentry Middleware
 import { initSentry, sentryBreadcrumbMiddleware } from "./middleware/sentry";
@@ -385,6 +389,9 @@ app.use("/sep24", sep24Router);
 app.use("/sep38", sep38Router);
 app.use("/sep12", createSep12Router(pool));
 app.use("/.well-known/stellar.toml", tomlRouter);
+
+// API documentation — development only (404 in production)
+app.use("/docs", docsRouter);
 
 // Prometheus Metrics Scraper Endpoint
 app.get("/metrics", async (req: Request, res: Response) => {

--- a/src/openapi/generator.ts
+++ b/src/openapi/generator.ts
@@ -1,0 +1,71 @@
+/**
+ * OpenAPI document generator.
+ *
+ * Imports all schema and path registration modules (side-effects only),
+ * then generates a fresh OpenAPI 3.0 document from the registry.
+ *
+ * Called at server start — never cached to disk.
+ */
+
+// ── Schema registrations (must run before path registrations) ─────────────────
+import './schemas/common';
+import './schemas/auth';
+import './schemas/transactions';
+import './schemas/vaults';
+import './schemas/contacts';
+import './schemas/fees';
+import './schemas/kyc';
+import './schemas/htlc';
+import './schemas/prices';
+
+// ── Path registrations ────────────────────────────────────────────────────────
+import './paths/auth';
+import './paths/transactions';
+import './paths/vaults';
+import './paths/contacts';
+import './paths/fees';
+import './paths/kyc';
+import './paths/htlc';
+import './paths/prices';
+
+import { OpenApiGeneratorV3 } from '@asteasolutions/zod-to-openapi';
+import { registry } from './registry';
+
+/**
+ * Generate a fresh OpenAPI 3.0 document on every call.
+ * No caching — the spec always reflects the current schema state.
+ */
+export function generateOpenAPIDocument(): Record<string, unknown> {
+  const generator = new OpenApiGeneratorV3(registry.definitions);
+
+  return generator.generateDocument({
+    openapi: '3.0.3',
+    info: {
+      title: 'Mobile Money Bridge API',
+      version: '1.0.0',
+      description:
+        'API for bridging mobile money providers (MTN, Airtel, Orange) with the Stellar network. ' +
+        'This spec is generated at runtime from Zod schemas — it is always in sync with validation logic.',
+      contact: {
+        name: 'API Support',
+      },
+    },
+    servers: [
+      {
+        url: 'http://localhost:3000',
+        description: 'Local development server',
+      },
+    ],
+    tags: [
+      { name: 'Auth', description: 'Authentication and token management' },
+      { name: 'Transactions', description: 'Mobile money ↔ Stellar transactions' },
+      { name: 'Vaults', description: 'Savings vaults' },
+      { name: 'Contacts', description: 'Saved payment contacts' },
+      { name: 'Fees', description: 'Fee configuration' },
+      { name: 'Fee Strategies', description: 'Dynamic fee strategy engine' },
+      { name: 'KYC', description: 'Know Your Customer identity verification' },
+      { name: 'HTLC', description: 'Hash Time-Locked Contracts on Stellar' },
+      { name: 'Prices', description: 'Historical price data' },
+    ],
+  }) as unknown as Record<string, unknown>;
+}

--- a/src/openapi/paths/auth.ts
+++ b/src/openapi/paths/auth.ts
@@ -1,0 +1,154 @@
+/**
+ * OpenAPI path registrations for /api/auth/*
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+import {
+  RegisterRequestSchema,
+  LoginRequestSchema,
+  LoginResponseSchema,
+  RefreshTokenRequestSchema,
+  TokenVerifyRequestSchema,
+} from '../schemas/auth';
+import { ErrorResponseSchema } from '../schemas/common';
+
+const TAG = 'Auth';
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/auth/register',
+  tags: [TAG],
+  summary: 'Register a new user',
+  request: {
+    body: {
+      content: { 'application/json': { schema: RegisterRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      description: 'User registered successfully',
+      content: {
+        'application/json': {
+          schema: z.object({
+            message: z.string().openapi({ example: 'User registered successfully' }),
+            userId: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+          }),
+        },
+      },
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/auth/login',
+  tags: [TAG],
+  summary: 'Authenticate and receive JWT tokens',
+  request: {
+    body: {
+      content: { 'application/json': { schema: LoginRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Login successful',
+      content: { 'application/json': { schema: LoginResponseSchema } },
+    },
+    401: { description: 'Invalid credentials', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    429: { description: 'Account locked due to too many failed attempts', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/auth/refresh',
+  tags: [TAG],
+  summary: 'Rotate refresh token and issue new access token',
+  request: {
+    body: {
+      content: { 'application/json': { schema: RefreshTokenRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Token rotation successful',
+      content: {
+        'application/json': {
+          schema: z.object({
+            message: z.string().openapi({ example: 'Token rotation successful' }),
+            token: z.string(),
+            refreshToken: z.string(),
+          }),
+        },
+      },
+    },
+    401: { description: 'Invalid or expired refresh token', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/auth/verify',
+  tags: [TAG],
+  summary: 'Verify a JWT token',
+  request: {
+    body: {
+      content: { 'application/json': { schema: TokenVerifyRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Token is valid',
+      content: {
+        'application/json': {
+          schema: z.object({
+            valid: z.boolean().openapi({ example: true }),
+            payload: z.record(z.string(), z.unknown()),
+          }),
+        },
+      },
+    },
+    401: { description: 'Token invalid or expired', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/auth/me',
+  tags: [TAG],
+  summary: 'Get current authenticated user',
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: 'Current user info',
+      content: {
+        'application/json': {
+          schema: z.object({
+            user: z.object({
+              userId: z.string().uuid(),
+              email: z.string(),
+              role: z.string(),
+              permissions: z.array(z.string()),
+              total_deposited: z.string(),
+              total_withdrawn: z.string(),
+              current_balance: z.string(),
+            }),
+            tokenInfo: z.object({
+              issuedAt: z.number().optional(),
+              expiresAt: z.number().optional(),
+            }),
+          }),
+        },
+      },
+    },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});

--- a/src/openapi/paths/contacts.ts
+++ b/src/openapi/paths/contacts.ts
@@ -1,0 +1,116 @@
+/**
+ * OpenAPI path registrations for /api/contacts/*
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+import {
+  CreateContactRequestSchema,
+  UpdateContactRequestSchema,
+  ContactSchema,
+} from '../schemas/contacts';
+import { ErrorResponseSchema } from '../schemas/common';
+
+const TAG = 'Contacts';
+const SECURITY = [{ bearerAuth: [] }];
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/contacts',
+  tags: [TAG],
+  summary: 'Create a new contact',
+  security: SECURITY,
+  request: {
+    body: {
+      content: { 'application/json': { schema: CreateContactRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      description: 'Contact created',
+      content: { 'application/json': { schema: ContactSchema } },
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/contacts',
+  tags: [TAG],
+  summary: 'List contacts for the authenticated user',
+  security: SECURITY,
+  responses: {
+    200: {
+      description: 'List of contacts',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(ContactSchema),
+          }),
+        },
+      },
+    },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/contacts/{id}',
+  tags: [TAG],
+  summary: 'Get a contact by ID',
+  security: SECURITY,
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Contact details',
+      content: { 'application/json': { schema: ContactSchema } },
+    },
+    404: { description: 'Contact not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'patch',
+  path: '/api/contacts/{id}',
+  tags: [TAG],
+  summary: 'Update a contact',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { 'application/json': { schema: UpdateContactRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Contact updated',
+      content: { 'application/json': { schema: ContactSchema } },
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    404: { description: 'Contact not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/contacts/{id}',
+  tags: [TAG],
+  summary: 'Delete a contact',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+  },
+  responses: {
+    200: { description: 'Contact deleted' },
+    404: { description: 'Contact not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});

--- a/src/openapi/paths/fees.ts
+++ b/src/openapi/paths/fees.ts
@@ -1,0 +1,218 @@
+/**
+ * OpenAPI path registrations for /api/fees/* and /api/fee-strategies/*
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+import {
+  CreateFeeConfigRequestSchema,
+  FeeEstimateRequestSchema,
+  FeeEstimateResponseSchema,
+  CreateFeeStrategyRequestSchema,
+} from '../schemas/fees';
+import { ErrorResponseSchema } from '../schemas/common';
+
+const SECURITY = [{ bearerAuth: [] }];
+
+// ─── Fee config ───────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/fees/estimate',
+  tags: ['Fees'],
+  summary: 'Estimate fee for a transaction amount',
+  request: {
+    body: {
+      content: { 'application/json': { schema: FeeEstimateRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Fee breakdown',
+      content: { 'application/json': { schema: FeeEstimateResponseSchema } },
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/fees',
+  tags: ['Fees'],
+  summary: 'List all fee configurations (admin)',
+  security: SECURITY,
+  responses: {
+    200: {
+      description: 'List of fee configurations',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(
+              z.object({
+                id: z.string().uuid(),
+                name: z.string(),
+                feePercentage: z.number(),
+                feeMinimum: z.number(),
+                feeMaximum: z.number(),
+                isActive: z.boolean(),
+              }),
+            ),
+          }),
+        },
+      },
+    },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/fees',
+  tags: ['Fees'],
+  summary: 'Create a fee configuration (admin)',
+  security: SECURITY,
+  request: {
+    body: {
+      content: { 'application/json': { schema: CreateFeeConfigRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: { description: 'Fee configuration created' },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+// ─── Fee strategies ───────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/fee-strategies/calculate',
+  tags: ['Fee Strategies'],
+  summary: 'Calculate fee using the strategy engine',
+  request: {
+    body: {
+      content: { 'application/json': { schema: FeeEstimateRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Calculated fee',
+      content: { 'application/json': { schema: FeeEstimateResponseSchema } },
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/fee-strategies',
+  tags: ['Fee Strategies'],
+  summary: 'List all fee strategies (admin)',
+  security: SECURITY,
+  responses: {
+    200: { description: 'List of fee strategies' },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/fee-strategies',
+  tags: ['Fee Strategies'],
+  summary: 'Create a fee strategy (admin)',
+  security: SECURITY,
+  request: {
+    body: {
+      content: { 'application/json': { schema: CreateFeeStrategyRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: { description: 'Fee strategy created' },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/fee-strategies/{id}',
+  tags: ['Fee Strategies'],
+  summary: 'Get a fee strategy by ID (admin)',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+  },
+  responses: {
+    200: { description: 'Fee strategy details' },
+    404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/api/fee-strategies/{id}',
+  tags: ['Fee Strategies'],
+  summary: 'Update a fee strategy (admin)',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { 'application/json': { schema: CreateFeeStrategyRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: { description: 'Fee strategy updated' },
+    404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/fee-strategies/{id}',
+  tags: ['Fee Strategies'],
+  summary: 'Delete a fee strategy (admin)',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+  },
+  responses: {
+    200: { description: 'Fee strategy deleted' },
+    404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/fee-strategies/{id}/activate',
+  tags: ['Fee Strategies'],
+  summary: 'Activate a fee strategy (admin)',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+  },
+  responses: {
+    200: { description: 'Strategy activated' },
+    404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/fee-strategies/{id}/deactivate',
+  tags: ['Fee Strategies'],
+  summary: 'Deactivate a fee strategy (admin)',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+  },
+  responses: {
+    200: { description: 'Strategy deactivated' },
+    404: { description: 'Not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});

--- a/src/openapi/paths/htlc.ts
+++ b/src/openapi/paths/htlc.ts
@@ -1,0 +1,98 @@
+/**
+ * OpenAPI path registrations for /api/htlc/*
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+import {
+  HtlcLockRequestSchema,
+  HtlcClaimRequestSchema,
+  HtlcRefundRequestSchema,
+  HtlcTransactionResponseSchema,
+} from '../schemas/htlc';
+import { ErrorResponseSchema } from '../schemas/common';
+
+const TAG = 'HTLC';
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/htlc/lock',
+  tags: [TAG],
+  summary: 'Build a Stellar HTLC lock transaction',
+  request: {
+    body: {
+      content: { 'application/json': { schema: HtlcLockRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Lock transaction XDR',
+      content: { 'application/json': { schema: HtlcTransactionResponseSchema } },
+    },
+    400: { description: 'Invalid parameters', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/htlc/claim',
+  tags: [TAG],
+  summary: 'Build a Stellar HTLC claim transaction',
+  request: {
+    body: {
+      content: { 'application/json': { schema: HtlcClaimRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Claim transaction XDR',
+      content: { 'application/json': { schema: HtlcTransactionResponseSchema } },
+    },
+    400: { description: 'Invalid parameters', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/htlc/refund',
+  tags: [TAG],
+  summary: 'Build a Stellar HTLC refund transaction',
+  request: {
+    body: {
+      content: { 'application/json': { schema: HtlcRefundRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Refund transaction XDR',
+      content: { 'application/json': { schema: HtlcTransactionResponseSchema } },
+    },
+    400: { description: 'Invalid parameters', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/htlc/{contractId}',
+  tags: [TAG],
+  summary: 'Get HTLC contract state',
+  request: {
+    params: z.object({
+      contractId: z.string().openapi({ example: 'contract_abc123' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'HTLC contract state',
+      content: {
+        'application/json': {
+          schema: z.record(z.string(), z.unknown()),
+        },
+      },
+    },
+    400: { description: 'Error fetching state', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});

--- a/src/openapi/paths/kyc.ts
+++ b/src/openapi/paths/kyc.ts
@@ -1,0 +1,78 @@
+/**
+ * OpenAPI path registrations for /api/kyc/*
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+import {
+  CreateKYCApplicantRequestSchema,
+  KYCApplicantResponseSchema,
+  UploadKYCDocumentRequestSchema,
+} from '../schemas/kyc';
+import { ErrorResponseSchema } from '../schemas/common';
+
+const TAG = 'KYC';
+const SECURITY = [{ bearerAuth: [] }];
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/kyc/applicants',
+  tags: [TAG],
+  summary: 'Create a KYC applicant',
+  security: SECURITY,
+  request: {
+    body: {
+      content: { 'application/json': { schema: CreateKYCApplicantRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      description: 'Applicant created',
+      content: { 'application/json': { schema: KYCApplicantResponseSchema } },
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/kyc/documents',
+  tags: [TAG],
+  summary: 'Upload a KYC identity document',
+  security: SECURITY,
+  request: {
+    body: {
+      content: { 'application/json': { schema: UploadKYCDocumentRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: { description: 'Document uploaded' },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/kyc/status',
+  tags: [TAG],
+  summary: 'Get KYC status for the authenticated user',
+  security: SECURITY,
+  responses: {
+    200: {
+      description: 'KYC status',
+      content: {
+        'application/json': {
+          schema: z.object({
+            level: z.enum(['none', 'basic', 'full']).openapi({ example: 'basic' }),
+            status: z.enum(['pending', 'approved', 'rejected', 'review']).openapi({ example: 'approved' }),
+          }),
+        },
+      },
+    },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});

--- a/src/openapi/paths/prices.ts
+++ b/src/openapi/paths/prices.ts
@@ -1,0 +1,77 @@
+/**
+ * OpenAPI path registrations for /api/v1/prices/*
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+import { PriceSnapshotSchema, PriceListResponseSchema } from '../schemas/prices';
+import { ErrorResponseSchema } from '../schemas/common';
+
+const TAG = 'Prices';
+const CURRENCY_ENUM = z.enum(['USD', 'XLM', 'XAF']);
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/prices/latest',
+  tags: [TAG],
+  summary: 'Get the latest price snapshot for a currency pair',
+  request: {
+    query: z.object({
+      base: CURRENCY_ENUM.openapi({ example: 'XLM' }),
+      quote: CURRENCY_ENUM.openapi({ example: 'USD' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Latest price snapshot',
+      content: { 'application/json': { schema: PriceSnapshotSchema } },
+    },
+    400: { description: 'Invalid query parameters', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    404: { description: 'No price data for this pair', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/prices/history',
+  tags: [TAG],
+  summary: 'Get price history for a currency pair within a date range',
+  request: {
+    query: z.object({
+      base: CURRENCY_ENUM.openapi({ example: 'XLM' }),
+      quote: CURRENCY_ENUM.openapi({ example: 'USD' }),
+      from: z.string().datetime().openapi({ example: '2024-04-01T00:00:00.000Z' }),
+      to: z.string().datetime().openapi({ example: '2024-04-25T23:59:59.000Z' }),
+      limit: z.coerce.number().int().positive().max(1000).optional().openapi({ example: 100 }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Price history',
+      content: { 'application/json': { schema: PriceListResponseSchema } },
+    },
+    400: { description: 'Invalid query parameters', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/prices/at',
+  tags: [TAG],
+  summary: 'Get the price nearest to a specific point in time',
+  request: {
+    query: z.object({
+      base: CURRENCY_ENUM.openapi({ example: 'XLM' }),
+      quote: CURRENCY_ENUM.openapi({ example: 'USD' }),
+      at: z.string().datetime().openapi({ example: '2024-04-15T12:00:00.000Z' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Nearest price snapshot',
+      content: { 'application/json': { schema: PriceSnapshotSchema } },
+    },
+    400: { description: 'Invalid query parameters', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    404: { description: 'No price data found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});

--- a/src/openapi/paths/transactions.ts
+++ b/src/openapi/paths/transactions.ts
@@ -1,0 +1,214 @@
+/**
+ * OpenAPI path registrations for /api/transactions/* and /api/v1/transactions/*
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+import {
+  TransactionRequestSchema,
+  TransactionResponseSchema,
+  TransactionDetailSchema,
+  TransactionListResponseSchema,
+  UpdateNotesRequestSchema,
+  MetadataRequestSchema,
+  DeleteMetadataKeysRequestSchema,
+} from '../schemas/transactions';
+import { ErrorResponseSchema } from '../schemas/common';
+
+const TAG = 'Transactions';
+const SECURITY = [{ bearerAuth: [] }];
+
+// ─── Deposit ──────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/v1/transactions/deposit',
+  tags: [TAG],
+  summary: 'Initiate a mobile money deposit to Stellar',
+  security: SECURITY,
+  request: {
+    body: {
+      content: { 'application/json': { schema: TransactionRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Deposit initiated',
+      content: { 'application/json': { schema: TransactionResponseSchema } },
+    },
+    400: { description: 'Validation error or limit exceeded', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+// ─── Withdraw ─────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/v1/transactions/withdraw',
+  tags: [TAG],
+  summary: 'Initiate a Stellar withdrawal to mobile money',
+  security: SECURITY,
+  request: {
+    body: {
+      content: { 'application/json': { schema: TransactionRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Withdrawal initiated',
+      content: { 'application/json': { schema: TransactionResponseSchema } },
+    },
+    400: { description: 'Validation error or limit exceeded', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+// ─── List transactions ────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/transactions',
+  tags: [TAG],
+  summary: 'List transactions with pagination',
+  security: SECURITY,
+  request: {
+    query: z.object({
+      limit: z.coerce.number().int().positive().max(100).optional().openapi({ example: 20 }),
+      offset: z.coerce.number().int().min(0).optional().openapi({ example: 0 }),
+      before: z.string().optional().openapi({ description: 'Cursor for backward pagination' }),
+      after: z.string().optional().openapi({ description: 'Cursor for forward pagination' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Paginated list of transactions',
+      content: { 'application/json': { schema: TransactionListResponseSchema } },
+    },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+// ─── Get transaction ──────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/transactions/{id}',
+  tags: [TAG],
+  summary: 'Get a single transaction by ID',
+  security: SECURITY,
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Transaction details',
+      content: { 'application/json': { schema: TransactionDetailSchema } },
+    },
+    404: { description: 'Transaction not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+// ─── Cancel transaction ───────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/v1/transactions/{id}/cancel',
+  tags: [TAG],
+  summary: 'Cancel a pending transaction',
+  security: SECURITY,
+  request: {
+    params: z.object({
+      id: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+    }),
+  },
+  responses: {
+    200: { description: 'Transaction cancelled' },
+    400: { description: 'Cannot cancel transaction in current state', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    404: { description: 'Transaction not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+// ─── Update notes ─────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'patch',
+  path: '/api/v1/transactions/{id}/notes',
+  tags: [TAG],
+  summary: 'Update transaction notes',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { 'application/json': { schema: UpdateNotesRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: { description: 'Notes updated' },
+    404: { description: 'Transaction not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+// ─── Metadata ─────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'put',
+  path: '/api/v1/transactions/{id}/metadata',
+  tags: [TAG],
+  summary: 'Replace transaction metadata',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { 'application/json': { schema: MetadataRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: { description: 'Metadata replaced' },
+    404: { description: 'Transaction not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'patch',
+  path: '/api/v1/transactions/{id}/metadata',
+  tags: [TAG],
+  summary: 'Merge transaction metadata keys',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { 'application/json': { schema: MetadataRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: { description: 'Metadata merged' },
+    404: { description: 'Transaction not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/v1/transactions/{id}/metadata',
+  tags: [TAG],
+  summary: 'Delete specific metadata keys from a transaction',
+  security: SECURITY,
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { 'application/json': { schema: DeleteMetadataKeysRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: { description: 'Metadata keys deleted' },
+    404: { description: 'Transaction not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});

--- a/src/openapi/paths/vaults.ts
+++ b/src/openapi/paths/vaults.ts
@@ -1,0 +1,212 @@
+/**
+ * OpenAPI path registrations for /api/vaults/* and /api/v1/vaults/*
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+import {
+  CreateVaultRequestSchema,
+  UpdateVaultRequestSchema,
+  VaultTransferRequestSchema,
+  VaultResponseSchema,
+  VaultListResponseSchema,
+} from '../schemas/vaults';
+import { ErrorResponseSchema, PaginationSchema } from '../schemas/common';
+
+const TAG = 'Vaults';
+const SECURITY = [{ bearerAuth: [] }];
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/v1/vaults',
+  tags: [TAG],
+  summary: 'Create a new savings vault',
+  security: SECURITY,
+  request: {
+    body: {
+      content: { 'application/json': { schema: CreateVaultRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      description: 'Vault created',
+      content: { 'application/json': { schema: VaultResponseSchema } },
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    409: { description: 'Vault name already exists', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/vaults',
+  tags: [TAG],
+  summary: 'List all vaults for the authenticated user',
+  security: SECURITY,
+  request: {
+    query: z.object({
+      includeInactive: z.enum(['true', 'false']).optional().openapi({ example: 'false' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'List of vaults',
+      content: { 'application/json': { schema: VaultListResponseSchema } },
+    },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/vaults/balance-summary',
+  tags: [TAG],
+  summary: 'Get aggregated balance summary across all vaults',
+  security: SECURITY,
+  responses: {
+    200: {
+      description: 'Balance summary',
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean(),
+            data: z.object({
+              totalBalance: z.string().openapi({ example: '1500.00' }),
+              vaultCount: z.number().int().openapi({ example: 3 }),
+            }),
+          }),
+        },
+      },
+    },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/vaults/{vaultId}',
+  tags: [TAG],
+  summary: 'Get a vault by ID',
+  security: SECURITY,
+  request: {
+    params: z.object({
+      vaultId: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Vault details',
+      content: { 'application/json': { schema: VaultResponseSchema } },
+    },
+    403: { description: 'Access denied', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    404: { description: 'Vault not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/api/v1/vaults/{vaultId}',
+  tags: [TAG],
+  summary: 'Update a vault',
+  security: SECURITY,
+  request: {
+    params: z.object({ vaultId: z.string().uuid() }),
+    body: {
+      content: { 'application/json': { schema: UpdateVaultRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Vault updated',
+      content: { 'application/json': { schema: VaultResponseSchema } },
+    },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    403: { description: 'Access denied', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    404: { description: 'Vault not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'delete',
+  path: '/api/v1/vaults/{vaultId}',
+  tags: [TAG],
+  summary: 'Delete a vault',
+  security: SECURITY,
+  request: {
+    params: z.object({ vaultId: z.string().uuid() }),
+  },
+  responses: {
+    200: { description: 'Vault deleted' },
+    400: { description: 'Cannot delete vault (non-zero balance)', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    403: { description: 'Access denied', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    404: { description: 'Vault not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: '/api/v1/vaults/{vaultId}/transfer',
+  tags: [TAG],
+  summary: 'Deposit or withdraw funds from a vault',
+  security: SECURITY,
+  request: {
+    params: z.object({ vaultId: z.string().uuid() }),
+    body: {
+      content: { 'application/json': { schema: VaultTransferRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Transfer completed',
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean(),
+            data: z.object({
+              vault: z.record(z.string(), z.unknown()),
+              transaction: z.record(z.string(), z.unknown()),
+            }),
+          }),
+        },
+      },
+    },
+    400: { description: 'Insufficient funds or validation error', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    403: { description: 'Access denied', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    404: { description: 'Vault not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v1/vaults/{vaultId}/transactions',
+  tags: [TAG],
+  summary: 'List transactions for a vault',
+  security: SECURITY,
+  request: {
+    params: z.object({ vaultId: z.string().uuid() }),
+    query: z.object({
+      limit: z.coerce.number().int().positive().max(100).optional().openapi({ example: 50 }),
+      offset: z.coerce.number().int().min(0).optional().openapi({ example: 0 }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Vault transaction history',
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean(),
+            data: z.array(z.record(z.string(), z.unknown())),
+            pagination: PaginationSchema,
+          }),
+        },
+      },
+    },
+    403: { description: 'Access denied', content: { 'application/json': { schema: ErrorResponseSchema } } },
+    404: { description: 'Vault not found', content: { 'application/json': { schema: ErrorResponseSchema } } },
+  },
+});

--- a/src/openapi/registry.ts
+++ b/src/openapi/registry.ts
@@ -1,0 +1,19 @@
+/**
+ * Central OpenAPI registry.
+ *
+ * This file MUST be imported before any Zod schema is used so that
+ * extendZodWithOpenApi() runs first and the .openapi() method is available
+ * on every Zod type.
+ *
+ * Import order in src/index.ts:
+ *   import './openapi/registry';   ← first
+ *   import { z } from 'zod';       ← after
+ */
+
+import { extendZodWithOpenApi, OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+// Extend Zod once, globally.
+extendZodWithOpenApi(z);
+
+export const registry = new OpenAPIRegistry();

--- a/src/openapi/schemas/auth.ts
+++ b/src/openapi/schemas/auth.ts
@@ -1,0 +1,68 @@
+/**
+ * Auth domain schemas — derived from src/routes/auth.ts
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+
+export const RegisterRequestSchema = registry.register(
+  'RegisterRequest',
+  z
+    .object({
+      phone_number: z.string().min(1).openapi({ example: '+237670000000' }),
+      password: z
+        .string()
+        .min(12)
+        .openapi({
+          example: 'Str0ng!Pass#2024',
+          description:
+            'Minimum 12 characters, must include uppercase, lowercase, and a special character.',
+        }),
+    })
+    .openapi('RegisterRequest'),
+);
+
+export const LoginRequestSchema = registry.register(
+  'LoginRequest',
+  z
+    .object({
+      phone_number: z.string().openapi({ example: '+237670000000' }),
+      password: z.string().openapi({ example: 'Str0ng!Pass#2024' }),
+    })
+    .openapi('LoginRequest'),
+);
+
+export const LoginResponseSchema = registry.register(
+  'LoginResponse',
+  z
+    .object({
+      message: z.string().openapi({ example: 'Login successful' }),
+      token: z.string().openapi({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' }),
+      refreshToken: z.string().openapi({ example: 'dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4...' }),
+      user: z.object({
+        userId: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+        email: z.string().openapi({ example: '+237670000000' }),
+        role: z.string().openapi({ example: 'user' }),
+        permissions: z.array(z.string()).openapi({ example: ['read:transactions'] }),
+      }),
+    })
+    .openapi('LoginResponse'),
+);
+
+export const RefreshTokenRequestSchema = registry.register(
+  'RefreshTokenRequest',
+  z
+    .object({
+      refreshToken: z.string().openapi({ example: 'dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4...' }),
+    })
+    .openapi('RefreshTokenRequest'),
+);
+
+export const TokenVerifyRequestSchema = registry.register(
+  'TokenVerifyRequest',
+  z
+    .object({
+      token: z.string().openapi({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' }),
+    })
+    .openapi('TokenVerifyRequest'),
+);

--- a/src/openapi/schemas/common.ts
+++ b/src/openapi/schemas/common.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared / reusable OpenAPI component schemas.
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+
+// ─── Error response ───────────────────────────────────────────────────────────
+
+export const ErrorResponseSchema = registry.register(
+  'ErrorResponse',
+  z
+    .object({
+      error: z.string().openapi({ example: 'Validation failed' }),
+      message: z.string().optional().openapi({ example: 'Amount must be a positive number' }),
+    })
+    .openapi('ErrorResponse', { description: 'Standard error envelope' }),
+);
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+export const PaginationSchema = registry.register(
+  'Pagination',
+  z
+    .object({
+      limit: z.number().int().openapi({ example: 50 }),
+      offset: z.number().int().openapi({ example: 0 }),
+      hasMore: z.boolean().openapi({ example: false }),
+    })
+    .openapi('Pagination'),
+);
+
+// ─── Security scheme ─────────────────────────────────────────────────────────
+
+registry.registerComponent('securitySchemes', 'bearerAuth', {
+  type: 'http',
+  scheme: 'bearer',
+  bearerFormat: 'JWT',
+});

--- a/src/openapi/schemas/contacts.ts
+++ b/src/openapi/schemas/contacts.ts
@@ -1,0 +1,52 @@
+/**
+ * Contacts domain schemas — derived from src/routes/contacts.ts
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+
+export const CreateContactRequestSchema = registry.register(
+  'CreateContactRequest',
+  z
+    .object({
+      destinationType: z.enum(['phone', 'stellar']).openapi({ example: 'phone' }),
+      destinationValue: z
+        .string()
+        .min(1)
+        .openapi({
+          example: '+237670000000',
+          description: 'E.164 phone number or Stellar public key depending on destinationType',
+        }),
+      nickname: z.string().min(1).max(100).openapi({ example: 'Mom' }),
+    })
+    .openapi('CreateContactRequest'),
+);
+
+export const UpdateContactRequestSchema = registry.register(
+  'UpdateContactRequest',
+  z
+    .object({
+      destinationType: z.enum(['phone', 'stellar']).optional().openapi({ example: 'stellar' }),
+      destinationValue: z
+        .string()
+        .min(1)
+        .optional()
+        .openapi({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN' }),
+      nickname: z.string().min(1).max(100).optional().openapi({ example: 'Dad' }),
+    })
+    .openapi('UpdateContactRequest'),
+);
+
+export const ContactSchema = registry.register(
+  'Contact',
+  z
+    .object({
+      id: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+      userId: z.string().uuid().openapi({ example: 'b2c3d4e5-f6a7-8901-bcde-f12345678901' }),
+      destinationType: z.enum(['phone', 'stellar']).openapi({ example: 'phone' }),
+      destinationValue: z.string().openapi({ example: '+237670000000' }),
+      nickname: z.string().openapi({ example: 'Mom' }),
+      createdAt: z.string().datetime().openapi({ example: '2024-04-25T10:00:00.000Z' }),
+    })
+    .openapi('Contact'),
+);

--- a/src/openapi/schemas/fees.ts
+++ b/src/openapi/schemas/fees.ts
@@ -1,0 +1,78 @@
+/**
+ * Fees domain schemas — derived from src/routes/fees.ts and src/routes/feeStrategies.ts
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+
+// ─── Fee config ───────────────────────────────────────────────────────────────
+
+export const CreateFeeConfigRequestSchema = registry.register(
+  'CreateFeeConfigRequest',
+  z
+    .object({
+      name: z.string().min(1).max(100).openapi({ example: 'Standard Fee' }),
+      description: z.string().optional().openapi({ example: 'Default fee for all users' }),
+      feePercentage: z.number().min(0).max(100).openapi({ example: 1.5 }),
+      feeMinimum: z.number().min(0).openapi({ example: 50 }),
+      feeMaximum: z.number().min(0).openapi({ example: 5000 }),
+    })
+    .openapi('CreateFeeConfigRequest'),
+);
+
+export const FeeEstimateRequestSchema = registry.register(
+  'FeeEstimateRequest',
+  z
+    .object({
+      amount: z.number().positive().openapi({ example: 10000 }),
+      userId: z.string().uuid().optional().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+      transactionType: z
+        .enum(['send', 'deposit', 'withdraw', 'payment'])
+        .optional()
+        .openapi({ example: 'deposit' }),
+    })
+    .openapi('FeeEstimateRequest'),
+);
+
+export const FeeEstimateResponseSchema = registry.register(
+  'FeeEstimateResponse',
+  z
+    .object({
+      amount: z.number().openapi({ example: 10000 }),
+      fee: z.number().openapi({ example: 150 }),
+      netAmount: z.number().openapi({ example: 9850 }),
+      feePercentage: z.number().openapi({ example: 1.5 }),
+    })
+    .openapi('FeeEstimateResponse'),
+);
+
+// ─── Fee strategy ─────────────────────────────────────────────────────────────
+
+export const VolumeTierSchema = registry.register(
+  'VolumeTier',
+  z
+    .object({
+      minAmount: z.number().min(0).openapi({ example: 0 }),
+      maxAmount: z.number().positive().nullable().openapi({ example: 100000 }),
+      feePercentage: z.number().min(0).max(100).optional().openapi({ example: 2.0 }),
+      flatAmount: z.number().min(0).optional().openapi({ example: 100 }),
+    })
+    .openapi('VolumeTier'),
+);
+
+export const CreateFeeStrategyRequestSchema = registry.register(
+  'CreateFeeStrategyRequest',
+  z
+    .object({
+      name: z.string().min(1).max(100).openapi({ example: 'Weekend Discount' }),
+      description: z.string().optional().openapi({ example: 'Reduced fees on weekends' }),
+      strategyType: z
+        .enum(['flat', 'percentage', 'time_based', 'volume_based'])
+        .openapi({ example: 'percentage' }),
+      scope: z.enum(['user', 'provider', 'global']).openapi({ example: 'global' }),
+      feePercentage: z.number().min(0).max(100).optional().openapi({ example: 1.0 }),
+      flatAmount: z.number().min(0).optional().openapi({ example: 50 }),
+      volumeTiers: z.array(VolumeTierSchema).optional(),
+    })
+    .openapi('CreateFeeStrategyRequest'),
+);

--- a/src/openapi/schemas/htlc.ts
+++ b/src/openapi/schemas/htlc.ts
@@ -1,0 +1,52 @@
+/**
+ * HTLC domain schemas — derived from src/routes/htlc.ts
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+
+export const HtlcLockRequestSchema = registry.register(
+  'HtlcLockRequest',
+  z
+    .object({
+      senderAddress: z.string().openapi({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN' }),
+      receiverAddress: z.string().openapi({ example: 'GBVVJJWVHSN5BKPKODEOQHKZXQMQFZAZDXQMQFZAZDXQMQFZAZDXQMQ' }),
+      tokenAddress: z.string().openapi({ example: 'USDC' }),
+      amount: z.string().openapi({ example: '100.00' }),
+      hashlock: z.string().length(64).openapi({ example: 'a'.repeat(64), description: '64-char hex hash' }),
+      timelock: z.number().openapi({ example: 1714000000, description: 'Unix timestamp' }),
+      contractId: z.string().openapi({ example: 'contract_abc123' }),
+    })
+    .openapi('HtlcLockRequest'),
+);
+
+export const HtlcClaimRequestSchema = registry.register(
+  'HtlcClaimRequest',
+  z
+    .object({
+      claimerAddress: z.string().openapi({ example: 'GBVVJJWVHSN5BKPKODEOQHKZXQMQFZAZDXQMQFZAZDXQMQFZAZDXQMQ' }),
+      preimage: z.string().length(64).openapi({ example: 'b'.repeat(64), description: '64-char hex preimage' }),
+      contractId: z.string().openapi({ example: 'contract_abc123' }),
+    })
+    .openapi('HtlcClaimRequest'),
+);
+
+export const HtlcRefundRequestSchema = registry.register(
+  'HtlcRefundRequest',
+  z
+    .object({
+      refunderAddress: z.string().openapi({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN' }),
+      contractId: z.string().openapi({ example: 'contract_abc123' }),
+    })
+    .openapi('HtlcRefundRequest'),
+);
+
+export const HtlcTransactionResponseSchema = registry.register(
+  'HtlcTransactionResponse',
+  z
+    .object({
+      xdr: z.string().openapi({ description: 'Base64-encoded Stellar XDR transaction envelope' }),
+      hash: z.string().openapi({ description: 'Hex-encoded transaction hash' }),
+    })
+    .openapi('HtlcTransactionResponse'),
+);

--- a/src/openapi/schemas/kyc.ts
+++ b/src/openapi/schemas/kyc.ts
@@ -1,0 +1,65 @@
+/**
+ * KYC domain schemas — derived from src/controllers/kycController.ts
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+
+export const KYCAddressSchema = registry.register(
+  'KYCAddress',
+  z
+    .object({
+      street: z.string().min(1).openapi({ example: '123 Main St' }),
+      town: z.string().min(1).openapi({ example: 'Douala' }),
+      postcode: z.string().min(1).openapi({ example: '00237' }),
+      country: z.string().length(3).openapi({ example: 'CMR', description: 'ISO 3166-1 alpha-3' }),
+      state: z.string().optional().openapi({ example: 'Littoral' }),
+      building_number: z.string().optional().openapi({ example: '12' }),
+      flat_number: z.string().optional(),
+    })
+    .openapi('KYCAddress'),
+);
+
+export const CreateKYCApplicantRequestSchema = registry.register(
+  'CreateKYCApplicantRequest',
+  z
+    .object({
+      first_name: z.string().min(1).openapi({ example: 'Jean' }),
+      last_name: z.string().min(1).openapi({ example: 'Dupont' }),
+      email: z.string().email().optional().openapi({ example: 'jean.dupont@example.com' }),
+      dob: z.string().optional().openapi({ example: '1990-01-15', description: 'YYYY-MM-DD' }),
+      phone_number: z.string().optional().openapi({ example: '+237670000000' }),
+      address: KYCAddressSchema.optional(),
+    })
+    .openapi('CreateKYCApplicantRequest'),
+);
+
+export const KYCApplicantResponseSchema = registry.register(
+  'KYCApplicantResponse',
+  z
+    .object({
+      success: z.boolean().openapi({ example: true }),
+      data: z.object({
+        applicantId: z.string().openapi({ example: 'applicant_abc123' }),
+        status: z
+          .enum(['pending', 'approved', 'rejected', 'review'])
+          .openapi({ example: 'pending' }),
+      }),
+    })
+    .openapi('KYCApplicantResponse'),
+);
+
+export const UploadKYCDocumentRequestSchema = registry.register(
+  'UploadKYCDocumentRequest',
+  z
+    .object({
+      applicant_id: z.string().openapi({ example: 'applicant_abc123' }),
+      type: z
+        .enum(['passport', 'driving_license', 'national_identity_card', 'residence_permit'])
+        .openapi({ example: 'passport' }),
+      side: z.enum(['front', 'back']).optional().openapi({ example: 'front' }),
+      filename: z.string().min(1).openapi({ example: 'passport_front.jpg' }),
+      data: z.string().min(1).openapi({ description: 'Base64-encoded document image' }),
+    })
+    .openapi('UploadKYCDocumentRequest'),
+);

--- a/src/openapi/schemas/prices.ts
+++ b/src/openapi/schemas/prices.ts
@@ -1,0 +1,29 @@
+/**
+ * Price history domain schemas — derived from src/routes/priceHistory.ts
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+
+export const PriceSnapshotSchema = registry.register(
+  'PriceSnapshot',
+  z
+    .object({
+      id: z.string().openapi({ example: '1' }),
+      base: z.string().openapi({ example: 'XLM' }),
+      quote: z.string().openapi({ example: 'USD' }),
+      price: z.number().openapi({ example: 0.1234 }),
+      recordedAt: z.string().datetime().openapi({ example: '2024-04-25T10:00:00.000Z' }),
+    })
+    .openapi('PriceSnapshot'),
+);
+
+export const PriceListResponseSchema = registry.register(
+  'PriceListResponse',
+  z
+    .object({
+      data: z.array(PriceSnapshotSchema),
+      count: z.number().int().openapi({ example: 48 }),
+    })
+    .openapi('PriceListResponse'),
+);

--- a/src/openapi/schemas/transactions.ts
+++ b/src/openapi/schemas/transactions.ts
@@ -1,0 +1,115 @@
+/**
+ * Transaction domain schemas — derived from src/controllers/transactionController.ts
+ * and src/middleware/validateTransaction.ts
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+
+export const TransactionRequestSchema = registry.register(
+  'TransactionRequest',
+  z
+    .object({
+      amount: z.number().positive().openapi({ example: 5000 }),
+      phoneNumber: z
+        .string()
+        .regex(/^\+?\d{10,15}$/)
+        .openapi({ example: '+237670000000', description: 'E.164 or local format phone number' }),
+      provider: z.enum(['mtn', 'airtel', 'orange']).openapi({ example: 'mtn' }),
+      stellarAddress: z
+        .string()
+        .regex(/^G[A-Z2-7]{55}$/)
+        .openapi({
+          example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+          description: 'Stellar public key (56 chars, starts with G)',
+        }),
+      userId: z.string().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+      notes: z.string().max(256).optional().openapi({ example: 'School fees payment' }),
+    })
+    .openapi('TransactionRequest'),
+);
+
+export const TransactionResponseSchema = registry.register(
+  'TransactionResponse',
+  z
+    .object({
+      success: z.boolean().openapi({ example: true }),
+      transactionId: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+      referenceNumber: z.string().openapi({ example: 'TXN-20240425-001' }),
+      status: z
+        .enum(['pending', 'processing', 'completed', 'failed', 'cancelled'])
+        .openapi({ example: 'pending' }),
+      amount: z.number().openapi({ example: 5000 }),
+      provider: z.string().openapi({ example: 'mtn' }),
+      createdAt: z.string().datetime().openapi({ example: '2024-04-25T10:00:00.000Z' }),
+    })
+    .openapi('TransactionResponse'),
+);
+
+export const TransactionDetailSchema = registry.register(
+  'TransactionDetail',
+  z
+    .object({
+      id: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+      referenceNumber: z.string().openapi({ example: 'TXN-20240425-001' }),
+      type: z.enum(['deposit', 'withdraw']).openapi({ example: 'deposit' }),
+      status: z
+        .enum(['pending', 'processing', 'completed', 'failed', 'cancelled'])
+        .openapi({ example: 'completed' }),
+      amount: z.number().openapi({ example: 5000 }),
+      provider: z.string().openapi({ example: 'mtn' }),
+      phoneNumber: z.string().openapi({ example: '+237670000000' }),
+      stellarAddress: z.string().openapi({
+        example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      }),
+      notes: z.string().optional().openapi({ example: 'School fees payment' }),
+      metadata: z.record(z.string(), z.unknown()).optional(),
+      createdAt: z.string().datetime().openapi({ example: '2024-04-25T10:00:00.000Z' }),
+      updatedAt: z.string().datetime().openapi({ example: '2024-04-25T10:05:00.000Z' }),
+    })
+    .openapi('TransactionDetail'),
+);
+
+export const TransactionListResponseSchema = registry.register(
+  'TransactionListResponse',
+  z
+    .object({
+      success: z.boolean().openapi({ example: true }),
+      data: z.array(TransactionDetailSchema),
+      pagination: z.object({
+        total: z.number().int().openapi({ example: 120 }),
+        limit: z.number().int().openapi({ example: 20 }),
+        offset: z.number().int().openapi({ example: 0 }),
+      }),
+    })
+    .openapi('TransactionListResponse'),
+);
+
+export const UpdateNotesRequestSchema = registry.register(
+  'UpdateNotesRequest',
+  z
+    .object({
+      notes: z.string().max(256).openapi({ example: 'Updated payment note' }),
+    })
+    .openapi('UpdateNotesRequest'),
+);
+
+export const MetadataRequestSchema = registry.register(
+  'MetadataRequest',
+  z
+    .object({
+      metadata: z.record(z.string(), z.unknown()).openapi({
+        example: { category: 'utilities', invoiceId: 'INV-001' },
+      }),
+    })
+    .openapi('MetadataRequest'),
+);
+
+export const DeleteMetadataKeysRequestSchema = registry.register(
+  'DeleteMetadataKeysRequest',
+  z
+    .object({
+      keys: z.array(z.string()).openapi({ example: ['category', 'invoiceId'] }),
+    })
+    .openapi('DeleteMetadataKeysRequest'),
+);

--- a/src/openapi/schemas/vaults.ts
+++ b/src/openapi/schemas/vaults.ts
@@ -1,0 +1,88 @@
+/**
+ * Vault domain schemas — derived from src/controllers/vaultController.ts
+ */
+
+import { z } from 'zod';
+import { registry } from '../registry';
+
+export const CreateVaultRequestSchema = registry.register(
+  'CreateVaultRequest',
+  z
+    .object({
+      name: z.string().min(1).max(100).openapi({ example: 'Emergency Fund' }),
+      description: z.string().max(1000).optional().openapi({ example: 'Savings for emergencies' }),
+      targetAmount: z
+        .string()
+        .regex(/^\d+(\.\d{1,7})?$/)
+        .optional()
+        .openapi({ example: '1000.00', description: 'Target savings amount (decimal string)' }),
+    })
+    .openapi('CreateVaultRequest'),
+);
+
+export const UpdateVaultRequestSchema = registry.register(
+  'UpdateVaultRequest',
+  z
+    .object({
+      name: z.string().min(1).max(100).optional().openapi({ example: 'Emergency Fund v2' }),
+      description: z.string().max(1000).optional().openapi({ example: 'Updated description' }),
+      targetAmount: z
+        .string()
+        .regex(/^\d+(\.\d{1,7})?$/)
+        .optional()
+        .openapi({ example: '2000.00' }),
+      isActive: z.boolean().optional().openapi({ example: true }),
+    })
+    .openapi('UpdateVaultRequest'),
+);
+
+export const VaultTransferRequestSchema = registry.register(
+  'VaultTransferRequest',
+  z
+    .object({
+      amount: z
+        .string()
+        .regex(/^\d+(\.\d{1,7})?$/)
+        .openapi({ example: '250.00', description: 'Amount to deposit or withdraw' }),
+      type: z.enum(['deposit', 'withdraw']).openapi({ example: 'deposit' }),
+      description: z.string().max(500).optional().openapi({ example: 'Monthly savings' }),
+    })
+    .openapi('VaultTransferRequest'),
+);
+
+export const VaultSchema = registry.register(
+  'Vault',
+  z
+    .object({
+      id: z.string().uuid().openapi({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' }),
+      userId: z.string().uuid().openapi({ example: 'b2c3d4e5-f6a7-8901-bcde-f12345678901' }),
+      name: z.string().openapi({ example: 'Emergency Fund' }),
+      description: z.string().optional().openapi({ example: 'Savings for emergencies' }),
+      balance: z.string().openapi({ example: '500.00' }),
+      targetAmount: z.string().optional().openapi({ example: '1000.00' }),
+      isActive: z.boolean().openapi({ example: true }),
+      createdAt: z.string().datetime().openapi({ example: '2024-04-25T10:00:00.000Z' }),
+      updatedAt: z.string().datetime().openapi({ example: '2024-04-25T10:05:00.000Z' }),
+    })
+    .openapi('Vault'),
+);
+
+export const VaultResponseSchema = registry.register(
+  'VaultResponse',
+  z
+    .object({
+      success: z.boolean().openapi({ example: true }),
+      data: VaultSchema,
+    })
+    .openapi('VaultResponse'),
+);
+
+export const VaultListResponseSchema = registry.register(
+  'VaultListResponse',
+  z
+    .object({
+      success: z.boolean().openapi({ example: true }),
+      data: z.array(VaultSchema),
+    })
+    .openapi('VaultListResponse'),
+);

--- a/src/routes/docs.ts
+++ b/src/routes/docs.ts
@@ -1,0 +1,68 @@
+/**
+ * /docs routes — development only.
+ *
+ * GET /docs/openapi.json  → raw OpenAPI 3.0 spec (generated fresh from Zod schemas)
+ * GET /docs               → Swagger UI
+ *
+ * Both routes are guarded: they return 404 when NODE_ENV !== 'development'.
+ * Mount this router BEFORE the error handler in src/index.ts.
+ */
+
+import { Router, Request, Response } from 'express';
+import swaggerUi from 'swagger-ui-express';
+import { generateOpenAPIDocument } from '../openapi/generator';
+
+export const docsRouter = Router();
+
+const isDev = process.env.NODE_ENV === 'development';
+
+// ─── Guard middleware ─────────────────────────────────────────────────────────
+
+function devOnly(_req: Request, res: Response, next: () => void): void {
+  if (!isDev) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  next();
+}
+
+// ─── /docs/openapi.json ───────────────────────────────────────────────────────
+
+docsRouter.get('/openapi.json', devOnly, (_req: Request, res: Response) => {
+  const spec = generateOpenAPIDocument();
+  res.setHeader('Content-Type', 'application/json');
+  res.json(spec);
+});
+
+// ─── /docs (Swagger UI) ───────────────────────────────────────────────────────
+
+// swagger-ui-express needs the spec at setup time, but we want it generated
+// fresh on each server start. We generate it once when the module loads
+// (which happens at server start) and pass it to the UI middleware.
+//
+// If you restart the server the module is re-evaluated and a new spec is
+// generated — satisfying the "auto-update on server restart" requirement.
+
+if (isDev) {
+  const spec = generateOpenAPIDocument();
+
+  docsRouter.use(
+    '/',
+    devOnly,
+    swaggerUi.serve,
+    swaggerUi.setup(spec, {
+      customSiteTitle: 'Mobile Money Bridge — API Docs',
+      swaggerOptions: {
+        persistAuthorization: true,
+        displayRequestDuration: true,
+        filter: true,
+        tryItOutEnabled: true,
+      },
+    }),
+  );
+} else {
+  // In non-dev environments the route still exists but devOnly will 404 it.
+  docsRouter.use('/', devOnly, (_req: Request, res: Response) => {
+    res.status(404).json({ error: 'Not found' });
+  });
+}


### PR DESCRIPTION
- Install @asteasolutions/zod-to-openapi v8 (Zod v4 native) and swagger-ui-express
- Add src/openapi/registry.ts: calls extendZodWithOpenApi(z) once globally
- Add src/openapi/schemas/: annotated Zod schemas for auth, transactions, vaults, contacts, fees, fee-strategies, kyc, htlc, and prices (38 components)
- Add src/openapi/paths/: registerPath() route definitions for all 36 endpoints
- Add src/openapi/generator.ts: produces a fresh OpenAPI 3.0 doc on each start
- Add src/routes/docs.ts: serves Swagger UI at /docs and raw JSON at /docs/openapi.json; both routes return 404 when NODE_ENV != development
- Wire registry import and docsRouter into src/index.ts
- Mark openapi.yaml as legacy with TODO to point sdk:generate at the live /docs/openapi.json endpoint instead
- Document the dev workflow and source-of-truth in README.md

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes


closes #581 
