### PR TITLE
feat: implement batch transaction processing for MTN B2B payouts (#513)

### DIFF
--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -218,4 +218,45 @@ export class TransactionModel {
 
     return res.rows[0];
   }
+
+  /**
+   * Find pending transactions by status, provider, and type.
+   * Used by batch payout worker to group transactions for efficient processing.
+   */
+  async findByStatusAndProvider(
+    status: TransactionStatus,
+    provider: string,
+    type: "deposit" | "withdraw",
+    limit = 50,
+  ) {
+    const capped = Math.min(Math.max(limit, 1), 50);
+
+    const result = await queryRead(
+      `SELECT ${TRANSACTION_SELECT_COLUMNS}
+        FROM transactions
+        WHERE status = $1
+          AND provider = $2
+          AND type = $3
+        ORDER BY created_at ASC
+        LIMIT $4`,
+      [status, provider.toLowerCase(), type, capped],
+    );
+
+    return result.rows.map(mapTransactionRow).filter((t: any) => t !== null);
+  }
+
+  async patchMetadata(id: string, patch: Record<string, unknown>) {
+    validateMetadata(patch);
+
+    const result = await queryWrite(
+      `UPDATE transactions
+        SET metadata = COALESCE(metadata, '{}'::jsonb) || $1::jsonb,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = $2
+        RETURNING ${TRANSACTION_SELECT_COLUMNS}`,
+      [JSON.stringify(patch), id],
+    );
+
+    return mapTransactionRow(result.rows[0]);
+  }
 }

