### PR TITLE
feat(auth): add rate limiting to login and register endpoints

### DIFF
--- a/src/middleware/authRateLimit.ts
+++ b/src/middleware/authRateLimit.ts
@@ -1,0 +1,18 @@
+import rateLimit from "express-rate-limit";
+
+/**
+ * Rate limiter for authentication routes (Login/Register)
+ * Limit: 5 attempts per 15 minutes per IP
+ */
+export const authRateLimiter = process.env.NODE_ENV === "test"
+  ? (req: any, res: any, next: any) => next()
+  : rateLimit({
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      max: 5, // 5 attempts
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: {
+        error: "Too Many Requests",
+        message: "Too many authentication attempts from this IP, please try again after 15 minutes",
+      },
+    });

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -15,6 +15,7 @@ import { hashPassword } from '../utils/password';
 import { redisClient } from '../config/redis';
 import { TransactionModel } from '../models/transaction';
 import { EmailService } from '../services/email';
+import { authRateLimiter } from '../middleware/authRateLimit';
 
 const emailService = new EmailService();
 
@@ -33,7 +34,7 @@ export const registerSchema = z.object({
 /**
  * POST /api/auth/register
  */
-authRoutes.post('/register', validateRequest(registerSchema), async (req: Request, res: Response) => {
+authRoutes.post('/register', authRateLimiter, validateRequest(registerSchema), async (req: Request, res: Response) => {
   const { phone_number, password } = req.body as z.infer<typeof registerSchema>;
   try {
     const passwordHash = await hashPassword(password);
@@ -61,7 +62,7 @@ authRoutes.use('/sso/oidc', createOIDCRouter());
  * Enforces account lockout after 5 failed attempts within 10 minutes.
  * Sends an email notification when an account is locked.
  */
-authRoutes.post('/login', async (req: Request, res: Response) => {
+authRoutes.post('/login', authRateLimiter, async (req: Request, res: Response) => {
   const { phone_number } = req.body;
 
   if (!phone_number) {


### PR DESCRIPTION
## Description

Add IP-based rate limiting to authentication endpoints to mitigate brute-force attacks on login and registration.

## Related Issue

Closes #733

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Code refactoring
* [ ] Performance improvement

## Changes Made

* Added `authRateLimit` middleware using express-rate-limit
* Configured limit to 5 requests per 15 minutes per IP
* Applied rate limiting to `/login` and `/register` routes

## Testing

* Ran existing authentication tests to ensure no regressions
* Verified that requests exceeding 5 attempts return HTTP 429
* Confirmed rate limiting is bypassed in test environment

## Checklist

* [x] Code follows project style
* [x] Self-reviewed my code
* [ ] Commented complex code
* [ ] Updated documentation
* [x] No new warnings
* [ ] Added tests (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

Rate limiting is implemented using in-memory store suitable for basic protection. Can be extended to Redis for distributed environments if needed.
