### PR TITLE
feat: add gzip compression toggle for outgoing webhooks (#737)

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -6,17 +6,18 @@ import { WebhookService, WebhookEvent } from "../services/webhook";
 const router = Router();
 const transactionModel = new TransactionModel();
 
-/**
- * Flat webhook payload structure optimized for Zapier/Make.com
- * All fields are at the root level for easy mapping in no-code tools
- */
+interface WebhookSettings {
+  compression: boolean;
+}
+
+const webhookSettings: WebhookSettings = {
+  compression: process.env.WEBHOOK_COMPRESSION === "true",
+};
+
 export interface FlatWebhookPayload {
-  // Event metadata
   event_id: string;
   event_type: "transaction.completed" | "transaction.failed" | "transaction.pending" | "transaction.cancelled";
   timestamp: string;
-  
-  // Transaction core fields (flat structure)
   transaction_id: string;
   reference_number: string;
   transaction_type: "deposit" | "withdraw";
@@ -26,34 +27,21 @@ export interface FlatWebhookPayload {
   provider: string;
   stellar_address: string;
   status: "pending" | "completed" | "failed" | "cancelled";
-  
-  // Optional fields
   user_id?: string;
   notes?: string;
   tags?: string;
-  
-  // Timestamps
   created_at: string;
   updated_at?: string;
-  
-  // Metadata (flattened key-value pairs)
   metadata_key?: string;
   metadata_value?: string;
-  
-  // Processing info
   webhook_delivery_status?: string;
   webhook_delivered_at?: string;
 }
 
-/**
- * Sample webhook payload for schema discovery
- * This helps Zapier/Make.com understand the webhook structure
- */
 export const SAMPLE_WEBHOOK_PAYLOAD: FlatWebhookPayload = {
   event_id: "evt_1234567890",
   event_type: "transaction.completed",
   timestamp: "2026-03-27T11:46:00.000Z",
-  
   transaction_id: "txn_abc123def456",
   reference_number: "REF-20260327-001",
   transaction_type: "deposit",
@@ -63,237 +51,114 @@ export const SAMPLE_WEBHOOK_PAYLOAD: FlatWebhookPayload = {
   provider: "mpesa",
   stellar_address: "GD5DJQDQKEZBDQZBH4ENLN5JTQAVLHKUL2QHYK3LTJY2J5N2Z5Q5K7",
   status: "completed",
-  
   user_id: "user_789",
   notes: "Test transaction",
   tags: "test,deposit",
-  
   created_at: "2026-03-27T11:45:00.000Z",
   updated_at: "2026-03-27T11:46:00.000Z",
-  
   metadata_key: "stellar_hash",
   metadata_value: "abc123def456789...",
-  
   webhook_delivery_status: "delivered",
-  webhook_delivered_at: "2026-03-27T11:46:05.000Z"
+  webhook_delivered_at: "2026-03-27T11:46:05.000Z",
 };
 
-/**
- * Convert transaction to flat webhook payload
- */
-function transactionToFlatPayload(
-  event: WebhookEvent,
-  transaction: any,
-  eventId: string
-): FlatWebhookPayload {
-  const payload: FlatWebhookPayload = {
-    event_id: eventId,
-    event_type: event,
-    timestamp: new Date().toISOString(),
-    
-    transaction_id: transaction.id,
-    reference_number: transaction.referenceNumber,
-    transaction_type: transaction.type,
-    amount: transaction.amount,
-    currency: transaction.currency || "USD",
-    phone_number: transaction.phoneNumber,
-    provider: transaction.provider,
-    stellar_address: transaction.stellarAddress,
-    status: transaction.status,
-    
-    user_id: transaction.userId || undefined,
-    notes: transaction.notes || undefined,
-    tags: transaction.tags ? transaction.tags.join(",") : undefined,
-    
-    created_at: transaction.createdAt.toISOString(),
-    updated_at: transaction.updatedAt ? transaction.updatedAt.toISOString() : undefined,
-    
-    webhook_delivery_status: transaction.webhook_delivery_status,
-    webhook_delivered_at: transaction.webhook_delivered_at ? transaction.webhook_delivered_at.toISOString() : undefined
-  };
-
-  // Flatten first metadata key-value pair for easy access
-  if (transaction.metadata && typeof transaction.metadata === "object") {
-    const entries = Object.entries(transaction.metadata);
-    if (entries.length > 0) {
-      payload.metadata_key = entries[0][0];
-      payload.metadata_value = String(entries[0][1]);
-    }
-  }
-
-  return payload;
-}
-
-/**
- * Generate unique event ID
- */
-function generateEventId(): string {
-  return `evt_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-}
-
-/**
- * Verify webhook signature for incoming webhooks
- */
-function verifyWebhookSignature(
-  payload: string,
-  signature: string | undefined,
-  secret: string,
-): boolean {
-  if (!signature || !signature.startsWith("sha256=")) {
-    return false;
-  }
-
+function verifyWebhookSignature(payload: string, signature: string | undefined, secret: string): boolean {
+  if (!signature || !signature.startsWith("sha256=")) return false;
   const expectedSignature = signature.substring(7);
-  const computedSignature = createHmac("sha256", secret)
-    .update(payload)
-    .digest("hex");
-
-  if (expectedSignature.length !== computedSignature.length) {
-    return false;
-  }
-
-  return timingSafeEqual(
-    Buffer.from(expectedSignature),
-    Buffer.from(computedSignature),
-  );
+  const computedSignature = createHmac("sha256", secret).update(payload).digest("hex");
+  if (expectedSignature.length !== computedSignature.length) return false;
+  return timingSafeEqual(Buffer.from(expectedSignature), Buffer.from(computedSignature));
 }
 
-/**
- * GET /webhooks/schema - Returns webhook schema for discovery
- * This endpoint helps Zapier/Make.com understand the webhook structure
- */
+/** GET /webhooks/settings - returns current compression toggle state */
+router.get("/settings", (req: Request, res: Response) => {
+  res.json({
+    compression: webhookSettings.compression,
+    description: {
+      compression: "When enabled, outgoing webhook payloads are Gzip-compressed (Content-Encoding: gzip). Reduces egress bandwidth for large payloads.",
+    },
+  });
+});
+
+/** PATCH /webhooks/settings - toggle compression on/off. Body: { "compression": true | false } */
+router.patch("/settings", (req: Request, res: Response) => {
+  const { compression } = req.body as { compression?: unknown };
+  if (compression === undefined) {
+    return res.status(400).json({ error: "Missing field: compression (boolean)" });
+  }
+  if (typeof compression !== "boolean") {
+    return res.status(400).json({ error: "Invalid value for 'compression': must be a boolean" });
+  }
+  webhookSettings.compression = compression;
+  console.log(`[webhook-settings] compression set to ${compression}`);
+  return res.json({ updated: true, settings: { compression: webhookSettings.compression } });
+});
+
 router.get("/schema", (req: Request, res: Response) => {
   res.json({
     name: "Mobile Money Webhooks",
     description: "Flat webhook payloads optimized for no-code automation platforms",
     version: "1.0.0",
-    events: [
-      "transaction.completed",
-      "transaction.failed", 
-      "transaction.pending",
-      "transaction.cancelled"
-    ],
+    events: ["transaction.completed", "transaction.failed", "transaction.pending", "transaction.cancelled"],
     sample_payload: SAMPLE_WEBHOOK_PAYLOAD,
+    settings: { compression: webhookSettings.compression },
     schema: {
       type: "object",
       properties: {
-        event_id: { type: "string", description: "Unique event identifier" },
-        event_type: { type: "string", enum: ["transaction.completed", "transaction.failed", "transaction.pending", "transaction.cancelled"] },
-        timestamp: { type: "string", format: "date-time" },
-        transaction_id: { type: "string" },
-        reference_number: { type: "string" },
+        event_id: { type: "string" }, event_type: { type: "string" }, timestamp: { type: "string", format: "date-time" },
+        transaction_id: { type: "string" }, reference_number: { type: "string" },
         transaction_type: { type: "string", enum: ["deposit", "withdraw"] },
-        amount: { type: "string" },
-        currency: { type: "string" },
-        phone_number: { type: "string" },
-        provider: { type: "string" },
-        stellar_address: { type: "string" },
+        amount: { type: "string" }, currency: { type: "string" }, phone_number: { type: "string" },
+        provider: { type: "string" }, stellar_address: { type: "string" },
         status: { type: "string", enum: ["pending", "completed", "failed", "cancelled"] },
-        user_id: { type: "string" },
-        notes: { type: "string" },
-        tags: { type: "string" },
-        created_at: { type: "string", format: "date-time" },
-        updated_at: { type: "string", format: "date-time" },
-        metadata_key: { type: "string" },
-        metadata_value: { type: "string" },
-        webhook_delivery_status: { type: "string" },
-        webhook_delivered_at: { type: "string", format: "date-time" }
-      }
+        user_id: { type: "string" }, notes: { type: "string" }, tags: { type: "string" },
+        created_at: { type: "string", format: "date-time" }, updated_at: { type: "string", format: "date-time" },
+        metadata_key: { type: "string" }, metadata_value: { type: "string" },
+        webhook_delivery_status: { type: "string" }, webhook_delivered_at: { type: "string", format: "date-time" },
+      },
     },
     setup_instructions: {
-      zapier: {
-        webhook_url: `${req.protocol}://${req.get('host')}/api/webhooks`,
-        authentication: "X-Webhook-Signature header with HMAC-SHA256",
-        sample_payload_url: `${req.protocol}://${req.get('host')}/api/webhooks/sample`
-      },
-      make_com: {
-        webhook_url: `${req.protocol}://${req.get('host')}/api/webhooks`,
-        authentication: "X-Webhook-Signature header with HMAC-SHA256", 
-        sample_payload_url: `${req.protocol}://${req.get('host')}/api/webhooks/sample`
-      }
-    }
+      zapier: { webhook_url: `${req.protocol}://${req.get("host")}/api/webhooks`, authentication: "X-Webhook-Signature header with HMAC-SHA256" },
+      make_com: { webhook_url: `${req.protocol}://${req.get("host")}/api/webhooks`, authentication: "X-Webhook-Signature header with HMAC-SHA256" },
+    },
   });
 });
 
