### PR TITLE
feat(dev): add provider mock server for offline development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,9 +180,22 @@ CHANNEL_POOL_QUEUE_TIMEOUT_MS=10000
 MTN_API_KEY=your_mtn_api_key
 MTN_API_SECRET=your_mtn_api_secret
 MTN_SUBSCRIPTION_KEY=your_mtn_subscription_key
+MTN_BASE_URL=https://sandbox.momodeveloper.mtn.com
+MTN_TARGET_ENVIRONMENT=sandbox
 
 AIRTEL_API_KEY=your_airtel_api_key
 AIRTEL_API_SECRET=your_airtel_api_secret
+AIRTEL_BASE_URL=https://openapi.airtel.africa
+AIRTEL_COUNTRY=NG
+AIRTEL_CURRENCY=NGN
+
+# Local provider mock server for offline development.
+# In Docker development, set MTN_BASE_URL=http://provider-mock:4010/mtn
+# and AIRTEL_BASE_URL=http://provider-mock:4010/airtel.
+PROVIDER_MOCK_PORT=4010
+PROVIDER_MOCK_DELAY_MS=0
+PROVIDER_MOCK_BALANCE=100000
+PROVIDER_MOCK_CURRENCY=XAF
 
 ORANGE_API_KEY=your_orange_api_key
 ORANGE_API_SECRET=your_orange_api_secret

--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ npm run docker:dev:down
 
 Includes hot reload and debugger on port `9229`.
 
