### PR TITLE
ci: add Slack failure notification for main branch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,3 +266,34 @@ jobs:
             echo "  - ${{ github.repository }}:latest"
           fi
           echo "=================================="
+
+  # Slack failure notification — fires only when a job fails on the main branch.
+  # Requires the SLACK_WEBHOOK_URL repository secret (see CONTRIBUTING.md).
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: [security, test, build, docker]
+    # Always run this job so it can evaluate the failure condition,
+    # but only send a notification when something upstream failed on main.
+    if: |
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      contains(needs.*.result, 'failure')
+    steps:
+      - name: Send Slack failure notification
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: CI Failed on `main`",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":x: *CI Failed on `main`*\n*Workflow:* ${{ github.workflow }}\n*Triggered by:* ${{ github.actor }}\n*Commit:* `${{ github.sha }}`\n*<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failed run>*"
+                  }
+                }
+              ]
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,20 @@ New to the project? Look for issues labeled `good first issue`:
 - Fix typos
 - Add logging
 
+## 🔔 CI Slack Notifications
+
+When a CI run fails on the `main` branch, an automatic Slack notification is sent with the workflow name, triggering actor, commit SHA, and a direct link to the failed run.
+
+### Required secret
+
+| Secret name | Where to get it |
+|---|---|
+| `SLACK_WEBHOOK_URL` | Create an [Incoming Webhook](https://api.slack.com/messaging/webhooks) in your Slack workspace, then add the generated URL as a repository secret under **Settings → Secrets and variables → Actions**. |
+
+Notifications fire **only** on `main` branch failures. Passing builds and pull-request runs are never notified.
+
+---
+
 ## 🔒 Security Issues
 
 **DO NOT** open public issues for security vulnerabilities.


### PR DESCRIPTION
- Add notify-slack job to CI workflow using slackapi/slack-github-action@v2
- Triggers only on failure of any upstream job (security, test, build, docker)
- Scoped to main branch only via github.ref check
- Message includes workflow name, actor, commit SHA, and link to failed run
- Webhook URL referenced via secrets.SLACK_WEBHOOK_URL (never hardcoded)
- Document SLACK_WEBHOOK_URL secret setup in CONTRIBUTING.md

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Not

closes #555 