-/**
- * GET /webhooks/sample - Returns a sample webhook payload
- * Used by no-code platforms to understand the data structure
- */
-router.get("/sample", (req: Request, res: Response) => {
-  res.json(SAMPLE_WEBHOOK_PAYLOAD);
-});
+router.get("/sample", (req: Request, res: Response) => res.json(SAMPLE_WEBHOOK_PAYLOAD));
 
-/**
- * POST /webhooks - Main webhook endpoint for receiving events
- * Compatible with Zapier/Make.com webhook receivers
- */
 router.post("/", async (req: Request, res: Response) => {
   const webhookSecret = process.env.WEBHOOK_SECRET;
-
   if (!webhookSecret) {
     console.error("[webhook] WEBHOOK_SECRET not configured");
-    return res.status(500).json({ 
-      error: "Webhook processing not configured",
-      setup_url: `${req.protocol}://${req.get('host')}/api/webhooks/schema`
-    });
+    return res.status(500).json({ error: "Webhook processing not configured" });
   }
-
   const signature = req.headers["x-webhook-signature"] as string | undefined;
   const rawPayload = JSON.stringify(req.body);
-
   if (!verifyWebhookSignature(rawPayload, signature, webhookSecret)) {
     console.warn("[webhook] Invalid signature");
     return res.status(401).json({ error: "Invalid signature" });
   }
-
   try {
-    // Process the flat webhook payload
     const payload = req.body as FlatWebhookPayload;
-    
-    // Validate required fields
     if (!payload.transaction_id || !payload.event_type) {
-      console.warn("[webhook] Missing required fields", payload);
       return res.status(400).json({ error: "Missing required fields" });
     }
-
-    // Find and update the transaction if it exists
     const transaction = await transactionModel.findById(payload.transaction_id);
-    
     if (!transaction) {
-      console.warn(`[webhook] Transaction not found: ${payload.transaction_id}`);
-      return res.status(404).json({ 
-        error: "Transaction not found",
-        transaction_id: payload.transaction_id
-      });
+      return res.status(404).json({ error: "Transaction not found", transaction_id: payload.transaction_id });
     }
-
-    // Update transaction status if needed
     if (payload.status && payload.status !== transaction.status) {
-      const newStatus = payload.status as TransactionStatus;
-      await transactionModel.updateStatus(transaction.id, newStatus);
-      console.log(`[webhook] Updated transaction ${transaction.id} to ${newStatus}`);
+      await transactionModel.updateStatus(transaction.id, payload.status as TransactionStatus);
+      console.log(`[webhook] Updated transaction ${transaction.id} to ${payload.status}`);
     }
-
-    // Log successful processing
     console.log(`[webhook] Processed event ${payload.event_id} for transaction ${payload.transaction_id}`);
-
-    return res.status(200).json({
-      success: true,
-      event_id: payload.event_id,
-      transaction_id: payload.transaction_id,
-      processed_at: new Date().toISOString()
-    });
-
+    return res.status(200).json({ success: true, event_id: payload.event_id, transaction_id: payload.transaction_id, processed_at: new Date().toISOString() });
   } catch (error) {
     console.error("[webhook] Processing error", error);
     return res.status(500).json({ error: "Internal server error" });
   }
 });
 
