### PR TITLE
feat: implement keyset pagination for ledger entries

### DIFF
--- a/migrations/20260529_add_ledger_keyset_pagination_indexes.sql
+++ b/migrations/20260529_add_ledger_keyset_pagination_indexes.sql
@@ -1,0 +1,8 @@
+-- Add covering indexes for keyset-paginated ledger entry queries.
+-- The trailing id keeps ordering deterministic when entries share a date/timestamp.
+
+CREATE INDEX IF NOT EXISTS idx_ledger_entries_account_keyset
+  ON ledger_entries(account_id, entry_date DESC, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ledger_entries_keyset
+  ON ledger_entries(entry_date DESC, created_at DESC, id DESC);

--- a/src/models/ledger.ts
+++ b/src/models/ledger.ts
@@ -1,5 +1,10 @@
 import { Pool, QueryResult } from 'pg';
 import { pool } from '../config/database';
+import {
+  decodeLedgerEntryCursor,
+  encodeLedgerEntryCursor,
+  LedgerEntryPage,
+} from '../services/ledgerService';
 
 /**
  * Ledger Model
@@ -33,6 +38,14 @@ export interface LedgerEntryRecord {
   metadata: Record<string, any>;
   created_at: Date;
 }
+
+const normalizeLedgerEntryLimit = (limit: number): number => {
+  if (!Number.isFinite(limit)) {
+    return 100;
+  }
+
+  return Math.min(Math.max(Math.trunc(limit), 1), 500);
+};
 
 export class LedgerModel {
   private pool: Pool;
@@ -165,6 +178,54 @@ export class LedgerModel {
   }
 
   /**
+   * Get ledger entries by account using keyset pagination
+   */
+  async getEntriesByAccountPage(
+    accountCode: string,
+    options: {
+      startDate?: Date;
+      endDate?: Date;
+      limit?: number;
+      cursor?: string;
+    } = {}
+  ): Promise<LedgerEntryPage> {
+    const limit = normalizeLedgerEntryLimit(options.limit ?? 100);
+    const cursor = options.cursor ? decodeLedgerEntryCursor(options.cursor) : null;
+    const result = await this.pool.query(
+      `SELECT le.*, a.code as account_code, a.name as account_name
+       FROM ledger_entries le
+       JOIN accounts a ON le.account_id = a.id
+       WHERE a.code = $1
+         AND ($2::DATE IS NULL OR le.entry_date >= $2)
+         AND ($3::DATE IS NULL OR le.entry_date <= $3)
+         AND (
+           $4::DATE IS NULL
+           OR (le.entry_date, le.created_at, le.id) < ($4::DATE, $5::TIMESTAMP, $6::UUID)
+         )
+       ORDER BY le.entry_date DESC, le.created_at DESC, le.id DESC
+       LIMIT $7`,
+      [
+        accountCode,
+        options.startDate || null,
+        options.endDate || null,
+        cursor?.entryDate || null,
+        cursor?.createdAt || null,
+        cursor?.id || null,
+        limit + 1
+      ]
+    );
+    const hasMore = result.rows.length > limit;
+    const entries = hasMore ? result.rows.slice(0, limit) : result.rows;
+
+    return {
+      entries,
+      nextCursor: hasMore ? encodeLedgerEntryCursor(entries[entries.length - 1]) : null,
+      hasMore,
+      limit,
+    };
+  }
+
+  /**
    * Get ledger entries by reference number
    */
   async getEntriesByReferenceNumber(referenceNumber: string): Promise<LedgerEntryRecord[]> {
@@ -198,6 +259,50 @@ export class LedgerModel {
       [startDate, endDate, limit, offset]
     );
     return result.rows;
+  }
+
+  /**
+   * Get ledger entries by date range using keyset pagination
+   */
+  async getEntriesByDateRangePage(
+    startDate: Date,
+    endDate: Date,
+    options: {
+      limit?: number;
+      cursor?: string;
+    } = {}
+  ): Promise<LedgerEntryPage> {
+    const limit = normalizeLedgerEntryLimit(options.limit ?? 100);
+    const cursor = options.cursor ? decodeLedgerEntryCursor(options.cursor) : null;
+    const result = await this.pool.query(
+      `SELECT le.*, a.code as account_code, a.name as account_name
+       FROM ledger_entries le
+       JOIN accounts a ON le.account_id = a.id
+       WHERE le.entry_date BETWEEN $1 AND $2
+         AND (
+           $3::DATE IS NULL
+           OR (le.entry_date, le.created_at, le.id) < ($3::DATE, $4::TIMESTAMP, $5::UUID)
+         )
+       ORDER BY le.entry_date DESC, le.created_at DESC, le.id DESC
+       LIMIT $6`,
+      [
+        startDate,
+        endDate,
+        cursor?.entryDate || null,
+        cursor?.createdAt || null,
+        cursor?.id || null,
+        limit + 1
+      ]
+    );
+    const hasMore = result.rows.length > limit;
+    const entries = hasMore ? result.rows.slice(0, limit) : result.rows;
+
+    return {
+      entries,
+      nextCursor: hasMore ? encodeLedgerEntryCursor(entries[entries.length - 1]) : null,
+      hasMore,
+      limit,
+    };
   }
 
   /**

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -2625,4 +2625,62 @@ router.delete(
   },
 );
 
+router.get(
+  "/ledger/accounts/:accountCode/entries",
+  requireAdmin,
+  rateLimitListQueries,
+  async (req: Request, res: Response) => {
+    try {
+      const limit = Number(req.query.limit) || 100;
+      const cursor =
+        typeof req.query.cursor === "string" ? req.query.cursor : undefined;
+      const startDate =
+        typeof req.query.startDate === "string"
+          ? new Date(req.query.startDate)
+          : undefined;
+      const endDate =
+        typeof req.query.endDate === "string"
+          ? new Date(req.query.endDate)
+          : undefined;
+
+      if (startDate && Number.isNaN(startDate.getTime())) {
+        return res.status(400).json({ message: "Invalid startDate" });
+      }
+
+      if (endDate && Number.isNaN(endDate.getTime())) {
+        return res.status(400).json({ message: "Invalid endDate" });
+      }
+
+      const page = await ledgerService.getEntriesByAccountPage(
+        req.params.accountCode,
+        {
+          startDate,
+          endDate,
+          limit,
+          cursor,
+        },
+      );
+
+      res.json({
+        entries: page.entries,
+        pagination: {
+          limit: page.limit,
+          nextCursor: page.nextCursor,
+          hasMore: page.hasMore,
+        },
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === "Invalid ledger entry cursor"
+      ) {
+        return res.status(400).json({ message: error.message });
+      }
+
+      console.error("[ledger:entries]", error);
+      res.status(500).json({ message: "Failed to fetch ledger entries" });
+    }
+  },
+);
+
 export { router as adminRoutes };

--- a/src/services/ledgerService.ts
+++ b/src/services/ledgerService.ts
@@ -48,6 +48,93 @@ export interface LedgerBalanceCheck {
   is_balanced: boolean;
 }
 
+export interface LedgerEntryRow {
+  id: string;
+  entry_date: Date | string;
+  account_code: string;
+  account_name: string;
+  debit_amount: number | string;
+  credit_amount: number | string;
+  description: string;
+  reference_number: string;
+  transaction_id: string | null;
+  created_at: Date | string;
+}
+
+export interface LedgerEntryCursor {
+  entryDate: string;
+  createdAt: string;
+  id: string;
+}
+
+export interface LedgerEntryPage {
+  entries: LedgerEntryRow[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  limit: number;
+}
+
+const DEFAULT_LEDGER_ENTRY_LIMIT = 100;
+const MAX_LEDGER_ENTRY_LIMIT = 500;
+
+const normalizeLimit = (limit: number): number => {
+  if (!Number.isFinite(limit)) {
+    return DEFAULT_LEDGER_ENTRY_LIMIT;
+  }
+
+  return Math.min(Math.max(Math.trunc(limit), 1), MAX_LEDGER_ENTRY_LIMIT);
+};
+
+const toCursorDate = (value: Date | string): string => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return value;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const encodeLedgerEntryCursor = (
+  entry: Pick<LedgerEntryRow, 'entry_date' | 'created_at' | 'id'>
+): string => {
+  const payload: LedgerEntryCursor = {
+    entryDate: toCursorDate(entry.entry_date),
+    createdAt: toCursorDate(entry.created_at),
+    id: entry.id,
+  };
+
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+};
+
+export const decodeLedgerEntryCursor = (cursor: string): LedgerEntryCursor => {
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'));
+
+    if (
+      !parsed ||
+      typeof parsed.entryDate !== 'string' ||
+      typeof parsed.createdAt !== 'string' ||
+      typeof parsed.id !== 'string'
+    ) {
+      throw new Error('Cursor is missing required ledger entry fields');
+    }
+
+    if (
+      Number.isNaN(Date.parse(parsed.entryDate)) ||
+      Number.isNaN(Date.parse(parsed.createdAt)) ||
+      !UUID_PATTERN.test(parsed.id)
+    ) {
+      throw new Error('Cursor contains invalid ledger entry values');
+    }
+
+    return parsed;
+  } catch (error) {
+    throw new Error('Invalid ledger entry cursor');
+  }
+};
+
 export class LedgerService {
   private pool: Pool;
 
@@ -366,7 +453,32 @@ export class LedgerService {
     startDate?: Date,
     endDate?: Date,
     limit: number = 100
-  ) {
+  ): Promise<LedgerEntryRow[]> {
+    const page = await this.getEntriesByAccountPage(accountCode, {
+      startDate,
+      endDate,
+      limit,
+    });
+
+    return page.entries;
+  }
+
+  /**
+   * Get a keyset-paginated page of ledger entries for a specific account
+   */
+  async getEntriesByAccountPage(
+    accountCode: string,
+    options: {
+      startDate?: Date;
+      endDate?: Date;
+      limit?: number;
+      cursor?: string;
+    } = {}
+  ): Promise<LedgerEntryPage> {
+    const pageLimit = normalizeLimit(options.limit ?? DEFAULT_LEDGER_ENTRY_LIMIT);
+    const cursor = options.cursor ? decodeLedgerEntryCursor(options.cursor) : null;
+    const queryLimit = pageLimit + 1;
+
     const result = await this.pool.query(
       `SELECT 
         le.id,
@@ -384,11 +496,33 @@ export class LedgerService {
       WHERE a.code = $1
         AND ($2::DATE IS NULL OR le.entry_date >= $2)
         AND ($3::DATE IS NULL OR le.entry_date <= $3)
-      ORDER BY le.entry_date DESC, le.created_at DESC
-      LIMIT $4`,
-      [accountCode, startDate || null, endDate || null, limit]
+        AND (
+          $4::DATE IS NULL
+          OR (le.entry_date, le.created_at, le.id) < ($4::DATE, $5::TIMESTAMP, $6::UUID)
+        )
+      ORDER BY le.entry_date DESC, le.created_at DESC, le.id DESC
+      LIMIT $7`,
+      [
+        accountCode,
+        options.startDate || null,
+        options.endDate || null,
+        cursor?.entryDate || null,
+        cursor?.createdAt || null,
+        cursor?.id || null,
+        queryLimit
+      ]
     );
-    return result.rows;
+
+    const rows = result.rows as LedgerEntryRow[];
+    const hasMore = rows.length > pageLimit;
+    const entries = hasMore ? rows.slice(0, pageLimit) : rows;
+
+    return {
+      entries,
+      nextCursor: hasMore ? encodeLedgerEntryCursor(entries[entries.length - 1]) : null,
+      hasMore,
+      limit: pageLimit,
+    };
   }
 }
 

--- a/tests/services/ledgerKeysetPagination.test.ts
+++ b/tests/services/ledgerKeysetPagination.test.ts
@@ -1,0 +1,123 @@
+import {
+  LedgerService,
+  decodeLedgerEntryCursor,
+  encodeLedgerEntryCursor,
+} from "../../src/services/ledgerService";
+
+describe("LedgerService keyset pagination", () => {
+  it("encodes and decodes stable ledger entry cursors", () => {
+    const cursor = encodeLedgerEntryCursor({
+      id: "11111111-1111-1111-1111-111111111111",
+      entry_date: new Date("2026-04-29T00:00:00.000Z"),
+      created_at: new Date("2026-04-29T10:15:30.000Z"),
+    });
+
+    expect(decodeLedgerEntryCursor(cursor)).toEqual({
+      id: "11111111-1111-1111-1111-111111111111",
+      entryDate: "2026-04-29T00:00:00.000Z",
+      createdAt: "2026-04-29T10:15:30.000Z",
+    });
+  });
+
+  it("rejects malformed cursors", () => {
+    expect(() => decodeLedgerEntryCursor("not-a-cursor")).toThrow(
+      "Invalid ledger entry cursor",
+    );
+
+    const invalidValues = Buffer.from(
+      JSON.stringify({
+        entryDate: "not-a-date",
+        createdAt: "also-not-a-date",
+        id: "not-a-uuid",
+      }),
+      "utf8",
+    ).toString("base64url");
+
+    expect(() => decodeLedgerEntryCursor(invalidValues)).toThrow(
+      "Invalid ledger entry cursor",
+    );
+  });
+
+  it("queries one extra row and returns a next cursor when another page exists", async () => {
+    const rows = [
+      {
+        id: "33333333-3333-3333-3333-333333333333",
+        entry_date: "2026-04-29",
+        account_code: "1100",
+        account_name: "Mobile Money Float",
+        debit_amount: "3",
+        credit_amount: "0",
+        description: "third",
+        reference_number: "REF-3",
+        transaction_id: null,
+        created_at: "2026-04-29T10:03:00.000Z",
+      },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        entry_date: "2026-04-29",
+        account_code: "1100",
+        account_name: "Mobile Money Float",
+        debit_amount: "2",
+        credit_amount: "0",
+        description: "second",
+        reference_number: "REF-2",
+        transaction_id: null,
+        created_at: "2026-04-29T10:02:00.000Z",
+      },
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        entry_date: "2026-04-29",
+        account_code: "1100",
+        account_name: "Mobile Money Float",
+        debit_amount: "1",
+        credit_amount: "0",
+        description: "first",
+        reference_number: "REF-1",
+        transaction_id: null,
+        created_at: "2026-04-29T10:01:00.000Z",
+      },
+    ];
+    const query = jest.fn().mockResolvedValue({ rows });
+    const service = new LedgerService({ query } as any);
+
+    const page = await service.getEntriesByAccountPage("1100", { limit: 2 });
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "(le.entry_date, le.created_at, le.id) < ($4::DATE, $5::TIMESTAMP, $6::UUID)",
+      ),
+      ["1100", null, null, null, null, null, 3],
+    );
+    expect(page.entries).toHaveLength(2);
+    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).toBe(
+      encodeLedgerEntryCursor({
+        id: "22222222-2222-2222-2222-222222222222",
+        entry_date: "2026-04-29",
+        created_at: "2026-04-29T10:02:00.000Z",
+      }),
+    );
+  });
+
+  it("uses decoded cursor values in the keyset predicate", async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const service = new LedgerService({ query } as any);
+    const cursor = encodeLedgerEntryCursor({
+      id: "22222222-2222-2222-2222-222222222222",
+      entry_date: "2026-04-29",
+      created_at: "2026-04-29T10:02:00.000Z",
+    });
+
+    await service.getEntriesByAccountPage("1100", { limit: 25, cursor });
+
+    expect(query.mock.calls[0][1]).toEqual([
+      "1100",
+      null,
+      null,
+      "2026-04-29",
+      "2026-04-29T10:02:00.000Z",
+      "22222222-2222-2222-2222-222222222222",
+      26,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Added keyset cursor encoding/decoding for ledger entry queries.
- Added keyset-paginated ledger account/date-range query methods.
- Added admin ledger entries endpoint with `pagination.nextCursor`.
- Added ledger keyset indexes for stable `entry_date DESC, created_at DESC, id DESC` scans.
- Added unit coverage for cursor validation, next cursor generation, and keyset query parameters.

Closes #876

## Verification
- `npx jest tests/services/ledgerKeysetPagination.test.ts --runInBand --testPathIgnorePatterns=tests/pact` passed.

## Notes
- `npm run type-check` still fails due existing unrelated repo-wide TypeScript errors outside this change.