### PR TITLE
feat: add Python SDK auto-generation target in openapitools.json

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,18 @@
   "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.21.0"
+    "version": "7.21.0",
+    "generators": {
+      "python": {
+        "generatorName": "python",
+        "inputSpec": "http://localhost:3000/docs/openapi.json",
+        "output": "sdk/python",
+        "additionalProperties": {
+          "packageName": "mobile_money_sdk",
+          "projectName": "mobile-money-sdk",
+          "projectVersion": "1.0.0"
+        }
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:load:legacy": "k6 run tests/load/k6/load_test_scenarios.js",
     "test:bench": "node tests/load/autocannon/benchmark.js",
     "sdk:generate": "echo 'Start dev server first (npm run dev), then run: openapi-generator-cli generate -i http://localhost:3000/docs/openapi.json -c sdk-config.yaml -o sdk'",
+    "sdk:generate:python": "openapi-generator-cli generate --generator-key python",
     "sdk:build": "cd sdk && ./gradlew build",
     "docs:dev": "npm --prefix docs-portal run start",
     "docs:build": "npm --prefix docs-portal run build"


### PR DESCRIPTION
Closes #994

---

Configure python generation settings in openapitools.json with generator-key 'python'. Adds sdk:generate:python npm script for convenient generation. Output targets sdk/python with package name mobile_money_sdk.

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