-/**
- * POST /webhooks/test - Test endpoint for webhook delivery testing
- * Returns the received payload for debugging
- */
 router.post("/test", (req: Request, res: Response) => {
   console.log("[webhook-test] Received payload:", req.body);
   res.json({
@@ -301,11 +166,13 @@ router.post("/test", (req: Request, res: Response) => {
     timestamp: new Date().toISOString(),
     payload: req.body,
     headers: {
-      'content-type': req.get('content-type'),
-      'x-webhook-signature': req.get('x-webhook-signature'),
-      'user-agent': req.get('user-agent')
-    }
+      "content-type": req.get("content-type"),
+      "x-webhook-signature": req.get("x-webhook-signature"),
+      "content-encoding": req.get("content-encoding"),
+      "user-agent": req.get("user-agent"),
+    },
   });
 });
 
+export { webhookSettings };
 export default router;

--- a/src/services/webhook.ts
+++ b/src/services/webhook.ts
@@ -1,8 +1,12 @@
 import { createHmac } from "crypto";
+import { gzip } from "zlib";
+import { promisify } from "util";
 import {
   Transaction,
   WebhookDeliveryUpdate,
 } from "../models/transaction";
+
+const gzipAsync = promisify(gzip);
 
 export type WebhookEvent = "transaction.completed" | "transaction.failed";
 export type WebhookDeliveryStatus =
@@ -30,11 +34,9 @@ export interface WebhookOutboxEntry {
   nextAttemptAt?: Date;
   errorMessage?: string;
   createdAt: Date;
+  compress?: boolean;
 }
 
-/**
- * Flat webhook payload optimized for Zapier/Make.com
- */
 export interface FlatWebhookPayload {
   event_id: string;
   event_type: WebhookEvent;
@@ -83,14 +85,13 @@ interface WebhookServiceOptions {
   sleep?: (ms: number) => Promise<void>;
   now?: () => Date;
   logger?: WebhookLogger;
+  /** When true, payloads are Gzip-compressed before sending (Content-Encoding: gzip) */
+  compress?: boolean;
 }
 
 interface WebhookTransactionModel {
   findById(id: string): Promise<Transaction | null>;
-  updateWebhookDelivery(
-    id: string,
-    delivery: WebhookDeliveryUpdate,
-  ): Promise<void>;
+  updateWebhookDelivery(id: string, delivery: WebhookDeliveryUpdate): Promise<void>;
 }
 
 export interface WebhookOutboxModel {
@@ -104,24 +105,17 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function getStringValue(
-  transaction: Record<string, unknown>,
-  ...keys: string[]
-): string | undefined {
+function getStringValue(transaction: Record<string, unknown>, ...keys: string[]): string | undefined {
   for (const key of keys) {
     const value = transaction[key];
-    if (value !== undefined && value !== null) {
-      return String(value);
-    }
+    if (value !== undefined && value !== null) return String(value);
   }
-
   return undefined;
 }
 
 function toWebhookData(transaction: Transaction): Record<string, string> {
   const record = transaction as unknown as Record<string, unknown>;
   const data: Record<string, string> = {};
-
   const mappings: Array<[string, string[]]> = [
     ["id", ["id"]],
     ["referenceNumber", ["referenceNumber", "reference_number"]],
@@ -133,15 +127,23 @@ function toWebhookData(transaction: Transaction): Record<string, string> {
     ["stellarAddress", ["stellarAddress", "stellar_address"]],
     ["userId", ["userId", "user_id"]],
   ];
-
   for (const [targetKey, sourceKeys] of mappings) {
     const value = getStringValue(record, ...sourceKeys);
-    if (value) {
-      data[targetKey] = value;
-    }
+    if (value) data[targetKey] = value;
   }
-
   return data;
+}
+
+/** Gzip-compress the payload if compression is enabled. Returns body + extra headers. */
+async function prepareBody(
+  rawPayload: string,
+  compress: boolean,
+): Promise<{ body: Buffer | string; extraHeaders: Record<string, string> }> {
+  if (compress) {
+    const body = await gzipAsync(Buffer.from(rawPayload, "utf-8"));
+    return { body, extraHeaders: { "Content-Encoding": "gzip" } };
+  }
+  return { body: rawPayload, extraHeaders: {} };
 }
 
 export class WebhookService {
@@ -153,35 +155,31 @@ export class WebhookService {
   private readonly sleepImpl: (ms: number) => Promise<void>;
   private readonly now: () => Date;
   private readonly logger: WebhookLogger;
+  /** Whether to Gzip-compress outgoing webhook payloads */
+  readonly compress: boolean;
 
   constructor(options: WebhookServiceOptions = {}) {
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.webhookUrl = options.webhookUrl ?? process.env.WEBHOOK_URL ?? "";
-    this.webhookSecret =
-      options.webhookSecret ?? process.env.WEBHOOK_SECRET ?? "";
+    this.webhookSecret = options.webhookSecret ?? process.env.WEBHOOK_SECRET ?? "";
     this.maxAttempts = options.maxAttempts ?? 3;
     this.baseDelayMs = options.baseDelayMs ?? 500;
     this.sleepImpl = options.sleep ?? wait;
     this.now = options.now ?? (() => new Date());
     this.logger = options.logger ?? console;
+    this.compress = options.compress ?? (process.env.WEBHOOK_COMPRESSION === "true");
   }
 
   buildPayload(event: WebhookEvent, transaction: Transaction): WebhookPayload {
-    return {
-      event,
-      timestamp: this.now().toISOString(),
-      data: toWebhookData(transaction),
-    };
+    return { event, timestamp: this.now().toISOString(), data: toWebhookData(transaction) };
   }
 
   buildFlatPayload(event: WebhookEvent, transaction: Transaction): FlatWebhookPayload {
     const eventId = `evt_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-
     const payload: FlatWebhookPayload = {
       event_id: eventId,
       event_type: event,
       timestamp: this.now().toISOString(),
-
       transaction_id: transaction.id,
       reference_number: transaction.referenceNumber,
       transaction_type: transaction.type,
@@ -191,19 +189,16 @@ export class WebhookService {
       provider: transaction.provider,
       stellar_address: transaction.stellarAddress,
       status: transaction.status,
-
       user_id: transaction.userId || undefined,
       notes: transaction.notes || undefined,
       tags: transaction.tags ? transaction.tags.join(",") : undefined,
-
       created_at: transaction.createdAt.toISOString(),
       updated_at: transaction.updatedAt ? transaction.updatedAt.toISOString() : undefined,
-
       webhook_delivery_status: (transaction as any).webhook_delivery_status,
-      webhook_delivered_at: (transaction as any).webhook_delivered_at ? (transaction as any).webhook_delivered_at.toISOString() : undefined
+      webhook_delivered_at: (transaction as any).webhook_delivered_at
+        ? (transaction as any).webhook_delivered_at.toISOString()
+        : undefined,
     };
-
-    // Flatten first metadata key-value pair for easy access
     if (transaction.metadata && typeof transaction.metadata === "object") {
       const entries = Object.entries(transaction.metadata);
       if (entries.length > 0) {
@@ -211,212 +206,102 @@ export class WebhookService {
         payload.metadata_value = String(entries[0][1]);
       }
     }
-
     return payload;
   }
 
   signPayload(rawPayload: string): string {
-    return `sha256=${createHmac("sha256", this.webhookSecret)
-      .update(rawPayload)
-      .digest("hex")}`;
+    return `sha256=${createHmac("sha256", this.webhookSecret).update(rawPayload).digest("hex")}`;
   }
 
-  async sendTransactionEvent(
-    event: WebhookEvent,
-    transaction: Transaction,
-  ): Promise<WebhookDeliveryResult> {
+  async sendTransactionEvent(event: WebhookEvent, transaction: Transaction): Promise<WebhookDeliveryResult> {
     if (!this.webhookUrl) {
       const message = "WEBHOOK_URL is not configured";
       this.logger.warn(`[webhook] ${message}`);
-      return {
-        status: "skipped",
-        attempts: 0,
-        lastAttemptAt: null,
-        deliveredAt: null,
-        lastError: message,
-      };
+      return { status: "skipped", attempts: 0, lastAttemptAt: null, deliveredAt: null, lastError: message };
     }
-
     if (!this.webhookSecret) {
       const message = "WEBHOOK_SECRET is not configured";
       this.logger.warn(`[webhook] ${message}`);
-      return {
-        status: "skipped",
-        attempts: 0,
-        lastAttemptAt: null,
-        deliveredAt: null,
-        lastError: message,
-      };
+      return { status: "skipped", attempts: 0, lastAttemptAt: null, deliveredAt: null, lastError: message };
     }
 
     const payload = this.buildPayload(event, transaction);
     const rawPayload = JSON.stringify(payload);
     const signature = this.signPayload(rawPayload);
+    const { body, extraHeaders } = await prepareBody(rawPayload, this.compress);
+
     let lastError: string | null = null;
     let lastStatusCode: number | undefined;
     let lastAttemptAt: Date | null = null;
 
     for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
       lastAttemptAt = this.now();
-
       try {
         const response = await this.fetchImpl(this.webhookUrl, {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Webhook-Signature": signature,
-          },
-          body: rawPayload,
+          headers: { "Content-Type": "application/json", "X-Webhook-Signature": signature, ...extraHeaders },
+          body,
         });
-
         lastStatusCode = response.status;
-
-        if (!response.ok) {
-          throw new Error(`Webhook responded with HTTP ${response.status}`);
-        }
-
-        this.logger.log(
-          `[webhook] delivered event=${event} transactionId=${payload.data.id} attempt=${attempt}`,
-        );
-
-        return {
-          status: "delivered",
-          attempts: attempt,
-          statusCode: response.status,
-          lastAttemptAt,
-          deliveredAt: lastAttemptAt,
-          lastError: null,
-        };
+        if (!response.ok) throw new Error(`Webhook responded with HTTP ${response.status}`);
+        this.logger.log(`[webhook] delivered event=${event} transactionId=${payload.data.id} attempt=${attempt} compressed=${this.compress}`);
+        return { status: "delivered", attempts: attempt, statusCode: response.status, lastAttemptAt, deliveredAt: lastAttemptAt, lastError: null };
       } catch (error) {
-        lastError =
-          error instanceof Error ? error.message : "Unknown webhook error";
-
-        this.logger.warn(
-          `[webhook] delivery failed event=${event} transactionId=${payload.data.id} attempt=${attempt}/${this.maxAttempts}: ${lastError}`,
-        );
-
-        if (attempt < this.maxAttempts) {
-          await this.sleepImpl(this.baseDelayMs * 2 ** (attempt - 1));
-        }
+        lastError = error instanceof Error ? error.message : "Unknown webhook error";
+        this.logger.warn(`[webhook] delivery failed event=${event} transactionId=${payload.data.id} attempt=${attempt}/${this.maxAttempts}: ${lastError}`);
+        if (attempt < this.maxAttempts) await this.sleepImpl(this.baseDelayMs * 2 ** (attempt - 1));
       }
     }
 
-    this.logger.error(
-      `[webhook] delivery exhausted event=${event} transactionId=${payload.data.id}: ${lastError}`,
-    );
-
-    return {
-      status: "failed",
-      attempts: this.maxAttempts,
-      statusCode: lastStatusCode,
-      lastAttemptAt,
-      deliveredAt: null,
-      lastError,
-    };
+    this.logger.error(`[webhook] delivery exhausted event=${event} transactionId=${payload.data.id}: ${lastError}`);
+    return { status: "failed", attempts: this.maxAttempts, statusCode: lastStatusCode, lastAttemptAt, deliveredAt: null, lastError };
   }
 
-  async sendFlatTransactionEvent(
-    event: WebhookEvent,
-    transaction: Transaction,
-  ): Promise<WebhookDeliveryResult> {
+  async sendFlatTransactionEvent(event: WebhookEvent, transaction: Transaction): Promise<WebhookDeliveryResult> {
     if (!this.webhookUrl) {
       const message = "WEBHOOK_URL is not configured";
       this.logger.warn(`[webhook] ${message}`);
-      return {
-        status: "skipped",
-        attempts: 0,
-        lastAttemptAt: null,
-        deliveredAt: null,
-        lastError: message,
-      };
+      return { status: "skipped", attempts: 0, lastAttemptAt: null, deliveredAt: null, lastError: message };
     }
-
     if (!this.webhookSecret) {
       const message = "WEBHOOK_SECRET is not configured";
       this.logger.warn(`[webhook] ${message}`);
-      return {
-        status: "skipped",
-        attempts: 0,
-        lastAttemptAt: null,
-        deliveredAt: null,
-        lastError: message,
-      };
+      return { status: "skipped", attempts: 0, lastAttemptAt: null, deliveredAt: null, lastError: message };
     }
 
     const payload = this.buildFlatPayload(event, transaction);
     const rawPayload = JSON.stringify(payload);
     const signature = this.signPayload(rawPayload);
+    const { body, extraHeaders } = await prepareBody(rawPayload, this.compress);
+
     let lastError: string | null = null;
     let lastStatusCode: number | undefined;
     let lastAttemptAt: Date | null = null;
 
     for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
       lastAttemptAt = this.now();
-
       try {
         const response = await this.fetchImpl(this.webhookUrl, {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Webhook-Signature": signature,
-          },
-          body: rawPayload,
+          headers: { "Content-Type": "application/json", "X-Webhook-Signature": signature, ...extraHeaders },
+          body,
         });
-
         lastStatusCode = response.status;
-
-        if (!response.ok) {
-          throw new Error(`Webhook responded with HTTP ${response.status}`);
-        }
-
-        this.logger.log(
-          `[webhook] delivered flat event=${event} transactionId=${payload.transaction_id} attempt=${attempt}`,
-        );
-
-        return {
-          status: "delivered",
-          attempts: attempt,
-          statusCode: response.status,
-          lastAttemptAt,
-          deliveredAt: lastAttemptAt,
-          lastError: null,
-        };
+        if (!response.ok) throw new Error(`Webhook responded with HTTP ${response.status}`);
+        this.logger.log(`[webhook] delivered flat event=${event} transactionId=${payload.transaction_id} attempt=${attempt} compressed=${this.compress}`);
+        return { status: "delivered", attempts: attempt, statusCode: response.status, lastAttemptAt, deliveredAt: lastAttemptAt, lastError: null };
       } catch (error) {
-        lastError =
-          error instanceof Error ? error.message : "Unknown webhook error";
-
-        this.logger.warn(
-          `[webhook] delivery failed flat event=${event} transactionId=${payload.transaction_id} attempt=${attempt}/${this.maxAttempts}: ${lastError}`,
-        );
-
-        if (attempt < this.maxAttempts) {
-          await this.sleepImpl(this.baseDelayMs * 2 ** (attempt - 1));
-        }
+        lastError = error instanceof Error ? error.message : "Unknown webhook error";
+        this.logger.warn(`[webhook] delivery failed flat event=${event} transactionId=${payload.transaction_id} attempt=${attempt}/${this.maxAttempts}: ${lastError}`);
+        if (attempt < this.maxAttempts) await this.sleepImpl(this.baseDelayMs * 2 ** (attempt - 1));
       }
     }
 
-    this.logger.error(
-      `[webhook] delivery exhausted flat event=${event} transactionId=${payload.transaction_id}: ${lastError}`,
-    );
-
-    return {
-      status: "failed",
-      attempts: this.maxAttempts,
-      statusCode: lastStatusCode,
-      lastAttemptAt,
-      deliveredAt: null,
-      lastError,
-    };
+    this.logger.error(`[webhook] delivery exhausted flat event=${event} transactionId=${payload.transaction_id}: ${lastError}`);
+    return { status: "failed", attempts: this.maxAttempts, statusCode: lastStatusCode, lastAttemptAt, deliveredAt: null, lastError };
   }
 
-  /**
-   * Process a batch of entries from the webhook outbox.
-   * Implementing the worker part of the Outbox Pattern.
-   */
-  async processOutbox(
-    outboxModel: WebhookOutboxModel,
-    batchSize: number = 10,
-  ): Promise<{ processed: number; failures: number }> {
+  async processOutbox(outboxModel: WebhookOutboxModel, batchSize: number = 10): Promise<{ processed: number; failures: number }> {
     const entries = await outboxModel.findNextToProcess(batchSize);
     let processed = 0;
     let failures = 0;
@@ -424,62 +309,31 @@ export class WebhookService {
     for (const entry of entries) {
       const rawPayload = JSON.stringify(entry.payload);
       const signature = this.signPayload(rawPayload);
+      const useCompress = entry.compress ?? this.compress;
+      const { body, extraHeaders } = await prepareBody(rawPayload, useCompress);
       const now = this.now();
 
       try {
         const response = await this.fetchImpl(this.webhookUrl, {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Webhook-Signature": signature,
-          },
-          body: rawPayload,
+          headers: { "Content-Type": "application/json", "X-Webhook-Signature": signature, ...extraHeaders },
+          body,
         });
-
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-
-        this.logger.log(`[webhook-outbox] Delivered entry=${entry.id}`);
-
-        // Successfully delivered
-        await outboxModel.update(entry.id, {
-          status: "delivered",
-          attempts: entry.attempts + 1,
-          lastAttemptAt: now,
-          errorMessage: undefined,
-        });
-
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        this.logger.log(`[webhook-outbox] Delivered entry=${entry.id} compressed=${useCompress}`);
+        await outboxModel.update(entry.id, { status: "delivered", attempts: entry.attempts + 1, lastAttemptAt: now, errorMessage: undefined });
         processed++;
       } catch (error) {
         failures++;
         const errorMessage = error instanceof Error ? error.message : String(error);
         const attempts = entry.attempts + 1;
-
         if (attempts >= entry.maxAttempts) {
-          await outboxModel.update(entry.id, {
-            status: "failed",
-            attempts,
-            lastAttemptAt: now,
-            errorMessage: `Exhausted retries: ${errorMessage}`,
-          });
+          await outboxModel.update(entry.id, { status: "failed", attempts, lastAttemptAt: now, errorMessage: `Exhausted retries: ${errorMessage}` });
         } else {
-          // Exponential backoff for retries
           const backoffMs = this.baseDelayMs * Math.pow(2, attempts - 1);
-          const nextAttemptAt = new Date(now.getTime() + backoffMs);
-
-          await outboxModel.update(entry.id, {
-            status: "pending", // Reset to pending for next retry
-            attempts,
-            lastAttemptAt: now,
-            nextAttemptAt,
-            errorMessage,
-          });
+          await outboxModel.update(entry.id, { status: "pending", attempts, lastAttemptAt: now, nextAttemptAt: new Date(now.getTime() + backoffMs), errorMessage });
         }
-
-        this.logger.warn(
-          `[webhook-outbox] Failed to deliver entry=${entry.id} attempt=${attempts}/${entry.maxAttempts}: ${errorMessage}`,
-        );
+        this.logger.warn(`[webhook-outbox] Failed to deliver entry=${entry.id} attempt=${attempts}/${entry.maxAttempts}: ${errorMessage}`);
       }
     }
 
@@ -490,40 +344,22 @@ export class WebhookService {
 export async function notifyTransactionWebhook(
   transactionId: string,
   event: WebhookEvent,
-  dependencies: {
-    transactionModel: WebhookTransactionModel;
-    webhookService?: WebhookService;
-    logger?: WebhookLogger;
-  },
+  dependencies: { transactionModel: WebhookTransactionModel; webhookService?: WebhookService; logger?: WebhookLogger },
 ): Promise<WebhookDeliveryResult | null> {
-  const webhookService =
-    dependencies.webhookService ?? new WebhookService();
+  const webhookService = dependencies.webhookService ?? new WebhookService();
   const logger = dependencies.logger ?? console;
   const transaction = await dependencies.transactionModel.findById(transactionId);
-
   if (!transaction) {
-    logger.warn(
-      `[webhook] skipped event=${event} transactionId=${transactionId}: transaction not found`,
-    );
+    logger.warn(`[webhook] skipped event=${event} transactionId=${transactionId}: transaction not found`);
     return null;
   }
-
   const result = await webhookService.sendTransactionEvent(event, transaction);
-
   await dependencies.transactionModel.updateWebhookDelivery(transactionId, {
-    status: result.status,
-    lastAttemptAt: result.lastAttemptAt,
-    deliveredAt: result.deliveredAt,
-    lastError: result.lastError ?? null,
+    status: result.status, lastAttemptAt: result.lastAttemptAt, deliveredAt: result.deliveredAt, lastError: result.lastError ?? null,
   });
-
   return result;
 }
 
-/**
- * Records a webhook event into the outbox for asynchronous processing.
- * This should be called within the same database transaction as the business operation.
- */
 export async function enqueueTransactionWebhook(
   transactionId: string,
   event: WebhookEvent,
@@ -532,60 +368,41 @@ export async function enqueueTransactionWebhook(
     outboxModel: WebhookOutboxModel;
     webhookService?: WebhookService;
     useFlatPayload?: boolean;
+    compress?: boolean;
   },
 ): Promise<string | null> {
   const webhookService = dependencies.webhookService ?? new WebhookService();
   const transaction = await dependencies.transactionModel.findById(transactionId);
-
-  if (!transaction) {
-    return null;
-  }
-
+  if (!transaction) return null;
   const payload = dependencies.useFlatPayload
     ? webhookService.buildFlatPayload(event, transaction)
     : webhookService.buildPayload(event, transaction);
-
-  const entryId = await dependencies.outboxModel.insert({
+  return dependencies.outboxModel.insert({
     eventType: event,
     payload,
     status: "pending",
     attempts: 0,
     maxAttempts: 5,
     nextAttemptAt: new Date(),
+    compress: dependencies.compress ?? webhookService.compress,
   });
-
-  return entryId;
 }
 
 export async function notifyFlatTransactionWebhook(
   transactionId: string,
   event: WebhookEvent,
-  dependencies: {
-    transactionModel: WebhookTransactionModel;
-    webhookService?: WebhookService;
-    logger?: WebhookLogger;
-  },
+  dependencies: { transactionModel: WebhookTransactionModel; webhookService?: WebhookService; logger?: WebhookLogger },
 ): Promise<WebhookDeliveryResult | null> {
-  const webhookService =
-    dependencies.webhookService ?? new WebhookService();
+  const webhookService = dependencies.webhookService ?? new WebhookService();
   const logger = dependencies.logger ?? console;
   const transaction = await dependencies.transactionModel.findById(transactionId);
-
   if (!transaction) {
-    logger.warn(
-      `[webhook] skipped flat event=${event} transactionId=${transactionId}: transaction not found`,
-    );
+    logger.warn(`[webhook] skipped flat event=${event} transactionId=${transactionId}: transaction not found`);
     return null;
   }
-
   const result = await webhookService.sendFlatTransactionEvent(event, transaction);
-
   await dependencies.transactionModel.updateWebhookDelivery(transactionId, {
-    status: result.status,
-    lastAttemptAt: result.lastAttemptAt,
-    deliveredAt: result.deliveredAt,
-    lastError: result.lastError ?? null,
+    status: result.status, lastAttemptAt: result.lastAttemptAt, deliveredAt: result.deliveredAt, lastError: result.lastError ?? null,
   });
-
   return result;
 }


### PR DESCRIPTION
Closes #737 

## Changes
- `src/services/webhook.ts` — added `compress` option; `prepareBody()` gzips payload via Node `zlib` when enabled; signature always computed on raw JSON; outbox entries carry per-entry `compress` flag
- `src/routes/webhooks.ts` — added `GET /webhooks/settings` and `PATCH /webhooks/settings` to toggle compression on/off at runtime

## How to test
# Enable via env var
WEBHOOK_COMPRESSION=true

# Or toggle at runtime
curl -X PATCH http://localhost:3000/api/webhooks/settings \
  -H "Content-Type: application/json" \
  -d '{"compression": true}'

# Check current setting
curl http://localhost:3000/api/webhooks/settings