### PR TITLE
fix(db): enforce SSL certificate verification for RDS in production

### DIFF
--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -2,6 +2,8 @@ import { Pool, QueryConfig, QueryResult, QueryResultRow, PoolClient } from "pg";
 import { isReadOnlyQuery } from "../utils/readOnlyDetector";
 import { IS_SANDBOX, SANDBOX_DATABASE_URL, DATABASE_URL } from "./env";
 
+const productionSsl =
+  process.env.NODE_ENV === "production" ? { rejectUnauthorized: true } : undefined;
 
 // Configuration for slow query logging
 const SLOW_QUERY_THRESHOLD_MS = parseInt(
@@ -137,6 +139,7 @@ export const pool = new Pool({
     max: 1000,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 500,
+    ssl: productionSsl,
   });
 
 // Wrap query for slow-query logging while preserving Pool typings.
@@ -191,6 +194,7 @@ const replicaUrls: string[] = process.env.READ_REPLICA_URL
         max: 50,
         idleTimeoutMillis: 30000,
         connectionTimeoutMillis: 500,
+        ssl: productionSsl,
       }),
   );
 


### PR DESCRIPTION
## Summary

- Enable TLS on the primary and read-replica PostgreSQL pools when `NODE_ENV` is `production`
- Set `rejectUnauthorized: true` so RDS server certificates are verified (no insecure `no-verify` mode)

## Context

Production connects to AWS RDS PostgreSQL. Without an explicit `ssl` option, `node-pg` uses plain TCP. This change encrypts traffic and validates the server certificate in production only; local/dev behavior is unchanged.

## Test plan

- [ ] Deploy or run locally with `NODE_ENV=production` and a TLS-enabled Postgres endpoint; confirm the app connects successfully
- [ ] Confirm non-production (`development`, `staging` local) still connects without SSL when using a local database
- [ ] Optional: run `SELECT ssl_is_used()` on a production connection to confirm TLS is active


Closes #878 