### PR TITLE
feat: add centralized log redaction to prevent secret leakage

### DIFF
--- a/src/services/structuredLogger.ts
+++ b/src/services/structuredLogger.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import util from "util";
+import { redact } from "../utils/redact";
 
 type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -65,14 +66,22 @@ function tryParseJsonObject(value: string): JsonRecord | null {
 }
 
 function serializeError(
-  error: Error & { code?: string | number },
-): StructuredError {
-  return {
+  error: Error & { code?: string | number; [key: string]: unknown },
+): JsonRecord {
+  const result: JsonRecord = {
     name: error.name,
     message: error.message,
     stack: error.stack,
     code: error.code !== undefined ? String(error.code) : undefined,
   };
+  // Copy all enumerable own properties so that extra fields attached to the
+  // Error (e.g. statusCode, details, token) are preserved for redaction.
+  for (const key of Object.keys(error)) {
+    if (!(key in result)) {
+      result[key] = error[key];
+    }
+  }
+  return result;
 }
 
 function serializeUnknown(value: unknown): unknown {
@@ -257,7 +266,8 @@ export function buildStructuredLogEntry(
   }
 
   const errorArg = args.find(
-    (arg): arg is Error & { code?: string | number } => arg instanceof Error,
+    (arg): arg is Error & { code?: string | number; [key: string]: unknown } =>
+      arg instanceof Error,
   );
   if (errorArg && entry.error === undefined) {
     entry.error = serializeError(errorArg);
@@ -278,7 +288,9 @@ function getLogStream(): fs.WriteStream {
 
 function writeEntry(level: LogLevel, args: unknown[]): void {
   const entry = buildStructuredLogEntry(level, args);
-  const line = JSON.stringify(entry);
+  // Redact sensitive fields before serialising — covers every log call site.
+  const safeEntry = redact(entry) as typeof entry;
+  const line = JSON.stringify(safeEntry);
   const output = `${line}\n`;
 
   if (level === "error" || level === "warn") {

--- a/src/utils/__tests__/redact.integration.test.ts
+++ b/src/utils/__tests__/redact.integration.test.ts
@@ -11,6 +11,9 @@
  * We drive the pipeline at the same level the logger does:
  *   buildStructuredLogEntry  →  redact  →  JSON.stringify
  * so the assertions reflect exactly what would be written to stdout/file.
+ *
+ * NOTE: All credential-like strings in this file are intentionally fake
+ * test placeholders — they are not real secrets.
  */
 
 import { buildStructuredLogEntry } from "../../services/structuredLogger";
@@ -34,7 +37,7 @@ function pipeline(
 
 describe("smoke — sensitive body fields are redacted in log output", () => {
   it("redacts password and token from a logged request body", () => {
-    const body = { username: "alice", password: "supersecret", token: "abc123" };
+    const body = { username: "alice", password: "test-value-not-real", token: "test-token-not-real" };
     const log = pipeline("info", { event: "user.login", body });
 
     const loggedBody = (log as any).body as Record<string, unknown>;
@@ -44,7 +47,7 @@ describe("smoke — sensitive body fields are redacted in log output", () => {
   });
 
   it("redacts apiKey and secret from a logged payload", () => {
-    const payload = { apiKey: "key-abc-123", secret: "my-secret-value", amount: 500 };
+    const payload = { apiKey: "test-api-key-not-real", secret: "test-secret-not-real", amount: 500 };
     const log = pipeline("info", { event: "api.call", payload });
 
     const loggedPayload = (log as any).payload as Record<string, unknown>;
@@ -57,7 +60,7 @@ describe("smoke — sensitive body fields are redacted in log output", () => {
     const data = {
       user: {
         id: "u-1",
-        loginInfo: { password: "hunter2", refreshToken: "rt-xyz" },
+        loginInfo: { password: "test-value-not-real", refreshToken: "rt-test-not-real" },
       },
     };
     const log = pipeline("info", { event: "debug.dump", data });
@@ -83,7 +86,7 @@ describe("smoke — sensitive body fields are redacted in log output", () => {
   });
 
   it("redacts a stringified-JSON body field", () => {
-    const rawBody = JSON.stringify({ password: "pw123", user: "bob" });
+    const rawBody = JSON.stringify({ password: "pw-test-not-real", user: "bob" });
     const log = pipeline("info", { event: "raw.body", rawBody });
 
     const loggedRaw = (log as any).rawBody as string;
@@ -101,7 +104,7 @@ describe("smoke — sensitive HTTP headers are redacted", () => {
   it("redacts Authorization header", () => {
     const headers = {
       "content-type": "application/json",
-      authorization: "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig",
+      authorization: "Bearer test-token-not-real",
       "x-request-id": "req-001",
     };
     const log = pipeline("info", { event: "http.request", headers });
@@ -115,7 +118,7 @@ describe("smoke — sensitive HTTP headers are redacted", () => {
   it("redacts Cookie header", () => {
     const headers = {
       "content-type": "application/json",
-      cookie: "session=abc123; csrf=xyz",
+      cookie: "session=test-session; csrf=test-csrf",
     };
     const log = pipeline("info", { event: "http.request", headers });
 
@@ -125,8 +128,8 @@ describe("smoke — sensitive HTTP headers are redacted", () => {
   });
 
   it("redacts X-Api-Key header (case-insensitive)", () => {
-    const headersLower = { "x-api-key": "api-key-value", host: "api.example.com" };
-    const headersUpper = { "X-Api-Key": "api-key-value", host: "api.example.com" };
+    const headersLower = { "x-api-key": "test-api-key-not-real", host: "api.example.com" };
+    const headersUpper = { "X-Api-Key": "test-api-key-not-real", host: "api.example.com" };
 
     const logLower = pipeline("info", { event: "http.request", headers: headersLower });
     const logUpper = pipeline("info", { event: "http.request", headers: headersUpper });
@@ -139,9 +142,9 @@ describe("smoke — sensitive HTTP headers are redacted", () => {
   it("redacts all three sensitive headers simultaneously", () => {
     const headers = {
       "content-type": "application/json",
-      authorization: "Bearer tok",
-      cookie: "session=s1",
-      "x-api-key": "k1",
+      authorization: "Bearer test-token-not-real",
+      cookie: "session=test-session",
+      "x-api-key": "test-api-key-not-real",
       "x-request-id": "req-002",
     };
     const log = pipeline("info", { event: "http.request", headers });
@@ -167,7 +170,7 @@ describe("smoke — sensitive HTTP headers are redacted", () => {
 describe("smoke — error objects with sensitive content are scrubbed", () => {
   it("redacts a token attached to a thrown Error", () => {
     const err = new Error("Auth failed") as Error & { token?: string };
-    err.token = "leaked-bearer-token";
+    err.token = "test-token-not-real";
 
     // Pass as a plain object field so buildMergedEntry spreads it into merged
     const log = pipeline("error", { event: "auth.error", err });
@@ -180,7 +183,7 @@ describe("smoke — error objects with sensitive content are scrubbed", () => {
 
   it("redacts an apiKey attached to a thrown Error", () => {
     const err = new Error("Invalid key") as Error & { apiKey?: string };
-    err.apiKey = "sk-live-supersecret";
+    err.apiKey = "test-api-key-not-real";
 
     const log = pipeline("error", { event: "api.error", err });
 
@@ -193,7 +196,7 @@ describe("smoke — error objects with sensitive content are scrubbed", () => {
     const err = new Error("Login failed") as Error & {
       details?: Record<string, unknown>;
     };
-    err.details = { attempted_password: "hunter2", username: "alice" };
+    err.details = { attempted_password: "test-value-not-real", username: "alice" };
 
     const log = pipeline("error", { event: "login.error", err });
 
@@ -280,7 +283,7 @@ describe("smoke — non-sensitive data is not altered", () => {
 
 describe("smoke — original objects are not mutated through the pipeline", () => {
   it("does not mutate a body object passed to the logger", () => {
-    const body = { password: "supersecret", username: "alice" };
+    const body = { password: "test-value-not-real", username: "alice" };
     const originalPassword = body.password;
 
     pipeline("info", { event: "login", body });
@@ -289,7 +292,7 @@ describe("smoke — original objects are not mutated through the pipeline", () =
   });
 
   it("does not mutate a headers object passed to the logger", () => {
-    const headers = { authorization: "Bearer tok", "content-type": "application/json" };
+    const headers = { authorization: "Bearer test-token-not-real", "content-type": "application/json" };
     const originalAuth = headers.authorization;
 
     pipeline("info", { event: "http.request", headers });

--- a/src/utils/__tests__/redact.integration.test.ts
+++ b/src/utils/__tests__/redact.integration.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Integration smoke-tests for the redaction layer.
+ *
+ * These tests verify the acceptance criteria end-to-end:
+ *   1. Sensitive body fields → [REDACTED] in log output
+ *   2. Authorization / Cookie / X-Api-Key headers → [REDACTED]
+ *   3. Error objects with sensitive content → scrubbed
+ *   4. Non-sensitive data passes through unchanged
+ *   5. Original objects are never mutated through the pipeline
+ *
+ * We drive the pipeline at the same level the logger does:
+ *   buildStructuredLogEntry  →  redact  →  JSON.stringify
+ * so the assertions reflect exactly what would be written to stdout/file.
+ */
+
+import { buildStructuredLogEntry } from "../../services/structuredLogger";
+import { redact, REDACTED } from "../redact";
+
+// ---------------------------------------------------------------------------
+// Helper — run the full pipeline and return the parsed log object
+// ---------------------------------------------------------------------------
+function pipeline(
+  level: "info" | "warn" | "error",
+  ...args: unknown[]
+): Record<string, unknown> {
+  const entry = buildStructuredLogEntry(level, args);
+  const safe = redact(entry) as typeof entry;
+  return JSON.parse(JSON.stringify(safe)) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Sensitive request body fields
+// ---------------------------------------------------------------------------
+
+describe("smoke — sensitive body fields are redacted in log output", () => {
+  it("redacts password and token from a logged request body", () => {
+    const body = { username: "alice", password: "supersecret", token: "abc123" };
+    const log = pipeline("info", { event: "user.login", body });
+
+    const loggedBody = (log as any).body as Record<string, unknown>;
+    expect(loggedBody.username).toBe("alice");
+    expect(loggedBody.password).toBe(REDACTED);
+    expect(loggedBody.token).toBe(REDACTED);
+  });
+
+  it("redacts apiKey and secret from a logged payload", () => {
+    const payload = { apiKey: "key-abc-123", secret: "my-secret-value", amount: 500 };
+    const log = pipeline("info", { event: "api.call", payload });
+
+    const loggedPayload = (log as any).payload as Record<string, unknown>;
+    expect(loggedPayload.apiKey).toBe(REDACTED);
+    expect(loggedPayload.secret).toBe(REDACTED);
+    expect(loggedPayload.amount).toBe(500);
+  });
+
+  it("redacts deeply nested sensitive fields", () => {
+    const data = {
+      user: {
+        id: "u-1",
+        loginInfo: { password: "hunter2", refreshToken: "rt-xyz" },
+      },
+    };
+    const log = pipeline("info", { event: "debug.dump", data });
+
+    const loggedData = (log as any).data as any;
+    expect(loggedData.user.id).toBe("u-1");
+    expect(loggedData.user.loginInfo.password).toBe(REDACTED);
+    expect(loggedData.user.loginInfo.refreshToken).toBe(REDACTED);
+  });
+
+  it("redacts sensitive fields inside arrays", () => {
+    const items = [
+      { id: 1, token: "tok-1", amount: 50 },
+      { id: 2, token: "tok-2", amount: 75 },
+    ];
+    const log = pipeline("info", { event: "batch", items });
+
+    const loggedItems = (log as any).items as Array<Record<string, unknown>>;
+    expect(loggedItems[0].token).toBe(REDACTED);
+    expect(loggedItems[0].amount).toBe(50);
+    expect(loggedItems[1].token).toBe(REDACTED);
+    expect(loggedItems[1].amount).toBe(75);
+  });
+
+  it("redacts a stringified-JSON body field", () => {
+    const rawBody = JSON.stringify({ password: "pw123", user: "bob" });
+    const log = pipeline("info", { event: "raw.body", rawBody });
+
+    const loggedRaw = (log as any).rawBody as string;
+    const parsed = JSON.parse(loggedRaw) as Record<string, unknown>;
+    expect(parsed.password).toBe(REDACTED);
+    expect(parsed.user).toBe("bob");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. HTTP headers — Authorization, Cookie, X-Api-Key
+// ---------------------------------------------------------------------------
+
+describe("smoke — sensitive HTTP headers are redacted", () => {
+  it("redacts Authorization header", () => {
+    const headers = {
+      "content-type": "application/json",
+      authorization: "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig",
+      "x-request-id": "req-001",
+    };
+    const log = pipeline("info", { event: "http.request", headers });
+
+    const loggedHeaders = (log as any).headers as Record<string, unknown>;
+    expect(loggedHeaders["content-type"]).toBe("application/json");
+    expect(loggedHeaders["x-request-id"]).toBe("req-001");
+    expect(loggedHeaders["authorization"]).toBe(REDACTED);
+  });
+
+  it("redacts Cookie header", () => {
+    const headers = {
+      "content-type": "application/json",
+      cookie: "session=abc123; csrf=xyz",
+    };
+    const log = pipeline("info", { event: "http.request", headers });
+
+    const loggedHeaders = (log as any).headers as Record<string, unknown>;
+    expect(loggedHeaders["cookie"]).toBe(REDACTED);
+    expect(loggedHeaders["content-type"]).toBe("application/json");
+  });
+
+  it("redacts X-Api-Key header (case-insensitive)", () => {
+    const headersLower = { "x-api-key": "api-key-value", host: "api.example.com" };
+    const headersUpper = { "X-Api-Key": "api-key-value", host: "api.example.com" };
+
+    const logLower = pipeline("info", { event: "http.request", headers: headersLower });
+    const logUpper = pipeline("info", { event: "http.request", headers: headersUpper });
+
+    expect((logLower as any).headers["x-api-key"]).toBe(REDACTED);
+    expect((logUpper as any).headers["X-Api-Key"]).toBe(REDACTED);
+    expect((logLower as any).headers["host"]).toBe("api.example.com");
+  });
+
+  it("redacts all three sensitive headers simultaneously", () => {
+    const headers = {
+      "content-type": "application/json",
+      authorization: "Bearer tok",
+      cookie: "session=s1",
+      "x-api-key": "k1",
+      "x-request-id": "req-002",
+    };
+    const log = pipeline("info", { event: "http.request", headers });
+    const loggedHeaders = (log as any).headers as Record<string, unknown>;
+
+    expect(loggedHeaders["authorization"]).toBe(REDACTED);
+    expect(loggedHeaders["cookie"]).toBe(REDACTED);
+    expect(loggedHeaders["x-api-key"]).toBe(REDACTED);
+    expect(loggedHeaders["content-type"]).toBe("application/json");
+    expect(loggedHeaders["x-request-id"]).toBe("req-002");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Error logging path — sensitive content in Error objects
+//
+// When an Error is passed as a value inside a log object (e.g. { err }),
+// buildMergedEntry spreads the object and serializeUnknown serializes the
+// Error via serializeError, which now preserves all enumerable own properties.
+// Redaction then walks the serialized result and scrubs sensitive keys.
+// ---------------------------------------------------------------------------
+
+describe("smoke — error objects with sensitive content are scrubbed", () => {
+  it("redacts a token attached to a thrown Error", () => {
+    const err = new Error("Auth failed") as Error & { token?: string };
+    err.token = "leaked-bearer-token";
+
+    // Pass as a plain object field so buildMergedEntry spreads it into merged
+    const log = pipeline("error", { event: "auth.error", err });
+
+    // The err field is serialized by serializeUnknown → serializeError
+    const loggedErr = (log as any).err as Record<string, unknown>;
+    expect(loggedErr["message"]).toBe("Auth failed");
+    expect(loggedErr["token"]).toBe(REDACTED);
+  });
+
+  it("redacts an apiKey attached to a thrown Error", () => {
+    const err = new Error("Invalid key") as Error & { apiKey?: string };
+    err.apiKey = "sk-live-supersecret";
+
+    const log = pipeline("error", { event: "api.error", err });
+
+    const loggedErr = (log as any).err as Record<string, unknown>;
+    expect(loggedErr["apiKey"]).toBe(REDACTED);
+    expect(loggedErr["message"]).toBe("Invalid key");
+  });
+
+  it("redacts a password in error details", () => {
+    const err = new Error("Login failed") as Error & {
+      details?: Record<string, unknown>;
+    };
+    err.details = { attempted_password: "hunter2", username: "alice" };
+
+    const log = pipeline("error", { event: "login.error", err });
+
+    const loggedErr = (log as any).err as Record<string, unknown>;
+    // details is an enumerable own property — preserved and walked by redact
+    const details = loggedErr["details"] as Record<string, unknown>;
+    // "attempted_password" contains "password" → redacted
+    expect(details["attempted_password"]).toBe(REDACTED);
+    expect(details["username"]).toBe("alice");
+  });
+
+  it("does not redact safe fields on an Error", () => {
+    const err = new Error("Not found") as Error & { statusCode?: number };
+    err.statusCode = 404;
+
+    const log = pipeline("error", { event: "not.found", err });
+
+    const loggedErr = (log as any).err as Record<string, unknown>;
+    expect(loggedErr["message"]).toBe("Not found");
+    expect(loggedErr["statusCode"]).toBe(404);
+    expect(loggedErr["name"]).toBe("Error");
+  });
+
+  it("mirrors the errorHandler console.error call shape", () => {
+    // errorHandler calls: console.error({ timestamp, requestId, code, message, stack, statusCode })
+    // When installGlobalLogger is active, console.error → writeEntry("error", args)
+    // which calls buildStructuredLogEntry then redact.
+    // We simulate that exact call shape here.
+    const errPayload = {
+      timestamp: new Date().toISOString(),
+      requestId: "req-abc",
+      code: "UNAUTHORIZED",
+      message: "Token validation failed",
+      stack: "Error: Token validation failed\n    at ...",
+      statusCode: 401,
+    };
+
+    const log = pipeline("error", errPayload);
+
+    // None of these field names are sensitive — they should pass through.
+    expect(log["code"]).toBe("UNAUTHORIZED");
+    expect(log["message"]).toBe("Token validation failed");
+    expect(log["statusCode"]).toBe(401);
+    expect(log["requestId"]).toBe("req-abc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Non-sensitive data passes through unchanged
+// ---------------------------------------------------------------------------
+
+describe("smoke — non-sensitive data is not altered", () => {
+  it("passes through a safe transaction log entry", () => {
+    const entry = {
+      event: "transaction.completed",
+      transactionId: "txn-123",
+      amount: 500,
+      currency: "XAF",
+      status: "completed",
+      userId: "u-42",
+    };
+    const log = pipeline("info", entry);
+
+    expect(log["transactionId"]).toBe("txn-123");
+    expect(log["amount"]).toBe(500);
+    expect(log["currency"]).toBe("XAF");
+    expect(log["status"]).toBe("completed");
+    expect(log["userId"]).toBe("u-42");
+  });
+
+  it("passes through standard ECS envelope fields", () => {
+    const log = pipeline("info", { message: "Server started", port: 3000 });
+
+    expect(log["@timestamp"]).toBeDefined();
+    expect((log as any).service?.name).toBeDefined();
+    expect((log as any).log?.level).toBe("info");
+    expect((log as any).ecs?.version).toBe("8.11.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Original objects are never mutated through the pipeline
+// ---------------------------------------------------------------------------
+
+describe("smoke — original objects are not mutated through the pipeline", () => {
+  it("does not mutate a body object passed to the logger", () => {
+    const body = { password: "supersecret", username: "alice" };
+    const originalPassword = body.password;
+
+    pipeline("info", { event: "login", body });
+
+    expect(body.password).toBe(originalPassword);
+  });
+
+  it("does not mutate a headers object passed to the logger", () => {
+    const headers = { authorization: "Bearer tok", "content-type": "application/json" };
+    const originalAuth = headers.authorization;
+
+    pipeline("info", { event: "http.request", headers });
+
+    expect(headers.authorization).toBe(originalAuth);
+  });
+});

--- a/src/utils/__tests__/redact.test.ts
+++ b/src/utils/__tests__/redact.test.ts
@@ -1,0 +1,332 @@
+import { redact, isSensitiveKey, REDACTED } from "../redact";
+
+// ---------------------------------------------------------------------------
+// isSensitiveKey
+// ---------------------------------------------------------------------------
+
+describe("isSensitiveKey", () => {
+  it("matches exact sensitive keys", () => {
+    expect(isSensitiveKey("password")).toBe(true);
+    expect(isSensitiveKey("token")).toBe(true);
+    expect(isSensitiveKey("secret")).toBe(true);
+    expect(isSensitiveKey("apiKey")).toBe(true);
+    expect(isSensitiveKey("authorization")).toBe(true);
+    expect(isSensitiveKey("pin")).toBe(true);
+    expect(isSensitiveKey("otp")).toBe(true);
+    expect(isSensitiveKey("mnemonic")).toBe(true);
+    expect(isSensitiveKey("seed")).toBe(true);
+    expect(isSensitiveKey("privateKey")).toBe(true);
+    expect(isSensitiveKey("cookie")).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(isSensitiveKey("PASSWORD")).toBe(true);
+    expect(isSensitiveKey("Token")).toBe(true);
+    expect(isSensitiveKey("SECRET")).toBe(true);
+    expect(isSensitiveKey("ApiKey")).toBe(true);
+    expect(isSensitiveKey("Authorization")).toBe(true);
+  });
+
+  it("matches partial / compound names", () => {
+    expect(isSensitiveKey("accessToken")).toBe(true);
+    expect(isSensitiveKey("refreshToken")).toBe(true);
+    expect(isSensitiveKey("idToken")).toBe(true);
+    expect(isSensitiveKey("newPassword")).toBe(true);
+    expect(isSensitiveKey("currentPassword")).toBe(true);
+    expect(isSensitiveKey("x-api-key")).toBe(true);
+    expect(isSensitiveKey("X-Api-Key")).toBe(true);
+    expect(isSensitiveKey("clientSecret")).toBe(true);
+    expect(isSensitiveKey("signingKey")).toBe(true);
+    expect(isSensitiveKey("encryptionKey")).toBe(true);
+    expect(isSensitiveKey("walletKey")).toBe(true);
+    expect(isSensitiveKey("stellarSecret")).toBe(true);
+  });
+
+  it("does not match non-sensitive keys", () => {
+    expect(isSensitiveKey("email")).toBe(false);
+    expect(isSensitiveKey("username")).toBe(false);
+    expect(isSensitiveKey("amount")).toBe(false);
+    expect(isSensitiveKey("status")).toBe(false);
+    expect(isSensitiveKey("createdAt")).toBe(false);
+    expect(isSensitiveKey("userId")).toBe(false);
+    expect(isSensitiveKey("transactionId")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redact — flat objects
+// ---------------------------------------------------------------------------
+
+describe("redact — flat object with sensitive keys", () => {
+  it("replaces sensitive field values with REDACTED", () => {
+    const input = {
+      username: "alice",
+      password: "super-secret-123",
+      email: "alice@example.com",
+      token: "eyJhbGciOiJIUzI1NiJ9.payload.sig",
+    };
+
+    const result = redact(input) as typeof input;
+
+    expect(result.username).toBe("alice");
+    expect(result.email).toBe("alice@example.com");
+    expect(result.password).toBe(REDACTED);
+    expect(result.token).toBe(REDACTED);
+  });
+
+  it("handles all common sensitive field names", () => {
+    const input = {
+      apiKey: "key-abc",
+      secret: "my-secret",
+      authorization: "Bearer xyz",
+      pin: "1234",
+      otp: "567890",
+      mnemonic: "word1 word2 word3",
+      privateKey: "-----BEGIN PRIVATE KEY-----",
+      cookie: "session=abc123",
+    };
+
+    const result = redact(input) as Record<string, unknown>;
+
+    for (const key of Object.keys(input)) {
+      expect(result[key]).toBe(REDACTED);
+    }
+  });
+
+  it("passes through non-sensitive fields unchanged", () => {
+    const input = { amount: 100, currency: "XLM", status: "completed" };
+    expect(redact(input)).toEqual(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redact — deep nesting
+// ---------------------------------------------------------------------------
+
+describe("redact — deeply nested objects", () => {
+  it("redacts sensitive fields at any depth", () => {
+    // Note: "credentials" itself matches the /credential/i pattern and is
+    // redacted as a whole — that is correct and intentional behaviour.
+    // This test uses a neutral container name to verify per-field deep walk.
+    const input = {
+      user: {
+        id: "u-1",
+        loginInfo: {
+          password: "hunter2",
+          token: "tok-abc",
+        },
+        profile: {
+          name: "Alice",
+          address: {
+            city: "Douala",
+          },
+        },
+      },
+    };
+
+    const result = redact(input) as typeof input & {
+      user: { loginInfo: { password: string; token: string } };
+    };
+
+    expect((result.user as any).loginInfo.password).toBe(REDACTED);
+    expect((result.user as any).loginInfo.token).toBe(REDACTED);
+    expect(result.user.profile.name).toBe("Alice");
+    expect(result.user.profile.address.city).toBe("Douala");
+    expect(result.user.id).toBe("u-1");
+  });
+
+  it("redacts the entire value when the container key is itself sensitive (e.g. credentials)", () => {
+    const input = {
+      user: {
+        credentials: { password: "hunter2", token: "tok-abc" },
+      },
+    };
+    const result = redact(input) as { user: { credentials: unknown } };
+    // The container key "credentials" matches /credential/i, so the whole
+    // nested object is replaced with REDACTED rather than walked.
+    expect(result.user.credentials).toBe(REDACTED);
+  });
+
+  it("handles triple-nested sensitive fields", () => {
+    const input = { a: { b: { c: { apiKey: "secret-key" } } } };
+    const result = redact(input) as typeof input;
+    expect(result.a.b.c.apiKey).toBe(REDACTED);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redact — arrays
+// ---------------------------------------------------------------------------
+
+describe("redact — arrays containing sensitive objects", () => {
+  it("redacts sensitive fields inside array elements", () => {
+    const input = [
+      { id: 1, token: "tok-1", amount: 50 },
+      { id: 2, token: "tok-2", amount: 75 },
+    ];
+
+    const result = redact(input) as typeof input;
+
+    expect(result[0].token).toBe(REDACTED);
+    expect(result[0].amount).toBe(50);
+    expect(result[1].token).toBe(REDACTED);
+    expect(result[1].amount).toBe(75);
+  });
+
+  it("handles nested arrays", () => {
+    const input = { items: [{ password: "pw1" }, { password: "pw2" }] };
+    const result = redact(input) as typeof input;
+    expect(result.items[0].password).toBe(REDACTED);
+    expect(result.items[1].password).toBe(REDACTED);
+  });
+
+  it("passes through arrays of non-sensitive objects unchanged", () => {
+    const input = [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }];
+    expect(redact(input)).toEqual(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redact — stringified JSON
+// ---------------------------------------------------------------------------
+
+describe("redact — stringified JSON as a field value", () => {
+  it("parses and redacts stringified JSON objects", () => {
+    const inner = JSON.stringify({ password: "pw", user: "alice" });
+    const input = { payload: inner };
+
+    const result = redact(input) as { payload: string };
+
+    const parsed = JSON.parse(result.payload);
+    expect(parsed.password).toBe(REDACTED);
+    expect(parsed.user).toBe("alice");
+  });
+
+  it("parses and redacts stringified JSON arrays", () => {
+    const inner = JSON.stringify([{ token: "tok-1" }, { token: "tok-2" }]);
+    const input = { data: inner };
+
+    const result = redact(input) as { data: string };
+
+    const parsed = JSON.parse(result.data) as Array<{ token: string }>;
+    expect(parsed[0].token).toBe(REDACTED);
+    expect(parsed[1].token).toBe(REDACTED);
+  });
+
+  it("leaves non-JSON strings untouched", () => {
+    const input = { message: "hello world", status: "ok" };
+    expect(redact(input)).toEqual(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redact — Error objects
+// ---------------------------------------------------------------------------
+
+describe("redact — Error objects", () => {
+  it("serializes an Error and redacts sensitive fields attached to it", () => {
+    const err = new Error("Something went wrong") as Error & {
+      token?: string;
+      statusCode?: number;
+    };
+    err.token = "leaked-token";
+    err.statusCode = 500;
+
+    const result = redact(err) as Record<string, unknown>;
+
+    expect(result["message"]).toBe("Something went wrong");
+    expect(result["token"]).toBe(REDACTED);
+    expect(result["statusCode"]).toBe(500);
+    expect(result["name"]).toBe("Error");
+  });
+
+  it("does not expose the original Error object", () => {
+    const err = new Error("test");
+    const result = redact(err);
+    expect(result).not.toBeInstanceOf(Error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redact — immutability
+// ---------------------------------------------------------------------------
+
+describe("redact — original objects are never mutated", () => {
+  it("does not mutate a flat object", () => {
+    const input = { password: "secret", name: "Alice" };
+    const copy = { ...input };
+    redact(input);
+    expect(input).toEqual(copy);
+  });
+
+  it("does not mutate a nested object", () => {
+    const input = { user: { token: "tok", id: "1" } };
+    const originalToken = input.user.token;
+    redact(input);
+    expect(input.user.token).toBe(originalToken);
+  });
+
+  it("does not mutate array elements", () => {
+    const input = [{ apiKey: "key-1" }, { apiKey: "key-2" }];
+    const originals = input.map((i) => i.apiKey);
+    redact(input);
+    input.forEach((item, idx) => {
+      expect(item.apiKey).toBe(originals[idx]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redact — non-sensitive pass-through
+// ---------------------------------------------------------------------------
+
+describe("redact — non-sensitive objects pass through unchanged", () => {
+  it("returns primitives as-is", () => {
+    expect(redact(42)).toBe(42);
+    expect(redact(true)).toBe(true);
+    expect(redact("hello")).toBe("hello");
+    expect(redact(null)).toBeNull();
+    expect(redact(undefined)).toBeUndefined();
+  });
+
+  it("returns a structurally equal clone for safe objects", () => {
+    const input = {
+      id: "txn-123",
+      amount: 500,
+      currency: "XAF",
+      status: "completed",
+      createdAt: "2026-04-25T10:00:00Z",
+    };
+    expect(redact(input)).toEqual(input);
+  });
+
+  it("does not alter the message field of a safe Error", () => {
+    const err = new Error("Not found");
+    const result = redact(err) as Record<string, unknown>;
+    expect(result["message"]).toBe("Not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redact — HTTP-specific headers
+// ---------------------------------------------------------------------------
+
+describe("redact — HTTP headers", () => {
+  it("redacts Authorization, Cookie, and X-Api-Key headers", () => {
+    const headers = {
+      "content-type": "application/json",
+      authorization: "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig",
+      cookie: "session=abc123; csrf=xyz",
+      "x-api-key": "api-key-value",
+      "x-request-id": "req-001",
+    };
+
+    const result = redact(headers) as typeof headers;
+
+    expect(result["content-type"]).toBe("application/json");
+    expect(result["x-request-id"]).toBe("req-001");
+    expect(result["authorization"]).toBe(REDACTED);
+    expect(result["cookie"]).toBe(REDACTED);
+    expect(result["x-api-key"]).toBe(REDACTED);
+  });
+});

--- a/src/utils/__tests__/redact.test.ts
+++ b/src/utils/__tests__/redact.test.ts
@@ -61,9 +61,9 @@ describe("redact — flat object with sensitive keys", () => {
   it("replaces sensitive field values with REDACTED", () => {
     const input = {
       username: "alice",
-      password: "super-secret-123",
+      password: "test-value-not-real",
       email: "alice@example.com",
-      token: "eyJhbGciOiJIUzI1NiJ9.payload.sig",
+      token: "test.jwt.token",
     };
 
     const result = redact(input) as typeof input;
@@ -76,14 +76,14 @@ describe("redact — flat object with sensitive keys", () => {
 
   it("handles all common sensitive field names", () => {
     const input = {
-      apiKey: "key-abc",
-      secret: "my-secret",
-      authorization: "Bearer xyz",
-      pin: "1234",
-      otp: "567890",
+      apiKey: "test-api-key",
+      secret: "test-secret-value",
+      authorization: "Bearer test-token",
+      pin: "0000",
+      otp: "000000",
       mnemonic: "word1 word2 word3",
-      privateKey: "-----BEGIN PRIVATE KEY-----",
-      cookie: "session=abc123",
+      privateKey: "TEST-PRIVATE-KEY-NOT-REAL",
+      cookie: "session=test-session",
     };
 
     const result = redact(input) as Record<string, unknown>;
@@ -112,8 +112,8 @@ describe("redact — deeply nested objects", () => {
       user: {
         id: "u-1",
         loginInfo: {
-          password: "hunter2",
-          token: "tok-abc",
+          password: "test-value-not-real",
+          token: "tok-test",
         },
         profile: {
           name: "Alice",
@@ -138,7 +138,7 @@ describe("redact — deeply nested objects", () => {
   it("redacts the entire value when the container key is itself sensitive (e.g. credentials)", () => {
     const input = {
       user: {
-        credentials: { password: "hunter2", token: "tok-abc" },
+        credentials: { password: "test-value-not-real", token: "tok-test" },
       },
     };
     const result = redact(input) as { user: { credentials: unknown } };
@@ -148,7 +148,7 @@ describe("redact — deeply nested objects", () => {
   });
 
   it("handles triple-nested sensitive fields", () => {
-    const input = { a: { b: { c: { apiKey: "secret-key" } } } };
+    const input = { a: { b: { c: { apiKey: "test-api-key" } } } };
     const result = redact(input) as typeof input;
     expect(result.a.b.c.apiKey).toBe(REDACTED);
   });
@@ -174,7 +174,7 @@ describe("redact — arrays containing sensitive objects", () => {
   });
 
   it("handles nested arrays", () => {
-    const input = { items: [{ password: "pw1" }, { password: "pw2" }] };
+    const input = { items: [{ password: "pw-test-1" }, { password: "pw-test-2" }] };
     const result = redact(input) as typeof input;
     expect(result.items[0].password).toBe(REDACTED);
     expect(result.items[1].password).toBe(REDACTED);
@@ -192,7 +192,7 @@ describe("redact — arrays containing sensitive objects", () => {
 
 describe("redact — stringified JSON as a field value", () => {
   it("parses and redacts stringified JSON objects", () => {
-    const inner = JSON.stringify({ password: "pw", user: "alice" });
+    const inner = JSON.stringify({ password: "pw-test", user: "alice" });
     const input = { payload: inner };
 
     const result = redact(input) as { payload: string };
@@ -229,7 +229,7 @@ describe("redact — Error objects", () => {
       token?: string;
       statusCode?: number;
     };
-    err.token = "leaked-token";
+    err.token = "test-token-not-real";
     err.statusCode = 500;
 
     const result = redact(err) as Record<string, unknown>;
@@ -253,21 +253,21 @@ describe("redact — Error objects", () => {
 
 describe("redact — original objects are never mutated", () => {
   it("does not mutate a flat object", () => {
-    const input = { password: "secret", name: "Alice" };
+    const input = { password: "test-value-not-real", name: "Alice" };
     const copy = { ...input };
     redact(input);
     expect(input).toEqual(copy);
   });
 
   it("does not mutate a nested object", () => {
-    const input = { user: { token: "tok", id: "1" } };
+    const input = { user: { token: "tok-test", id: "1" } };
     const originalToken = input.user.token;
     redact(input);
     expect(input.user.token).toBe(originalToken);
   });
 
   it("does not mutate array elements", () => {
-    const input = [{ apiKey: "key-1" }, { apiKey: "key-2" }];
+    const input = [{ apiKey: "key-test-1" }, { apiKey: "key-test-2" }];
     const originals = input.map((i) => i.apiKey);
     redact(input);
     input.forEach((item, idx) => {
@@ -315,9 +315,9 @@ describe("redact — HTTP headers", () => {
   it("redacts Authorization, Cookie, and X-Api-Key headers", () => {
     const headers = {
       "content-type": "application/json",
-      authorization: "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig",
-      cookie: "session=abc123; csrf=xyz",
-      "x-api-key": "api-key-value",
+      authorization: "Bearer test-token-not-real",
+      cookie: "session=test-session; csrf=test-csrf",
+      "x-api-key": "test-api-key-not-real",
       "x-request-id": "req-001",
     };
 

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,142 @@
+/**
+ * Centralized log redaction utility.
+ *
+ * Recursively walks any value and replaces the content of fields whose names
+ * match a known-sensitive pattern with the string "[REDACTED]".
+ *
+ * Design goals:
+ *  - Zero mutations — always returns a deep clone.
+ *  - Case-insensitive, partial-match field name detection (e.g. "accessToken",
+ *    "X-Api-Key", "newPassword" all match).
+ *  - Handles nested objects, arrays, stringified JSON embedded in string
+ *    values, and Error objects.
+ *  - No external dependencies — pure Node.js / TypeScript.
+ */
+
+export const REDACTED = "[REDACTED]";
+
+/**
+ * Patterns that identify sensitive field names.
+ * Each entry is tested case-insensitively against the full field name, so a
+ * partial match (e.g. "accessToken" contains "token") is sufficient.
+ */
+const SENSITIVE_PATTERNS: RegExp[] = [
+  /password/i,
+  /passwd/i,
+  /secret/i,
+  /token/i,
+  /apikey/i,
+  /api[_-]key/i,
+  /privatekey/i,
+  /private[_-]key/i,
+  /mnemonic/i,
+  /seed/i,
+  /authorization/i,
+  /auth/i,
+  /credential/i,
+  /pin\b/i,
+  /\botp\b/i,
+  /passphrase/i,
+  /cookie/i,
+  /x-api-key/i,
+  /access[_-]?key/i,
+  /client[_-]?secret/i,
+  /refresh[_-]?token/i,
+  /id[_-]?token/i,
+  /bearer/i,
+  /signature/i,
+  /signing[_-]?key/i,
+  /encryption[_-]?key/i,
+  /master[_-]?key/i,
+  /wallet[_-]?key/i,
+  /stellar[_-]?secret/i,
+  /stellar[_-]?seed/i,
+  /ssn/i,
+  /cvv/i,
+  /card[_-]?number/i,
+  /account[_-]?number/i,
+];
+
+/**
+ * Returns true when a field name should have its value redacted.
+ */
+export function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(key));
+}
+
+/**
+ * Attempts to parse a string as a JSON object or array.
+ * Returns the parsed value on success, or null if the string is not valid JSON
+ * or does not parse to an object/array (primitives are left as-is).
+ */
+function tryParseJson(value: string): Record<string, unknown> | unknown[] | null {
+  const trimmed = value.trim();
+  if (trimmed[0] !== "{" && trimmed[0] !== "[") return null;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as Record<string, unknown> | unknown[];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Core recursive redaction function.
+ *
+ * @param value   - Any value to redact.
+ * @param _key    - The field name under which this value lives (used by the
+ *                  parent call to decide whether to redact).
+ * @returns A deep clone of `value` with sensitive fields replaced.
+ */
+export function redact(value: unknown, _key?: string): unknown {
+  // ── Null / undefined ──────────────────────────────────────────────────────
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  // ── Error objects ─────────────────────────────────────────────────────────
+  // Serialize to a plain object so the recursive walk can inspect its fields.
+  if (value instanceof Error) {
+    const plain: Record<string, unknown> = {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+    // Copy any enumerable extra properties (e.g. code, statusCode, details).
+    for (const k of Object.keys(value as unknown as Record<string, unknown>)) {
+      plain[k] = (value as unknown as Record<string, unknown>)[k];
+    }
+    return redact(plain);
+  }
+
+  // ── Arrays ────────────────────────────────────────────────────────────────
+  if (Array.isArray(value)) {
+    return value.map((item) => redact(item));
+  }
+
+  // ── Plain objects ─────────────────────────────────────────────────────────
+  if (typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = isSensitiveKey(k) ? REDACTED : redact(v, k);
+    }
+    return result;
+  }
+
+  // ── Strings ───────────────────────────────────────────────────────────────
+  // If the string looks like a JSON object/array, parse and redact it, then
+  // re-serialize so the log entry stays valid JSON.
+  if (typeof value === "string") {
+    const parsed = tryParseJson(value);
+    if (parsed !== null) {
+      return JSON.stringify(redact(parsed));
+    }
+    return value;
+  }
+
+  // ── Primitives (number, boolean, bigint, symbol) ──────────────────────────
+  return value;
+}


### PR DESCRIPTION
- Add src/utils/redact.ts with redact(), isSensitiveKey(), REDACTED
- 35 sensitive patterns: password, token, secret, apiKey, mnemonic, seed, authorization, cookie, x-api-key, privateKey, stellarSecret, ssn, cvv, and more
- Handles nested objects, arrays, stringified JSON, Error objects
- Never mutates originals — always returns a deep clone
- Integrate redact() into structuredLogger.ts writeEntry() so every log call site is covered automatically with zero manual call sites
- Fix serializeError() to preserve all enumerable own properties on Error objects so extra fields (token, apiKey, details) are redacted
- Add 25 unit tests in redact.test.ts
- Add 18 integration smoke tests in redact.integration.test.ts

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes

closes #587