### PR TITLE
Add RSS memory auditing to load tests with threshold and reporting

### DIFF
--- a/tests/load/api.js
+++ b/tests/load/api.js
@@ -36,6 +36,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Counter, Rate, Trend } from 'k6/metrics';
+import exec from 'k6/x/exec';
 
 // ---------------------------------------------------------------------------
 // Custom metrics
@@ -49,6 +50,7 @@ const listLatency     = new Trend('list_latency_ms',     true);
 const txCreated       = new Counter('tx_created_total');
 const txFailed        = new Counter('tx_failed_total');
 const txSuccessRate   = new Rate('tx_success_rate');
+const rssMemory = new Trend('rss_memory_kb', true);
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -196,6 +198,8 @@ export const options = {
     tx_success_rate: [
       { threshold: 'rate>0.90', abortOnFail: isBreakpoint, delayAbortEval: '30s' },
     ],
+    // RSS memory usage threshold (max 500 MB)
+    rss_memory_kb: [{ threshold: 'max<512000', abortOnFail: isBreakpoint, delayAbortEval: '30s' }],
   },
 
   // Extended percentile set for the end-of-test summary table
@@ -258,6 +262,21 @@ function amountFor(prov, seed) {
  */
 function idempotencyKey(vuId, iter) {
   return `lt-vu${vuId}-it${iter}`;
+}
+
+// Helper to record RSS memory usage using k6 exec extension
+function recordRss() {
+  try {
+    // Get current process PID (Unix-like systems)
+    const pid = exec.run('bash', ['-c', 'echo $$']).trim();
+    const output = exec.run('ps', ['-p', pid, '-o', 'rss=']).trim();
+    const rssKb = parseInt(output, 10);
+    if (!isNaN(rssKb)) {
+      rssMemory.add(rssKb);
+    }
+  } catch (e) {
+    console.warn('Failed to record RSS:', e.message);
+  }
 }
 
 /** Build HTTP params with per-operation tag for metric segmentation. */
@@ -324,6 +343,8 @@ export default function () {
   const iter = __ITER;
   const seed = vuId * 100000 + iter;
   const prov = providerForVU(vuId);
+  // Record RSS memory usage for this iteration
+  recordRss();
 
   // 1. Health probe
   group('health_probe', function () {
@@ -514,6 +535,7 @@ export function handleSummary(data) {
     '╔══════════════════════════════════════════════════════════════════════════════╗',
     `║  Mobile Money API — Load Test Report                                         ║`,
     `║  Scenario : ${pad(SCENARIO, 65)}║`,
+    `║  RSS Memory (KB) : Avg ${pad(rssMemory.avg ? rssMemory.avg.toFixed(0) : 'N/A', 5)} Min ${pad(rssMemory.min || 'N/A',5)} Max ${pad(rssMemory.max || 'N/A',5)}║`,
     `║  Result   : ${pad(overallPass ? 'PASS' : 'FAIL', 65)}║`,
     '╚══════════════════════════════════════════════════════════════════════════════╝',
     '',
@@ -612,6 +634,11 @@ export function handleSummary(data) {
         httpErrorRatePass:   passErr,
         depositP95Pass:      passLat,
         txSuccessRatePass:   passTxSR,
+      },
+      rss_memory_kb: {
+        min: rssMemory.min,
+        max: rssMemory.max,
+        avg: rssMemory.avg,
       },
       sizing,
     },


### PR DESCRIPTION
this pr closes #1008 

This PR automates physical memory (RSS) consumption audits during load tests to detect and prevent memory leaks.

By integrating process-level resident set size tracking into the k6 load testing suite, we can continuously audit actual memory usage under active stress scenarios, assert against performance thresholds, and export detailed telemetry.

Key Changes
Command Execution Integration: Imported k6/x/exec to execute shell commands within the k6 load testing script environment.
rss_memory_kb Trend Metric: Added a new custom k6 Trend metric to capture memory profiles over time.
Automated RSS Collection:
Created a helper function recordRss() that finds the local load-generator process PID and queries its memory consumption (ps -p <PID> -o rss=).
Integrated recordRss() within the primary traffic simulation loop (default function) to collect data continuously.
Performance Threshold Safeguard: Added a critical memory consumption threshold to prevent runaway leakage:
Configured rss_memory_kb to fail the run if maximum memory exceeds 500 MB (512,000 KB) in breakpoint/stress test runs.
Formatted Reporting & Telemetry Output:
Updated printed console summary with real-time memory metrics (Avg, Min, Max).
Integrated the metrics into the structured results/load-test-summary.json file for automated reporting.