--- a/src/queue/batchPayoutWorker.ts
+++ b/src/queue/batchPayoutWorker.ts
@@ -1,0 +1,342 @@
+import { TransactionModel, TransactionStatus } from "../models/transaction";
+import { MobileMoneyService, BatchPayoutItem, BatchPayoutResult } from "../services/mobilemoney/mobileMoneyService";
+import { rabbitMQManager, EXCHANGES, ROUTING_KEYS } from "./rabbitmq";
+import { EmailService } from "../services/email";
+import { UserModel } from "../models/users";
+import { SmsService } from "../services/sms";
+import { notifyTransactionWebhook, WebhookService } from "../services/webhook";
+import { pushNotificationService } from "../services/push";
+import {
+  batchPayoutTotal,
+  batchPayoutItemsTotal,
+  batchPayoutDurationSeconds,
+  batchPayoutSize,
+} from "../utils/metrics";
+
+const transactionModel = new TransactionModel();
+const mobileMoneyService = new MobileMoneyService();
+const emailService = new EmailService();
+const userModel = new UserModel();
+const smsService = new SmsService();
+const webhookService = new WebhookService();
+const pushService = pushNotificationService;
+
+const BATCH_SIZE = 50;
+const BATCH_INTERVAL_MS = parseInt(process.env.BATCH_PAYOUT_INTERVAL_MS || "5000", 10);
+const SUPPORTED_PROVIDERS = ["mtn"];
+
+interface PendingPayout {
+  transactionId: string;
+  phoneNumber: string;
+  amount: string;
+  provider: string;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+async function sendTransactionEmail(transactionId: string): Promise<void> {
+  const transaction = await transactionModel.findById(transactionId);
+  if (!transaction?.userId) return;
+
+  const user = await userModel.findById(transaction.userId);
+  if (user?.email) {
+    await emailService.sendTransactionReceipt(
+      user.email,
+      transaction,
+      user.preferredLanguage,
+    );
+  }
+}
+
+async function sendFailureEmail(transactionId: string, reason: string): Promise<void> {
+  const transaction = await transactionModel.findById(transactionId);
+  if (!transaction?.userId) return;
+
+  const user = await userModel.findById(transaction.userId);
+  if (user?.email) {
+    await emailService.sendTransactionFailure(
+      user.email,
+      transaction,
+      reason,
+      user.preferredLanguage,
+    );
+  }
+}
+
+async function sendTransactionPush(
+  transactionId: string,
+  status: "completed" | "failed",
+  error?: string,
+): Promise<void> {
+  const transaction = await transactionModel.findById(transactionId);
+  if (!transaction?.userId) return;
+
+  try {
+    if (status === "completed") {
+      await pushService.sendTransactionComplete(transaction.userId, {
+        transactionId: transaction.id,
+        referenceNumber: transaction.referenceNumber,
+        type: "withdraw",
+        amount: String(transaction.amount),
+        status: "completed",
+        error,
+      });
+    } else {
+      await pushService.sendTransactionFailed(transaction.userId, {
+        transactionId: transaction.id,
+        referenceNumber: transaction.referenceNumber,
+        type: "withdraw",
+        amount: String(transaction.amount),
+        status: "failed",
+        error,
+      });
+    }
+  } catch (pushError) {
+    console.error(`[${transactionId}] Push notification failed:`, pushError);
+  }
+}
+
+async function sendTxnSms(
+  transactionId: string,
+  phoneNumber: string,
+  amount: string,
+  provider: string,
+  kind: "transaction_completed" | "transaction_failed",
+  errorMessage?: string,
+): Promise<void> {
+  try {
+    const txRow = await transactionModel.findById(transactionId);
+    if (!txRow?.userId) return;
+
+    const user = await userModel.findById(txRow.userId);
+    if (user?.smsOptOut) {
+      console.log(`[${transactionId}] SMS notifications skipped (User Opted Out)`);
+      return;
+    }
+
+    const ref = txRow?.referenceNumber ?? transactionId;
+    await smsService.notifyTransactionEvent(phoneNumber, {
+      referenceNumber: ref,
+      type: "withdraw",
+      amount: String(amount),
+      provider,
+      kind,
+      errorMessage,
+    });
+  } catch (smsErr) {
+    console.error(`[${transactionId}] SMS notification error`, smsErr);
+  }
+}
+
+/**
+ * Fetch pending MTN payouts from the database
+ */
+async function fetchPendingPayouts(provider: string): Promise<PendingPayout[]> {
+  const result = await transactionModel.findByStatusAndProvider(
+    TransactionStatus.Pending,
+    provider,
+    "withdraw",
+    BATCH_SIZE,
+  );
+
+  return result.map(tx => ({
+    transactionId: tx.id,
+    phoneNumber: tx.phoneNumber,
+    amount: String(tx.amount),
+    provider: tx.provider,
+  }));
+}
+
+/**
+ * Process batch payout results and update individual transactions
+ */
+async function processBatchResults(
+  results: BatchPayoutResult[],
+  payouts: PendingPayout[],
+): Promise<void> {
+  const resultMap = new Map(results.map(r => [r.referenceId, r]));
+
+  for (const payout of payouts) {
+    const result = resultMap.get(payout.transactionId);
+
+    if (!result) {
+      console.error(`[${payout.transactionId}] No result returned from batch`);
+      await transactionModel.updateStatus(
+        payout.transactionId,
+        TransactionStatus.Failed,
+      );
+      await transactionModel.patchMetadata(payout.transactionId, {
+        batchError: "No result returned from batch processing",
+      });
+      continue;
+    }
+
+    if (result.success) {
+      await transactionModel.updateStatus(
+        payout.transactionId,
+        TransactionStatus.Completed,
+      );
+
+      if (result.providerReference) {
+        await transactionModel.patchMetadata(payout.transactionId, {
+          providerReference: result.providerReference,
+        });
+      }
+
+      await notifyTransactionWebhook(payout.transactionId, "transaction.completed", {
+        transactionModel,
+        webhookService,
+      });
+      await sendTransactionEmail(payout.transactionId);
+      await sendTransactionPush(payout.transactionId, "completed");
+      await sendTxnSms(
+        payout.transactionId,
+        payout.phoneNumber,
+        payout.amount,
+        payout.provider,
+        "transaction_completed",
+      );
+
+      await rabbitMQManager.publish(
+        EXCHANGES.TRANSACTIONS,
+        ROUTING_KEYS.TRANSACTION_COMPLETED,
+        { transactionId: payout.transactionId, status: "completed" },
+      );
+
+      console.log(`[${payout.transactionId}] Batch payout completed successfully`);
+    } else {
+      const errorMsg = result.error || "Batch payout failed";
+      
+      await transactionModel.updateStatus(
+        payout.transactionId,
+        TransactionStatus.Failed,
+      );
+      await transactionModel.patchMetadata(payout.transactionId, {
+        batchError: errorMsg,
+      });
+
+      await notifyTransactionWebhook(payout.transactionId, "transaction.failed", {
+        transactionModel,
+        webhookService,
+      });
+      await sendFailureEmail(payout.transactionId, errorMsg);
+      await sendTransactionPush(payout.transactionId, "failed", errorMsg);
+      await sendTxnSms(
+        payout.transactionId,
+        payout.phoneNumber,
+        payout.amount,
+        payout.provider,
+        "transaction_failed",
+        errorMsg,
+      );
+
+      await rabbitMQManager.publish(
+        EXCHANGES.TRANSACTIONS,
+        ROUTING_KEYS.TRANSACTION_FAILED,
+        { transactionId: payout.transactionId, status: "failed", error: errorMsg },
+      );
+
+      console.log(`[${payout.transactionId}] Batch payout failed: ${errorMsg}`);
+    }
+  }
+}
+
+/**
+ * Process a single batch of payouts for a provider
+ */
+async function processBatch(provider: string): Promise<void> {
+  const payouts = await fetchPendingPayouts(provider);
+
+  if (payouts.length === 0) {
+    return;
+  }
+
+  console.log(`[BatchPayoutWorker] Processing ${payouts.length} pending ${provider} payouts`);
+
+  const batchItems: BatchPayoutItem[] = payouts.map(p => ({
+    referenceId: p.transactionId,
+    phoneNumber: p.phoneNumber,
+    amount: p.amount,
+  }));
+
+  const startTime = Date.now();
+  const result = await mobileMoneyService.sendBatchPayout(provider, batchItems);
+  const durationMs = Date.now() - startTime;
+
+  // Record metrics
+  const successCount = result.results.filter(r => r.success).length;
+  const failureCount = result.results.filter(r => !r.success).length;
+
+  batchPayoutTotal.inc({ provider, status: result.success ? "success" : "partial" });
+  batchPayoutItemsTotal.inc({ provider, status: "success" }, successCount);
+  batchPayoutItemsTotal.inc({ provider, status: "failed" }, failureCount);
+  batchPayoutDurationSeconds.observe({ provider }, durationMs / 1000);
+  batchPayoutSize.observe({ provider }, payouts.length);
+
+  console.log(
+    `[BatchPayoutWorker] Batch completed in ${durationMs}ms: ${successCount}/${payouts.length} successful`,
+  );
+
+  await processBatchResults(result.results, payouts);
+}
+
+/**
+ * Main batch worker loop
+ */
+let isRunning = false;
+let intervalId: NodeJS.Timeout | null = null;
+
+async function runBatchCycle(): Promise<void> {
+  if (isRunning) {
+    console.log("[BatchPayoutWorker] Previous cycle still running, skipping");
+    return;
+  }
+
+  isRunning = true;
+  try {
+    for (const provider of SUPPORTED_PROVIDERS) {
+      await processBatch(provider);
+    }
+  } catch (error) {
+    console.error("[BatchPayoutWorker] Error in batch cycle:", error);
+  } finally {
+    isRunning = false;
+  }
+}
+
+export function startBatchPayoutWorker(): void {
+  if (intervalId) {
+    console.log("[BatchPayoutWorker] Already running");
+    return;
+  }
+
+  console.log(`[BatchPayoutWorker] Starting with interval ${BATCH_INTERVAL_MS}ms`);
+  
+  // Run immediately on start
+  runBatchCycle().catch(err => 
+    console.error("[BatchPayoutWorker] Initial cycle error:", err)
+  );
+
+  // Then run on interval
+  intervalId = setInterval(() => {
+    runBatchCycle().catch(err =>
+      console.error("[BatchPayoutWorker] Interval cycle error:", err)
+    );
+  }, BATCH_INTERVAL_MS);
+}
+
+export function stopBatchPayoutWorker(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+    console.log("[BatchPayoutWorker] Stopped");
+  }
+}
+
+export const batchPayoutWorker = {
+  start: startBatchPayoutWorker,
+  stop: stopBatchPayoutWorker,
+  isRunning: () => isRunning,
+};

