### PR TITLE
[HARD] Build Internal 'API Documentation Portal' (Redoc)

### DIFF
--- a/.github/workflows/api-docs-portal.yml
+++ b/.github/workflows/api-docs-portal.yml
@@ -1,0 +1,53 @@
+name: API Docs Portal
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: docs-portal
+
+      - name: Build Docusaurus + Redoc portal
+        run: npm run build
+        working-directory: docs-portal
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-portal/build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -793,3 +793,23 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ---
 
 **Built with ❤️ for financial inclusion in Africa**
+
+## 📚 Internal API Documentation Portal (Docusaurus + Redoc)
+
+This repository now includes a dedicated documentation portal in `docs-portal/` that transforms `openapi.yaml` into a searchable, partner-friendly API reference.
+
+### Run docs portal locally
+
+```bash
+npm run docs:dev
+```
+
+### Build docs portal
+
+```bash
+npm run docs:build
+```
+
+### Release deployment
+
+On every GitHub Release publication, the workflow `.github/workflows/api-docs-portal.yml` builds `docs-portal` and deploys it to GitHub Pages.

--- a/docs-portal/docusaurus.config.ts
+++ b/docs-portal/docusaurus.config.ts
@@ -1,0 +1,66 @@
+import type { Config } from '@docusaurus/types';
+import type * as Preset from '@docusaurus/preset-classic';
+
+const config: Config = {
+  title: 'Mobile Money API Portal',
+  tagline: 'Searchable API docs powered by OpenAPI + Redoc',
+  favicon: 'img/logo.svg',
+
+  future: {
+    v4: true,
+  },
+
+  url: 'https://sublime247.github.io',
+  baseUrl: '/mobile-money/',
+
+  organizationName: 'sublime247',
+  projectName: 'mobile-money',
+
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
+
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en'],
+  },
+
+  presets: [
+    [
+      'classic',
+      {
+        docs: false,
+        blog: false,
+        theme: {
+          customCss: './src/css/custom.css',
+        },
+      } satisfies Preset.Options,
+    ],
+  ],
+
+  themeConfig: {
+    navbar: {
+      title: 'Mobile Money API',
+      items: [
+        { to: '/', label: 'Overview', position: 'left' },
+        { to: '/api', label: 'Reference', position: 'left' },
+        {
+          href: 'https://github.com/sublime247/mobile-money',
+          label: 'GitHub',
+          position: 'right',
+        },
+      ],
+    },
+    footer: {
+      style: 'dark',
+      links: [
+        {
+          title: 'Docs',
+          items: [{ label: 'API Reference', to: '/api' }],
+        },
+      ],
+      copyright: `Copyright © ${new Date().getFullYear()} Mobile Money`,
+    },
+  } satisfies Preset.ThemeConfig,
+};
+
+export default config;

--- a/docs-portal/package.json
+++ b/docs-portal/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mobile-money-docs-portal",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "sync:openapi": "cp ../openapi.yaml ./static/openapi.yaml",
+    "start": "npm run sync:openapi && docusaurus start --port 3001",
+    "build": "npm run sync:openapi && docusaurus build",
+    "serve": "docusaurus serve",
+    "deploy": "docusaurus deploy"
+  },
+  "dependencies": {
+    "@docusaurus/core": "3.9.2",
+    "@docusaurus/preset-classic": "3.9.2",
+    "@mdx-js/react": "^3.1.1",
+    "clsx": "^2.1.1",
+    "prism-react-renderer": "^2.4.1",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "redoc": "^2.5.1"
+  }
+}

--- a/docs-portal/src/components/ApiReference.tsx
+++ b/docs-portal/src/components/ApiReference.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { RedocStandalone } from 'redoc';
+
+export default function ApiReference(): React.JSX.Element {
+  return (
+    <RedocStandalone
+      specUrl="/openapi.yaml"
+      options={{
+        hideHostname: false,
+        disableSearch: false,
+        expandResponses: '200,201',
+        requiredPropsFirst: true,
+        sortPropsAlphabetically: true,
+      }}
+    />
+  );
+}