+The development compose stack now also starts a local provider mock server on
+`http://localhost:4010` and points MTN/Airtel traffic at it automatically.
+Use `?scenario=success|failed|pending` or `x-mock-scenario` to control mock
+responses, and `?delayMs=...` or `x-mock-delay-ms` to simulate timeouts.
+
+To run only the mock server outside Docker:
+
+```bash
+npm run provider-mock:dev
+```
+
 ### Docker Production
 
 ```bash

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,11 +15,17 @@ services:
       - NODE_ENV=development
       - DATABASE_URL=postgresql://user:password@db:5432/mobilemoney_stellar
       - REDIS_URL=redis://redis:6379
+      - MTN_BASE_URL=http://provider-mock:4010/mtn
+      - MTN_TARGET_ENVIRONMENT=sandbox
+      - AIRTEL_BASE_URL=http://provider-mock:4010/airtel
+      - AIRTEL_COUNTRY=NG
+      - AIRTEL_CURRENCY=NGN
     env_file:
       - .env
     depends_on:
       - db
       - redis
+      - provider-mock
 
   db:
     image: postgres:16-alpine
@@ -39,6 +45,22 @@ services:
     volumes:
       - redis_dev_data:/data
     command: redis-server --appendonly yes
+
+  provider-mock:
+    image: node:20-alpine
+    working_dir: /app
+    command: npx tsx watch scripts/provider-mock-server.ts
+    ports:
+      - "4010:4010"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - NODE_ENV=development
+      - PROVIDER_MOCK_PORT=4010
+      - PROVIDER_MOCK_DELAY_MS=0
+      - PROVIDER_MOCK_BALANCE=100000
+      - PROVIDER_MOCK_CURRENCY=XAF
 
 volumes:
   postgres_dev_data:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "tsx watch src/index.ts",
     "docker:dev": "docker-compose -f docker-compose.dev.yml up",
     "docker:dev:down": "docker-compose -f docker-compose.dev.yml down",
+    "provider-mock:dev": "tsx scripts/provider-mock-server.ts",
     "build": "tsc --noEmitOnError false || true",
     "start": "node dist/index.js",
     "lint": "eslint src --ext .ts",

--- a/scripts/provider-mock-server.ts
+++ b/scripts/provider-mock-server.ts
@@ -1,0 +1,384 @@
+import { randomUUID } from "crypto";
+import { Server } from "http";
+import { Request, Response } from "express";
+import express = require("express");
+
+type MockScenario = "success" | "failed" | "pending";
+
+interface StoredTransaction {
+  provider: "mtn" | "airtel";
+  scenario: MockScenario;
+  createdAt: string;
+}
+
+interface MockRequestBody {
+  scenario?: string;
+  delayMs?: number | string;
+  externalId?: string;
+  reference?: string;
+  transaction?: {
+    id?: string;
+  };
+}
+
+const DEFAULT_PORT = Number.parseInt(
+  process.env.PROVIDER_MOCK_PORT || "4010",
+  10,
+);
+const DEFAULT_DELAY_MS = Number.parseInt(
+  process.env.PROVIDER_MOCK_DELAY_MS || "0",
+  10,
+);
+const DEFAULT_BALANCE = process.env.PROVIDER_MOCK_BALANCE || "100000";
+const DEFAULT_CURRENCY = process.env.PROVIDER_MOCK_CURRENCY || "XAF";
+
+function normalizeScenario(value: unknown): MockScenario {
+  const normalized = String(value || "success")
+    .trim()
+    .toLowerCase();
+
+  if (
+    normalized === "fail" ||
+    normalized === "failed" ||
+    normalized === "error"
+  ) {
+    return "failed";
+  }
+
+  if (normalized === "pending") {
+    return "pending";
+  }
+
+  return "success";
+}
+
+function toDelayMs(value: unknown): number | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function getScenario(
+  req: Request<unknown, unknown, MockRequestBody>,
+): MockScenario {
+  return normalizeScenario(
+    req.query.scenario ||
+      req.header("x-mock-scenario") ||
+      req.body?.scenario ||
+      process.env.PROVIDER_MOCK_SCENARIO,
+  );
+}
+
+function getDelayMs(req: Request<unknown, unknown, MockRequestBody>): number {
+  return (
+    toDelayMs(req.query.delayMs) ??
+    toDelayMs(req.header("x-mock-delay-ms")) ??
+    toDelayMs(req.body?.delayMs) ??
+    DEFAULT_DELAY_MS
+  );
+}
+
+function getMtnStatus(
+  scenario: MockScenario,
+): "SUCCESSFUL" | "FAILED" | "PENDING" {
+  if (scenario === "failed") return "FAILED";
+  if (scenario === "pending") return "PENDING";
+  return "SUCCESSFUL";
+}
+
+function getAirtelStatus(scenario: MockScenario): "TS" | "TF" | "TP" {
+  if (scenario === "failed") return "TF";
+  if (scenario === "pending") return "TP";
+  return "TS";
+}
+
+async function applyDelay(
+  req: Request<unknown, unknown, MockRequestBody>,
+): Promise<void> {
+  const delayMs = getDelayMs(req);
+
+  if (delayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}
+
+function getReferenceId(
+  req: Request<unknown, unknown, MockRequestBody>,
+  fallbackPrefix: string,
+): string {
+  return (
+    req.header("X-Reference-Id") ||
+    req.body?.externalId ||
+    req.body?.reference ||
+    req.body?.transaction?.id ||
+    `${fallbackPrefix}-${randomUUID()}`
+  );
+}
+
+export function createProviderMockApp() {
+  const app = express();
+  const transactions = new Map<string, StoredTransaction>();
+
+  app.use(express.json());
+
+  app.get("/health", (_req: Request, res: Response) => {
+    res.json({
+      status: "ok",
+      providers: ["mtn", "airtel"],
+    });
+  });
+
+  app.post(
+    "/mtn/collection/token/",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      res.json({
+        access_token: "mock-mtn-access-token",
+        token_type: "access_token",
+        expires_in: 3600,
+      });
+    },
+  );
+
+  app.post(
+    "/mtn/collection/v1_0/requesttopay",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      const referenceId = getReferenceId(req, "mtn");
+
+      transactions.set(referenceId, {
+        provider: "mtn",
+        scenario,
+        createdAt: new Date().toISOString(),
+      });
+
+      if (scenario === "failed") {
+        return res.status(400).json({
+          status: "FAILED",
+          referenceId,
+          message: "Mock MTN request-to-pay failure",
+        });
+      }
+
+      return res.status(202).json({
+        status: getMtnStatus(scenario),
+        referenceId,
+        message: "Mock MTN request-to-pay accepted",
+      });
+    },
+  );
+
+  app.get(
+    "/mtn/collection/v1_0/requesttopay/:referenceId",
+    async (
+      req: Request<{ referenceId: string }, unknown, MockRequestBody>,
+      res: Response,
+    ) => {
+      await applyDelay(req);
+
+      const stored = transactions.get(req.params.referenceId);
+      const scenario = stored?.scenario || getScenario(req);
+
+      return res.json({
+        referenceId: req.params.referenceId,
+        status: getMtnStatus(scenario),
+      });
+    },
+  );
+
+  app.get(
+    "/mtn/disbursement/v1_0/account/balance",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      if (scenario === "failed") {
+        return res.status(503).json({
+          message: "Mock MTN balance service unavailable",
+        });
+      }
+
+      return res.json({
+        availableBalance: DEFAULT_BALANCE,
+        currency: DEFAULT_CURRENCY,
+      });
+    },
+  );
+
+  app.post(
+    "/airtel/auth/oauth2/token",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      res.json({
+        access_token: "mock-airtel-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    },
+  );
+
+  app.post(
+    "/airtel/merchant/v1/payments/",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      const referenceId = getReferenceId(req, "airtel-pay");
+
+      transactions.set(referenceId, {
+        provider: "airtel",
+        scenario,
+        createdAt: new Date().toISOString(),
+      });
+
+      if (scenario === "failed") {
+        return res.status(400).json({
+          status: {
+            success: false,
+            code: "DP_REQUEST_FAILED",
+          },
+          data: {
+            transaction: {
+              id: referenceId,
+              status: getAirtelStatus(scenario),
+            },
+          },
+        });
+      }
+
+      return res.status(200).json({
+        status: {
+          success: true,
+          code: scenario === "pending" ? "DP_PENDING" : "DP_SUCCESS",
+        },
+        data: {
+          transaction: {
+            id: referenceId,
+            status: getAirtelStatus(scenario),
+          },
+        },
+      });
+    },
+  );
+
+  app.get(
+    "/airtel/standard/v1/payments/:reference",
+    async (
+      req: Request<{ reference: string }, unknown, MockRequestBody>,
+      res: Response,
+    ) => {
+      await applyDelay(req);
+
+      const stored = transactions.get(req.params.reference);
+      const scenario = stored?.scenario || getScenario(req);
+
+      return res.json({
+        status: {
+          success: scenario !== "failed",
+          code: scenario === "failed" ? "DP_STATUS_FAILED" : "DP_STATUS_OK",
+        },
+        data: {
+          transaction: {
+            id: req.params.reference,
+            status: getAirtelStatus(scenario),
+          },
+        },
+      });
+    },
+  );
+
+  app.get(
+    "/airtel/standard/v1/users/balance",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      if (scenario === "failed") {
+        return res.status(503).json({
+          status: {
+            success: false,
+            code: "BALANCE_UNAVAILABLE",
+          },
+        });
+      }
+
+      return res.json({
+        status: {
+          success: true,
+          code: "BALANCE_OK",
+        },
+        data: {
+          availableBalance: DEFAULT_BALANCE,
+          currency: process.env.AIRTEL_CURRENCY || "NGN",
+        },
+      });
+    },
+  );
+
+  app.post(
+    "/airtel/standard/v1/disbursements/",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      const referenceId = getReferenceId(req, "airtel-payout");
+
+      transactions.set(referenceId, {
+        provider: "airtel",
+        scenario,
+        createdAt: new Date().toISOString(),
+      });
+
+      if (scenario === "failed") {
+        return res.status(400).json({
+          status: {
+            success: false,
+            code: "DS_REQUEST_FAILED",
+          },
+          data: {
+            transaction: {
+              id: referenceId,
+              status: getAirtelStatus(scenario),
+            },
+          },
+        });
+      }
+
+      return res.status(200).json({
+        status: {
+          success: true,
+          code: scenario === "pending" ? "DS_PENDING" : "DS_SUCCESS",
+        },
+        data: {
+          transaction: {
+            id: referenceId,
+            status: getAirtelStatus(scenario),
+          },
+        },
+      });
+    },
+  );
+
+  return app;
+}
+
+export function startProviderMockServer(port = DEFAULT_PORT): Server {
+  const app = createProviderMockApp();
+
+  return app.listen(port, () => {
+    console.info(
+      `[provider-mock] listening on port ${port} for MTN and Airtel mock traffic`,
+    );
+  });
+}
+
+if (require.main === module) {
+  startProviderMockServer();
+}

--- a/src/services/mobilemoney/mobileMoneyService.ts
+++ b/src/services/mobilemoney/mobileMoneyService.ts
@@ -2,5 +2,26 @@ export type ProviderTransactionStatus =
   | "completed"
   | "failed"
   | "pending"
-  | "unknown";git add .
-git commit
+  | "unknown";
+
+export interface MobileMoneyProvider {
+  requestPayment(
+    phoneNumber: string,
+    amount: string,
+  ): Promise<{ success: boolean; data?: unknown; error?: unknown }>;
+  sendPayout(
+    phoneNumber: string,
+    amount: string,
+  ): Promise<{ success: boolean; data?: unknown; error?: unknown }>;
+  getTransactionStatus(
+    referenceId: string,
+  ): Promise<{ status: ProviderTransactionStatus }>;
+}
+
+// The source TypeScript implementation is currently unavailable in this clone,
+// but the compiled CommonJS artifact is committed and used throughout the app.
+// Re-export it here so TypeScript consumers can continue importing the module.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { MobileMoneyService } = require("./mobileMoneyService.js");
+
+export { MobileMoneyService };

--- a/tests/scripts/providerMockServer.test.ts
+++ b/tests/scripts/providerMockServer.test.ts
@@ -1,0 +1,79 @@
+import { createProviderMockApp } from "../../scripts/provider-mock-server";
+import request = require("supertest");
+
+describe("provider mock server", () => {
+  const app = createProviderMockApp();
+
+  it("serves health information", async () => {
+    const response = await request(app).get("/health");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: "ok",
+      providers: ["mtn", "airtel"],
+    });
+  });
+
+  it("stores MTN pending transactions and returns the matching status", async () => {
+    const createResponse = await request(app)
+      .post("/mtn/collection/v1_0/requesttopay?scenario=pending")
+      .send({
+        externalId: "mtn-ref-123",
+      });
+
+    expect(createResponse.status).toBe(202);
+    expect(createResponse.body.status).toBe("PENDING");
+
+    const statusResponse = await request(app).get(
+      "/mtn/collection/v1_0/requesttopay/mtn-ref-123",
+    );
+
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body).toMatchObject({
+      referenceId: "mtn-ref-123",
+      status: "PENDING",
+    });
+  });
+
+  it("returns Airtel success status codes for stored transactions", async () => {
+    const createResponse = await request(app)
+      .post("/airtel/merchant/v1/payments/")
+      .send({
+        reference: "airtel-ref-123",
+        scenario: "success",
+      });
+
+    expect(createResponse.status).toBe(200);
+    expect(createResponse.body.data.transaction.status).toBe("TS");
+
+    const statusResponse = await request(app).get(
+      "/airtel/standard/v1/payments/airtel-ref-123",
+    );
+
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body.data.transaction.status).toBe("TS");
+  });
+
+  it("supports custom per-request delays", async () => {
+    const startedAt = Date.now();
+
+    const response = await request(app)
+      .get("/mtn/disbursement/v1_0/account/balance")
+      .set("x-mock-delay-ms", "60");
+
+    expect(response.status).toBe(200);
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(50);
+  });
+
+  it("returns provider failures when requested", async () => {
+    const response = await request(app).get(
+      "/airtel/standard/v1/users/balance?scenario=failed",
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.body.status).toEqual({
+      success: false,
+      code: "BALANCE_UNAVAILABLE",
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a lightweight Express-based provider mock server for local development so
MTN and Airtel flows can be exercised without external network access.

## Related Issue

Closes #580

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Added a local provider mock server with MTN and Airtel-style auth, payment,
  status, and balance endpoints
- Added support for success, failed, and pending scenarios plus custom
  per-request delays for timeout testing
- Wired the mock server into `docker-compose.dev.yml` and documented local
  usage in `README.md` and `.env.example`
- Added focused tests covering health, status transitions, delay handling, and
  failure responses

## Testing

- `npx jest tests/scripts/providerMockServer.test.ts --runInBand`
- `npx tsc --noEmit --pretty false scripts/provider-mock-server.ts tests/scripts/providerMockServer.test.ts src/services/mobilemoney/mobileMoneyService.ts`

## Checklist

- [x] Code follows project style
- [x] Self-reviewed my code
- [x] Commented complex code
- [x] Updated documentation
- [x] No new warnings
- [x] Added tests (if applicable)

## Additional Notes

- `src/services/mobilemoney/mobileMoneyService.ts` was restored as a typed
  re-export of the committed CommonJS build artifact so TypeScript consumers can
  continue importing it in this clone.
- Repo-wide `npm run lint` and `npx tsc --noEmit` still surface pre-existing
  issues outside this change set, so validation here was scoped to the new
  mock-server files.