--- a/src/services/mobilemoney/mobileMoneyService.js
+++ b/src/services/mobilemoney/mobileMoneyService.js
@@ -308,6 +308,110 @@ var MobileMoneyService = /** @class */ (function () {
         }
         return stats;
     };
+    MobileMoneyService.prototype.sendBatchPayout = function (provider, items) {
+        return __awaiter(this, void 0, void 0, function () {
+            var providerKey, MAX_BATCH_SIZE, providerInstance, results, _i, items_1, item, result_1, startTime_1, result, responseTimeMs, successCount, failureCount, i, i, error_2, errorMessage;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        providerKey = provider.toLowerCase();
+                        MAX_BATCH_SIZE = 50;
+                        if (items.length === 0) {
+                            return [2 /*return*/, { success: true, results: [] }];
+                        }
+                        if (items.length > MAX_BATCH_SIZE) {
+                            return [2 /*return*/, {
+                                    success: false,
+                                    results: items.map(function (item) { return ({
+                                        referenceId: item.referenceId,
+                                        success: false,
+                                        error: "Batch size exceeds maximum of ".concat(MAX_BATCH_SIZE),
+                                    }); }),
+                                    error: new Error("Batch size ".concat(items.length, " exceeds maximum of ").concat(MAX_BATCH_SIZE)),
+                                }];
+                        }
+                        _a.label = 1;
+                    case 1:
+                        _a.trys.push([1, 6, , 7]);
+                        return [4 /*yield*/, this.getProviderOrThrow(providerKey)];
+                    case 2:
+                        providerInstance = _a.sent();
+                        if (!providerInstance.sendBatchPayout) {
+                            // Fallback: process individually if batch not supported
+                            console.warn("Provider '".concat(providerKey, "' does not support batch payout, falling back to individual processing"));
+                            results = [];
+                            _i = 0, items_1 = items;
+                            _a.label = 3;
+                    case 3:
+                        if (!(_i < items_1.length)) return [3 /*break*/, 5];
+                        item = items_1[_i];
+                        return [4 /*yield*/, this.sendPayout(providerKey, item.phoneNumber, item.amount)];
+                    case 4:
+                        result_1 = _a.sent();
+                        results.push({
+                            referenceId: item.referenceId,
+                            success: true,
+                            providerReference: result_1.data ? String(result_1.data.referenceId || "") : undefined,
+                        });
+                        _i++;
+                        return [3 /*break*/, 3];
+                    case 5:
+                        return [2 /*return*/, { success: results.some(function (r) { return r.success; }), results: results }];
+                    case 6:
+                        error_2 = _a.sent();
+                        errorMessage = error_2 instanceof Error ? error_2.message : "Batch payout failed";
+                        metrics_1.transactionErrorsTotal.inc({
+                            type: "payout",
+                            provider: providerKey,
+                            error_type: "batch_payout_error",
+                        });
+                        return [2 /*return*/, {
+                                success: false,
+                                results: items.map(function (item) { return ({
+                                    referenceId: item.referenceId,
+                                    success: false,
+                                    error: errorMessage,
+                                }); }),
+                                error: error_2,
+                            }];
+                    case 7:
+                        startTime_1 = Date.now();
+                        return [4 /*yield*/, (0, circuitBreaker_1.executeWithCircuitBreaker)({
+                                provider: providerKey,
+                                operation: "sendBatchPayout",
+                                execute: function () { return __awaiter(_this, void 0, void 0, function () {
+                                    return __generator(this, function (_a) {
+                                        return [2 /*return*/, providerInstance.sendBatchPayout(items)];
+                                    });
+                                }); },
+                            })];
+                    case 8:
+                        result = _a.sent();
+                        responseTimeMs = Date.now() - startTime_1;
+                        successCount = result.results ? result.results.filter(function (r) { return r.success; }).length : 0;
+                        failureCount = result.results ? result.results.filter(function (r) { return !r.success; }).length : 0;
+                        for (i = 0; i < successCount; i++) {
+                            metrics_1.transactionTotal.inc({
+                                type: "payout",
+                                provider: providerKey,
+                                status: "success",
+                            });
+                        }
+                        for (i = 0; i < failureCount; i++) {
+                            metrics_1.transactionTotal.inc({
+                                type: "payout",
+                                provider: providerKey,
+                                status: "failure",
+                            });
+                        }
+                        console.log("[BatchPayout] Provider=".concat(providerKey, " processed ").concat(items.length, " items: ").concat(successCount, " success, ").concat(failureCount, " failed (").concat(responseTimeMs, "ms)"));
+                        return [2 /*return*/, result];
+                    case 9: return [2 /*return*/];
+                }
+            });
+        });
+    };
     return MobileMoneyService;
 }());
 exports.MobileMoneyService = MobileMoneyService;