--- a/docs-portal/src/css/custom.css
+++ b/docs-portal/src/css/custom.css
@@ -1,0 +1,9 @@
+:root {
+  --ifm-color-primary: #2e8555;
+  --ifm-color-primary-dark: #29784c;
+  --ifm-color-primary-darker: #277148;
+  --ifm-color-primary-darkest: #205d3b;
+  --ifm-color-primary-light: #33925e;
+  --ifm-color-primary-lighter: #359962;
+  --ifm-color-primary-lightest: #3cad6e;
+}

--- a/docs-portal/src/pages/api.tsx
+++ b/docs-portal/src/pages/api.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
+export default function ApiPage(): React.JSX.Element {
+  return (
+    <Layout title="API Reference" description="Mobile Money REST API reference">
+      <BrowserOnly fallback={<p style={{ padding: '2rem' }}>Loading API reference...</p>}>
+        {() => {
+          const ApiReference = require('../components/ApiReference').default;
+          return <ApiReference />;
+        }}
+      </BrowserOnly>
+    </Layout>
+  );
+}

--- a/docs-portal/src/pages/index.tsx
+++ b/docs-portal/src/pages/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+
+export default function Home(): React.JSX.Element {
+  return (
+    <Layout title="Developer Portal" description="Mobile Money partner API docs">
+      <main style={{ padding: '4rem 1.5rem', maxWidth: 900, margin: '0 auto' }}>
+        <h1>Mobile Money API Documentation Portal</h1>
+        <p>
+          This portal publishes a searchable, first-class API reference for partners using the
+          canonical <code>openapi.yaml</code> in this repository.
+        </p>
+        <p>
+          <Link className="button button--primary button--lg" to="/api">
+            Open API Reference
+          </Link>
+        </p>
+      </main>
+    </Layout>
+  );
+}

--- a/docs-portal/static/img/logo.svg
+++ b/docs-portal/static/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Mobile Money">
+  <rect width="100" height="100" rx="20" fill="#2e8555"/>
+  <text x="50" y="57" text-anchor="middle" font-size="42" fill="#fff" font-family="Arial">₿</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "test:write-latency": "ts-node scripts/test-write-latency.ts",
     "test:bench": "node tests/load/autocannon/benchmark.js",
     "sdk:generate": "openapi-generator-cli generate -i openapi.yaml -c sdk-config.yaml -o sdk",
-    "sdk:build": "cd sdk && ./gradlew build"
+    "sdk:build": "cd sdk && ./gradlew build",
+    "docs:dev": "npm --prefix docs-portal run start",
+    "docs:build": "npm --prefix docs-portal run build"
   },
   "lint-staged": {
     "*.{ts,tsx,js,cjs,mjs,json,md,yml,yaml}": "prettier --write"


### PR DESCRIPTION
## Description
Added a new Docusaurus site under docs-portal/ with configuration in docs-portal/docusaurus.config.ts and theme CSS in docs-portal/src/css/custom.css.

Embedded Redoc in a dedicated API page via docs-portal/src/components/ApiReference.tsx and docs-portal/src/pages/api.tsx that loads the spec from /openapi.yaml (copied at build time by the site script).

Added a simple landing page at docs-portal/src/pages/index.tsx and a small logo at docs-portal/static/img/logo.svg to provide a partner-facing entrypoint.

Added docs:dev and docs:build root scripts to package.json to run and build the portal and added a release-triggered workflow .github/workflows/api-docs-portal.yml that builds the site and deploys to GitHub Pages.

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing
Ran npm install in docs-portal/, which failed due to a registry permission error (403 Forbidden for @docusaurus/core) so dependencies could not be installed in this environment.

Ran npm run docs:build from the repository root, which completed the sync:openapi step but failed because the docusaurus binary was not available without installed dependencies (docusaurus: not found).

The GitHub Actions workflow was added and validated syntactically locally, but end-to-end CI deployment was not executed from this environment.

How did you test these changes?

## Checklist
close #741 

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
