### PR TITLE
feat: add automated provider reconciliation to starter node

### DIFF
--- a/bridge-starter-node/package.json
+++ b/bridge-starter-node/package.json
@@ -8,7 +8,9 @@
     "snyk:test:high": "snyk test --severity-threshold=high",
     "dev": "ts-node-dev --respawn --transpile-only src/app.ts",
     "build": "tsc",
-    "start": "node dist/app.js"
+    "start": "node dist/app.js",
+    "reconcile": "ts-node-dev --transpile-only src/scripts/reconcile.ts",
+    "reconcile:loop": "ts-node-dev --transpile-only src/scripts/reconcile.ts --loop"
   },
   "keywords": [],
   "author": "",

--- a/bridge-starter-node/src/scripts/reconcile.ts
+++ b/bridge-starter-node/src/scripts/reconcile.ts
@@ -1,0 +1,100 @@
+/**
+ * Reconciliation runner script.
+ *
+ * Can be executed directly:
+ *   npx ts-node-dev src/scripts/reconcile.ts          (one-shot)
+ *   npx ts-node-dev src/scripts/reconcile.ts --loop   (continuous, every 60 s)
+ *
+ * Or via the npm script added to package.json:
+ *   npm run reconcile            (one-shot)
+ *   npm run reconcile:loop       (continuous)
+ */
+
+import { reconcile } from "../services/reconciler";
+import type { ReconciliationReport } from "../types/reconciliation";
+
+// ─── Configuration ───────────────────────────────────────────────────────────
+
+/** Interval between reconciliation passes in loop mode (ms). */
+const LOOP_INTERVAL_MS = Number(process.env.RECONCILE_INTERVAL_MS) || 60_000;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function printReport(report: ReconciliationReport): void {
+  console.log("\n╔══════════════════════════════════════════════════════╗");
+  console.log("║         PROVIDER RECONCILIATION REPORT              ║");
+  console.log("╚══════════════════════════════════════════════════════╝\n");
+
+  console.log(`  Reconciled at : ${report.reconciledAt}`);
+  console.log(`  Local records : ${report.totalLocal}`);
+  console.log(`  Remote records: ${report.totalRemote}`);
+  console.log(`  ─────────────────────────────────`);
+  console.log(`  ✅ Matched      : ${report.matched}`);
+  console.log(`  ⚠️  Mismatched   : ${report.mismatched}`);
+  console.log(`  ❌ Missing local : ${report.missingLocal}`);
+  console.log(`  ❌ Missing remote: ${report.missingRemote}`);
+
+  if (report.entries.length > 0) {
+    console.log("\n  ── Entry Details ──────────────────────────────────\n");
+
+    for (const entry of report.entries) {
+      const icon = entry.match ? "✅" : "⚠️";
+      console.log(`  ${icon} [${entry.payoutId}]`);
+      console.log(
+        `     local  → status: ${entry.localStatus ?? "—"}, amount: ${entry.localAmount ?? "—"}`
+      );
+      console.log(
+        `     remote → status: ${entry.remoteStatus ?? "—"}, amount: ${entry.remoteAmount ?? "—"}`
+      );
+      if (entry.discrepancy) {
+        console.log(`     ⤷ ${entry.discrepancy}`);
+      }
+    }
+  } else {
+    console.log("\n  No payout records found on either side.");
+    console.log(
+      "  → Implement fetchLocalPayouts() and fetchRemotePayouts()"
+    );
+    console.log(
+      "    in src/services/reconciler.ts to connect your data sources.\n"
+    );
+  }
+
+  console.log("");
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function runOnce(): Promise<void> {
+  try {
+    const report = await reconcile();
+    printReport(report);
+  } catch (err) {
+    console.error("[reconciler] Reconciliation failed:", err);
+    process.exitCode = 1;
+  }
+}
+
+async function runLoop(): Promise<void> {
+  console.log(
+    `[reconciler] Starting reconciliation loop (interval: ${LOOP_INTERVAL_MS / 1000}s) …`
+  );
+  console.log("[reconciler] Press Ctrl+C to stop.\n");
+
+  // Run immediately on start, then on the interval
+  await runOnce();
+
+  setInterval(async () => {
+    await runOnce();
+  }, LOOP_INTERVAL_MS);
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+const isLoop = process.argv.includes("--loop");
+
+if (isLoop) {
+  runLoop();
+} else {
+  runOnce();
+}

--- a/bridge-starter-node/src/services/reconciler.ts
+++ b/bridge-starter-node/src/services/reconciler.ts
@@ -1,0 +1,189 @@
+/**
+ * Provider Reconciliation Service
+ *
+ * Compares local payout records against the provider's remote API to detect
+ * discrepancies such as:
+ *   - Status mismatches  (local says "completed", provider says "failed")
+ *   - Amount mismatches  (rounding / FX differences)
+ *   - Missing records    (exists locally but not remotely, or vice-versa)
+ *
+ * Integrators should supply their own `fetchLocalPayouts` and
+ * `fetchRemotePayouts` implementations — the defaults below are stubs
+ * that return demo data so the script is runnable out of the box.
+ */
+
+import axios from "axios";
+import { config } from "../config/env";
+import type {
+  LocalPayoutRecord,
+  RemotePayoutRecord,
+  ReconciliationEntry,
+  ReconciliationReport,
+} from "../types/reconciliation";
+
+// ─── Data-source adapters (replace with real implementations) ────────────────
+
+/**
+ * Fetch payout records from the local data store.
+ *
+ * Replace this stub with a real database / file query.
+ */
+export async function fetchLocalPayouts(): Promise<LocalPayoutRecord[]> {
+  // TODO: Replace with your actual local data source (database, CSV, etc.)
+  console.log("[reconciler] Fetching local payout records …");
+  return [];
+}
+
+/**
+ * Fetch payout records from the remote provider API.
+ *
+ * By default this calls `GET <BRIDGE_API_URL>/payouts` using the configured
+ * API key.  Adjust the endpoint, pagination, and response mapping to match
+ * your provider.
+ */
+export async function fetchRemotePayouts(): Promise<RemotePayoutRecord[]> {
+  console.log("[reconciler] Fetching remote payout records …");
+
+  if (!config.bridgeApiUrl) {
+    console.warn(
+      "[reconciler] BRIDGE_API_URL is not set — returning empty remote list."
+    );
+    return [];
+  }
+
+  try {
+    const response = await axios.get<RemotePayoutRecord[]>(
+      `${config.bridgeApiUrl}/payouts`,
+      {
+        headers: {
+          Authorization: `Bearer ${config.bridgeApiKey}`,
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    return response.data;
+  } catch (error: any) {
+    console.error(
+      "[reconciler] Failed to fetch remote payouts:",
+      error.response?.data || error.message
+    );
+    return [];
+  }
+}
+
+// ─── Core reconciliation logic ───────────────────────────────────────────────
+
+/**
+ * Compare a local record with its remote counterpart and produce a
+ * `ReconciliationEntry` describing any discrepancy.
+ */
+function compareRecords(
+  local: LocalPayoutRecord | null,
+  remote: RemotePayoutRecord | null
+): ReconciliationEntry {
+  // Record exists only on one side
+  if (!local) {
+    return {
+      payoutId: remote!.id,
+      localStatus: null,
+      remoteStatus: remote!.status,
+      localAmount: null,
+      remoteAmount: remote!.amount,
+      match: false,
+      discrepancy: "missing_local — record exists remotely but not locally",
+    };
+  }
+
+  if (!remote) {
+    return {
+      payoutId: local.id,
+      localStatus: local.status,
+      remoteStatus: null,
+      localAmount: local.amount,
+      remoteAmount: null,
+      match: false,
+      discrepancy: "missing_remote — record exists locally but not remotely",
+    };
+  }
+
+  // Both sides present — check for mismatches
+  const discrepancies: string[] = [];
+
+  if (local.status !== remote.status) {
+    discrepancies.push(
+      `status mismatch: local="${local.status}" remote="${remote.status}"`
+    );
+  }
+
+  if (local.amount !== remote.amount) {
+    discrepancies.push(
+      `amount mismatch: local=${local.amount} remote=${remote.amount}`
+    );
+  }
+
+  const match = discrepancies.length === 0;
+
+  return {
+    payoutId: local.id,
+    localStatus: local.status,
+    remoteStatus: remote.status,
+    localAmount: local.amount,
+    remoteAmount: remote.amount,
+    match,
+    discrepancy: match ? null : discrepancies.join("; "),
+  };
+}
+
+/**
+ * Run a full reconciliation pass:
+ *
+ * 1. Fetch local and remote payout lists.
+ * 2. Index both by payout ID.
+ * 3. Walk the union of IDs and compare each pair.
+ * 4. Return an aggregate `ReconciliationReport`.
+ */
+export async function reconcile(): Promise<ReconciliationReport> {
+  const localPayouts = await fetchLocalPayouts();
+  const remotePayouts = await fetchRemotePayouts();
+
+  // Index by ID for O(1) lookups
+  const localMap = new Map(localPayouts.map((p) => [p.id, p]));
+  const remoteMap = new Map(remotePayouts.map((p) => [p.id, p]));
+
+  // Union of all payout IDs
+  const allIds = new Set([...localMap.keys(), ...remoteMap.keys()]);
+
+  const entries: ReconciliationEntry[] = [];
+  let matched = 0;
+  let mismatched = 0;
+  let missingLocal = 0;
+  let missingRemote = 0;
+
+  for (const id of allIds) {
+    const local = localMap.get(id) ?? null;
+    const remote = remoteMap.get(id) ?? null;
+    const entry = compareRecords(local, remote);
+    entries.push(entry);
+
+    if (entry.match) {
+      matched++;
+    } else if (!local) {
+      missingLocal++;
+    } else if (!remote) {
+      missingRemote++;
+    } else {
+      mismatched++;
+    }
+  }
+
+  return {
+    reconciledAt: new Date().toISOString(),
+    totalLocal: localPayouts.length,
+    totalRemote: remotePayouts.length,
+    matched,
+    mismatched,
+    missingLocal,
+    missingRemote,
+    entries,
+  };
+}

--- a/bridge-starter-node/src/types/reconciliation.ts
+++ b/bridge-starter-node/src/types/reconciliation.ts
@@ -1,0 +1,62 @@
+/**
+ * Types for the provider reconciliation system.
+ */
+
+/** Status of a single payout as tracked locally. */
+export type PayoutStatus =
+  | "pending"
+  | "completed"
+  | "failed"
+  | "mismatched"
+  | "missing_local"
+  | "missing_remote";
+
+/** A payout record as stored in the local ledger. */
+export interface LocalPayoutRecord {
+  /** Unique payout / transaction ID. */
+  id: string;
+  /** Amount in the smallest currency unit (e.g. cents). */
+  amount: number;
+  /** ISO 4217 currency code. */
+  currency: string;
+  /** Recipient identifier (phone number, wallet address, etc.). */
+  recipient: string;
+  /** Current status known locally. */
+  status: PayoutStatus;
+  /** ISO-8601 timestamp of when the payout was initiated. */
+  createdAt: string;
+}
+
+/** A payout record as returned by the provider / remote API. */
+export interface RemotePayoutRecord {
+  id: string;
+  amount: number;
+  currency: string;
+  recipient: string;
+  status: string;
+  createdAt: string;
+}
+
+/** The result of reconciling a single payout. */
+export interface ReconciliationEntry {
+  payoutId: string;
+  localStatus: string | null;
+  remoteStatus: string | null;
+  localAmount: number | null;
+  remoteAmount: number | null;
+  match: boolean;
+  discrepancy: string | null;
+}
+
+/** Aggregated result of a full reconciliation run. */
+export interface ReconciliationReport {
+  /** ISO-8601 timestamp of when the reconciliation started. */
+  reconciledAt: string;
+  totalLocal: number;
+  totalRemote: number;
+  matched: number;
+  mismatched: number;
+  missingLocal: number;
+  missingRemote: number;
+  entries: ReconciliationEntry[];
+}


### PR DESCRIPTION
Closes #996

---

Implements a reconciliation service that compares local payout records against the remote provider API to detect status mismatches, amount discrepancies, and missing records. Adds a CLI runner script supporting one-shot and continuous loop modes via npm run reconcile / reconcile:loop.

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
