### PR TITLE
Fix Playwright E2E path references

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,13 +1,26 @@
 import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+
+const repoRoot = __dirname;
 
 export default defineConfig({
-  testDir: "./tests/e2e",
+  testDir: path.join(repoRoot, "tests", "e2e"),
+  outputDir: path.join(repoRoot, "test-results", "e2e"),
   timeout: 30_000,
   expect: {
     timeout: 5000,
   },
   fullyParallel: true,
-  reporter: [["list"], ["html", { open: "never" }]],
+  reporter: [
+    ["list"],
+    [
+      "html",
+      {
+        open: "never",
+        outputFolder: path.join(repoRoot, "playwright-report"),
+      },
+    ],
+  ],
   projects: [
     {
       name: "chromium",


### PR DESCRIPTION
## Summary
- Anchor Playwright E2E test discovery to the repository root instead of relying on the current working directory
- Anchor Playwright test artifacts and HTML report output to stable repo-root paths

Closes #920

## Testing
- `git diff --check -- playwright.config.ts`

Note: Full Playwright execution was not run locally because the available Node binary in this Codex desktop shell is blocked by Windows app execution permissions.