--- a/src/services/mobilemoney/mobileMoneyService.ts
+++ b/src/services/mobilemoney/mobileMoneyService.ts
@@ -13,6 +13,19 @@ export type ProviderTransactionStatus =
   | "pending"
   | "unknown";
 
+export interface BatchPayoutItem {
+  referenceId: string;
+  phoneNumber: string;
+  amount: string;
+}
+
+export interface BatchPayoutResult {
+  referenceId: string;
+  success: boolean;
+  error?: string;
+  providerReference?: string;
+}
+
 export interface MobileMoneyProvider {
   requestPayment(
     phoneNumber: string,
@@ -22,6 +35,9 @@ export interface MobileMoneyProvider {
     phoneNumber: string,
     amount: string,
   ): Promise<{ success: boolean; data?: unknown; error?: unknown }>;
+  sendBatchPayout?(
+    items: BatchPayoutItem[],
+  ): Promise<{ success: boolean; results: BatchPayoutResult[]; error?: unknown }>;
   getTransactionStatus(
     referenceId: string,
   ): Promise<{ status: ProviderTransactionStatus }>;

--- a/src/services/mobilemoney/providers/mtn.ts
+++ b/src/services/mobilemoney/providers/mtn.ts
@@ -8,6 +8,19 @@ interface MtnBalanceResponse {
   currency?: string;
 }
 
+export interface BatchPayoutItem {
+  referenceId: string;
+  phoneNumber: string;
+  amount: string;
+}
+
+export interface BatchPayoutResult {
+  referenceId: string;
+  success: boolean;
+  error?: string;
+  providerReference?: string;
+}
+
 export class MTNProvider {
   private apiKey: string;
   private apiSecret: string;
@@ -135,6 +148,129 @@ export class MTNProvider {
     const log = requestId ? logger.child({ requestId }) : logger;
     log.info({ phoneNumber, amount }, "MTN: Sending payout");
     return { success: true };
+  }
+
+  /**
+   * MTN B2B Batch Payout - Process up to 50 payouts in a single API call.
+   * This provides significant performance gains for high-volume payout operations.
+   */
+  async sendBatchPayout(items: BatchPayoutItem[], requestId?: string): Promise<{ success: boolean; results: BatchPayoutResult[]; error?: unknown }> {
+    const log = requestId ? logger.child({ requestId }) : logger;
+    const MAX_BATCH_SIZE = 50;
+    
+    if (items.length === 0) {
+      return { success: true, results: [] };
+    }
+
+    if (items.length > MAX_BATCH_SIZE) {
+      return {
+        success: false,
+        results: items.map(item => ({
+          referenceId: item.referenceId,
+          success: false,
+          error: `Batch size exceeds maximum of ${MAX_BATCH_SIZE}`,
+        })),
+        error: new Error(`Batch size ${items.length} exceeds maximum of ${MAX_BATCH_SIZE}`),
+      };
+    }
+
+    log.info({ itemCount: items.length }, "MTN: Starting batch payout");
+    const startTime = Date.now();
+
+    try {
+      const token = await this.getAccessToken();
+      const batchReference = `BATCH-${randomUUID()}`;
+      
+      // MTN disbursement batch API endpoint
+      const response = await axios.post(
+        `${this.baseUrl}/disbursement/v2_0/batch-payout`,
+        {
+          batchReference,
+          items: items.map(item => ({
+            referenceId: item.referenceId,
+            amount: item.amount,
+            currency: "XAF",
+            payee: {
+              partyIdType: "MSISDN",
+              partyId: item.phoneNumber,
+            },
+          })),
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Ocp-Apim-Subscription-Key": this.subscriptionKey,
+            "X-Target-Environment": this.environment,
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+      const duration = Date.now() - startTime;
+
+      // Process partial success response
+      const responseItems = response.data?.items ?? [];
+      const results: BatchPayoutResult[] = items.map(item => {
+        const responseItem = responseItems.find(
+          (r: { referenceId: string }) => r.referenceId === item.referenceId
+        );
+        
+        if (!responseItem) {
+          return {
+            referenceId: item.referenceId,
+            success: false,
+            error: "No response received for this item",
+          };
+        }
+
+        const status = String(responseItem.status ?? "").toUpperCase();
+        return {
+          referenceId: item.referenceId,
+          success: status === "SUCCESSFUL" || status === "SUCCESS",
+          error: status !== "SUCCESSFUL" && status !== "SUCCESS" 
+            ? responseItem.errorReason || responseItem.message || `Status: ${status}`
+            : undefined,
+          providerReference: responseItem.financialTransactionId || responseItem.transactionId,
+        };
+      });
+
+      const successCount = results.filter(r => r.success).length;
+      const failureCount = results.filter(r => !r.success).length;
+
+      log.info({ 
+        duration, 
+        successCount, 
+        failureCount,
+        batchReference 
+      }, "MTN: Batch payout completed");
+
+      return {
+        success: successCount > 0 || failureCount === 0,
+        results,
+        error: failureCount > 0 && successCount === 0 
+          ? new Error("All batch items failed") 
+          : undefined,
+      };
+    } catch (error: any) {
+      const duration = Date.now() - startTime;
+      const errorMessage = error.message || "Batch payout request failed";
+      
+      log.error({ 
+        duration, 
+        error: errorMessage,
+        itemCount: items.length
+      }, "MTN: Batch payout failed");
+
+      return {
+        success: false,
+        results: items.map(item => ({
+          referenceId: item.referenceId,
+          success: false,
+          error: errorMessage,
+        })),
+        error,
+      };
+    }
   }
 
   async getTransactionStatus(

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -96,6 +96,37 @@ export const healthCheckResponseTimeSeconds = new Histogram({
   registers: [register],
 });
 
+// Batch Payout Metrics
+export const batchPayoutTotal = new Counter({
+  name: "batch_payout_total",
+  help: "Total number of batch payout operations",
+  labelNames: ["provider", "status"],
+  registers: [register],
+});
+
+export const batchPayoutItemsTotal = new Counter({
+  name: "batch_payout_items_total",
+  help: "Total number of items processed in batch payouts",
+  labelNames: ["provider", "status"],
+  registers: [register],
+});
+
+export const batchPayoutDurationSeconds = new Histogram({
+  name: "batch_payout_duration_seconds",
+  help: "Duration of batch payout operations in seconds",
+  labelNames: ["provider"],
+  buckets: [0.1, 0.5, 1, 2, 5, 10, 30, 60],
+  registers: [register],
+});
+
+export const batchPayoutSize = new Histogram({
+  name: "batch_payout_size",
+  help: "Number of items in each batch payout",
+  labelNames: ["provider"],
+  buckets: [1, 5, 10, 20, 30, 40, 50],
+  registers: [register],
+});
+
 // Connection Metrics
 export const activeConnections = new Gauge({
   name: "active_connections",


### PR DESCRIPTION
- Add sendBatchPayout method to MTN provider for processing up to 50 payouts in a single API call
- Add BatchPayoutItem and BatchPayoutResult interfaces to MobileMoneyProvider
- Add sendBatchPayout method to MobileMoneyService with circuit breaker support
- Add findByStatusAndProvider method to TransactionModel for fetching pending payouts
- Create batchPayoutWorker for grouping and processing pending MTN payouts
- Add batch payout metrics (batchPayoutTotal, batchPayoutItemsTotal, batchPayoutDurationSeconds, batchPayoutSize)
- Implement partial success handling with individual error mapping to transactions

closes #513 