### PR TITLE
feat: add telemetry collection toggle in CLI configuration

### DIFF
--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { checkAuth } from "../api";
 import { getConfig } from "../config";
+import { trackEvent } from "../telemetry";
 
 export function registerAuthCommand(program: Command): void {
   const auth = program.command("auth").description("Authentication commands");
@@ -9,12 +10,15 @@ export function registerAuthCommand(program: Command): void {
     .command("check")
     .description("Verify the API key is valid")
     .action(async () => {
+      const start = Date.now();
       try {
         await checkAuth();
         const { apiUrl } = getConfig();
+        trackEvent({ command: "auth.check", success: true, durationMs: Date.now() - start });
         console.log(`✓ API key valid — connected to ${apiUrl}`);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
+        trackEvent({ command: "auth.check", success: false, durationMs: Date.now() - start });
         console.error(`✗ Auth failed: ${msg}`);
         process.exit(1);
       }

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,0 +1,36 @@
+import { Command } from "commander";
+import { getTelemetryEnabled, setTelemetryEnabled } from "../config";
+
+export function registerConfigCommand(program: Command): void {
+  const config = program
+    .command("config")
+    .description("Manage CLI configuration");
+
+  const telemetry = config
+    .command("telemetry")
+    .description("Configure anonymous telemetry collection");
+
+  telemetry
+    .command("on")
+    .description("Enable anonymous telemetry (default)")
+    .action(() => {
+      setTelemetryEnabled(true);
+      console.log("✓ Telemetry enabled. Thank you for helping improve momo-cli.");
+    });
+
+  telemetry
+    .command("off")
+    .description("Disable anonymous telemetry")
+    .action(() => {
+      setTelemetryEnabled(false);
+      console.log("✓ Telemetry disabled. No usage data will be collected.");
+    });
+
+  telemetry
+    .command("status")
+    .description("Show current telemetry setting")
+    .action(() => {
+      const enabled = getTelemetryEnabled();
+      console.log(`Telemetry is currently: ${enabled ? "on ✓" : "off ✗"}`);
+    });
+}

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,12 +1,15 @@
 import dotenv from "dotenv";
+import fs from "fs";
 import path from "path";
 
 // Load .momorc from the cli/ directory, fall back to process.env
-dotenv.config({ path: path.resolve(__dirname, "..", ".momorc") });
+const MOMORC_PATH = path.resolve(__dirname, "..", ".momorc");
+dotenv.config({ path: MOMORC_PATH });
 
 export interface CliConfig {
   apiUrl: string;
   apiKey: string;
+  telemetry: boolean;
 }
 
 export function getConfig(): CliConfig {
@@ -19,5 +22,49 @@ export function getConfig(): CliConfig {
   return {
     apiUrl: process.env.MOMO_API_URL ?? "http://localhost:3000",
     apiKey,
+    telemetry: getTelemetryEnabled(),
   };
+}
+
+/**
+ * Returns whether anonymous telemetry collection is enabled.
+ * Defaults to true if not explicitly set to "false".
+ */
+export function getTelemetryEnabled(): boolean {
+  return process.env.MOMO_TELEMETRY !== "false";
+}
+
+/**
+ * Persists the telemetry setting to the .momorc config file.
+ * Reads existing key=value lines and upserts MOMO_TELEMETRY.
+ */
+export function setTelemetryEnabled(enabled: boolean): void {
+  const value = enabled ? "true" : "false";
+
+  let lines: string[] = [];
+
+  // Read existing .momorc if it exists
+  if (fs.existsSync(MOMORC_PATH)) {
+    lines = fs.readFileSync(MOMORC_PATH, "utf-8").split("\n");
+  }
+
+  const key = "MOMO_TELEMETRY";
+  const entry = `${key}=${value}`;
+  const idx = lines.findIndex((l) => l.trimStart().startsWith(`${key}=`));
+
+  if (idx !== -1) {
+    lines[idx] = entry;
+  } else {
+    lines.push(entry);
+  }
+
+  const content =
+    lines
+      .filter((l, i) => l.trim() !== "" || i < lines.length - 1)
+      .join("\n")
+      .trimEnd() + "\n";
+  fs.writeFileSync(MOMORC_PATH, content, "utf-8");
+
+  // Keep the current process in sync without a restart
+  process.env[key] = value;
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { registerAuthCommand } from "./commands/auth";
-import { registerStatusCommand } from "./commands/status";
+import { registerConfigCommand } from "./commands/config";
 import { registerRetryCommand } from "./commands/retry";
+import { registerStatusCommand } from "./commands/status";
 
 const program = new Command("momo-cli")
   .version("1.0.0")
@@ -11,6 +12,7 @@ const program = new Command("momo-cli")
 registerAuthCommand(program);
 registerStatusCommand(program);
 registerRetryCommand(program);
+registerConfigCommand(program);
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const msg = err instanceof Error ? err.message : String(err);

--- a/cli/src/telemetry.ts
+++ b/cli/src/telemetry.ts
@@ -1,0 +1,26 @@
+import { getTelemetryEnabled } from "./config";
+
+export interface TelemetryEvent {
+  command: string;
+  success: boolean;
+  durationMs?: number;
+}
+
+/**
+ * Tracks an anonymous CLI usage event.
+ * No-ops silently if telemetry is disabled.
+ *
+ * Replace the console.debug stub below with a real
+ * analytics call (e.g. POST to your ingestion endpoint)
+ * when you are ready to collect data.
+ */
+export function trackEvent(event: TelemetryEvent): void {
+  if (!getTelemetryEnabled()) {
+    return;
+  }
+
+  // --- Stub: swap this for a real analytics call ---
+  // e.g. axios.post("https://telemetry.example.com/events", event).catch(() => {});
+  console.debug("[telemetry]", JSON.stringify(event));
+  // -------------------------------------------------
+}


### PR DESCRIPTION
close  #989 
cli/src/config.ts — added telemetry field to CliConfig; added getTelemetryEnabled() and setTelemetryEnabled() that read/write .momorc
cli/src/telemetry.ts — new trackEvent() helper that no-ops when telemetry is disabled
cli/src/commands/config.ts — new config telemetry <on|off|status> command
cli/src/commands/auth.ts — wired trackEvent() into auth check
cli/src/index.ts — registered the new config command