### PR TITLE
chore: elevate jest coverage thresholds to production standards (#909)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,10 +22,10 @@ module.exports = {
   coverageReporters: ["text", "text-summary", "lcov", "html", "json-summary"],
   coverageThreshold: {
     global: {
-      branches: 15,
-      functions: 25,
-      lines: 20,
-      statements: 20,
+      branches: 75,
+      functions: 75,
+      lines: 75,
+      statements: 75,
     },
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],

--- a/tests/utils/i18n.test.ts
+++ b/tests/utils/i18n.test.ts
@@ -1,0 +1,92 @@
+import { Request, Response, NextFunction } from "express";
+import { resolveLocale, resolveLocaleFromRequest, i18nMiddleware, SUPPORTED_LOCALES, translate } from "../../src/utils/i18n";
+import i18next from "i18next";
+
+describe("i18n utils", () => {
+  describe("resolveLocale", () => {
+    it("should return the exact matched locale", () => {
+      expect(resolveLocale("fr")).toBe("fr");
+      expect(resolveLocale("en")).toBe("en");
+    });
+
+    it("should match language when region is provided", () => {
+      expect(resolveLocale("fr-CA")).toBe("fr");
+      expect(resolveLocale("en-US")).toBe("en");
+      expect(resolveLocale("en_US")).toBe("en"); // Handles underscore
+    });
+
+    it("should fallback to en when locale is not supported", () => {
+      expect(resolveLocale("de")).toBe("en");
+      expect(resolveLocale("zh")).toBe("en");
+      expect(resolveLocale("")).toBe("en");
+      expect(resolveLocale(undefined)).toBe("en");
+    });
+  });
+
+  describe("resolveLocaleFromRequest", () => {
+    it("should use req.locale if already set", () => {
+      const req = { locale: "fr", headers: {} } as Request;
+      expect(resolveLocaleFromRequest(req)).toBe("fr");
+    });
+
+    it("should parse accept-language header", () => {
+      const req = { headers: { "accept-language": "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5" } } as Request;
+      expect(resolveLocaleFromRequest(req)).toBe("fr");
+    });
+
+    it("should prioritize correctly from accept-language header", () => {
+      const req = { headers: { "accept-language": "de;q=0.9, es;q=0.8" } } as Request;
+      expect(resolveLocaleFromRequest(req)).toBe("es");
+    });
+
+    it("should fallback to en if no accept-language header", () => {
+      const req = { headers: {} } as Request;
+      expect(resolveLocaleFromRequest(req)).toBe("en");
+    });
+
+    it("should fallback to en if header values are unsupported", () => {
+      const req = { headers: { "accept-language": "zh, de" } } as Request;
+      expect(resolveLocaleFromRequest(req)).toBe("en");
+    });
+    
+    it("should handle accept-language header as array", () => {
+      const req = { headers: { "accept-language": ["fr", "en;q=0.8"] } } as unknown as Request;
+      expect(resolveLocaleFromRequest(req)).toBe("fr");
+    });
+  });
+
+  describe("i18nMiddleware", () => {
+    it("should set locale on req and res.locals", () => {
+      const req = { headers: { "accept-language": "sw" } } as Request;
+      const res = { locals: {} } as Response;
+      const next: NextFunction = jest.fn();
+
+      i18nMiddleware(req, res, next);
+
+      expect(req.locale).toBe("sw");
+      expect(res.locals.locale).toBe("sw");
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe("translate", () => {
+    beforeAll(() => {
+      // Just ensure i18next is mockable or returns keys
+      jest.spyOn(i18next, "t").mockImplementation((key: string | string[]) => String(key));
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("should call i18next.t with resolved locale", () => {
+      translate("some.key", "fr-FR", { count: 1 });
+      expect(i18next.t).toHaveBeenCalledWith("some.key", expect.objectContaining({ lng: "fr", count: 1 }));
+    });
+    
+    it("should use fallback locale when none provided", () => {
+      translate("some.key");
+      expect(i18next.t).toHaveBeenCalledWith("some.key", expect.objectContaining({ lng: "en" }));
+    });
+  });
+});

--- a/tests/utils/masking.test.ts
+++ b/tests/utils/masking.test.ts
@@ -1,0 +1,79 @@
+import { maskPhoneNumber, maskEmail, maskStellarAddress, maskSensitiveData } from "../../src/utils/masking";
+
+describe("masking utils", () => {
+  describe("maskPhoneNumber", () => {
+    it("should mask a standard phone number", () => {
+      expect(maskPhoneNumber("+237677123456")).toBe("+237***56");
+    });
+    
+    it("should handle an empty string", () => {
+      expect(maskPhoneNumber("")).toBe("");
+    });
+    
+    it("should not mask a phone number of length 6 or less", () => {
+      expect(maskPhoneNumber("123456")).toBe("123456");
+    });
+    
+    it("should trim the phone number before masking", () => {
+      expect(maskPhoneNumber(" +237677123456 ")).toBe("+237***56");
+    });
+  });
+
+  describe("maskEmail", () => {
+    it("should mask a standard email", () => {
+      expect(maskEmail("johndoe@example.com")).toBe("jo***@example.com");
+    });
+
+    it("should handle an empty string", () => {
+      expect(maskEmail("")).toBe("");
+    });
+
+    it("should return the email if it doesn't contain an @ symbol", () => {
+      expect(maskEmail("invalidemail")).toBe("invalidemail");
+    });
+
+    it("should mask short local parts properly", () => {
+      expect(maskEmail("me@example.com")).toBe("me***@example.com");
+      expect(maskEmail("a@example.com")).toBe("a***@example.com");
+    });
+  });
+
+  describe("maskStellarAddress", () => {
+    it("should mask a standard stellar address", () => {
+      const address = "GBAR4321ABCD1234EFGH5678IJKL9012MNOP3456QRST7890UVWX";
+      expect(maskStellarAddress(address)).toBe("GBAR...UVWX");
+    });
+
+    it("should handle an empty string", () => {
+      expect(maskStellarAddress("")).toBe("");
+    });
+
+    it("should not mask if length is 8 or less", () => {
+      expect(maskStellarAddress("12345678")).toBe("12345678");
+    });
+  });
+
+  describe("maskSensitiveData", () => {
+    it("should mask phone numbers", () => {
+      expect(maskSensitiveData("+237677123456", "phone")).toBe("+237***56");
+    });
+
+    it("should mask emails", () => {
+      expect(maskSensitiveData("johndoe@example.com", "email")).toBe("jo***@example.com");
+    });
+
+    it("should mask stellar addresses", () => {
+      const address = "GBAR4321ABCD1234EFGH5678IJKL9012MNOP3456QRST7890UVWX";
+      expect(maskSensitiveData(address, "stellar")).toBe("GBAR...UVWX");
+    });
+
+    it("should return data as-is if type is unknown", () => {
+      // @ts-expect-error Testing invalid type
+      expect(maskSensitiveData("somedata", "unknown")).toBe("somedata");
+    });
+
+    it("should handle empty string", () => {
+      expect(maskSensitiveData("", "phone")).toBe("");
+    });
+  });
+});

--- a/tests/utils/password.test.ts
+++ b/tests/utils/password.test.ts
@@ -1,0 +1,60 @@
+import { hashPassword, comparePassword } from "../../src/utils/password";
+import bcrypt from "bcrypt";
+
+jest.mock("bcrypt");
+
+describe("password utils", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, BCRYPT_ROUNDS: "10" };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe("hashPassword", () => {
+    it("should hash a password correctly", async () => {
+      (bcrypt.hash as jest.Mock).mockResolvedValue("hashed_password");
+      
+      const result = await hashPassword("my_password");
+      
+      expect(result).toBe("hashed_password");
+      expect(bcrypt.hash).toHaveBeenCalledWith("my_password", 10);
+    });
+
+    it("should throw an error if hashing fails", async () => {
+      (bcrypt.hash as jest.Mock).mockRejectedValue(new Error("bcrypt error"));
+      
+      await expect(hashPassword("my_password")).rejects.toThrow("Could not hash password");
+    });
+  });
+
+  describe("comparePassword", () => {
+    it("should return true for a matching password", async () => {
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      
+      const result = await comparePassword("my_password", "hashed_password");
+      
+      expect(result).toBe(true);
+      expect(bcrypt.compare).toHaveBeenCalledWith("my_password", "hashed_password");
+    });
+
+    it("should return false for a non-matching password", async () => {
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+      
+      const result = await comparePassword("wrong_password", "hashed_password");
+      
+      expect(result).toBe(false);
+      expect(bcrypt.compare).toHaveBeenCalledWith("wrong_password", "hashed_password");
+    });
+
+    it("should throw an error if comparison fails", async () => {
+      (bcrypt.compare as jest.Mock).mockRejectedValue(new Error("bcrypt error"));
+      
+      await expect(comparePassword("my_password", "hashed_password")).rejects.toThrow("Could not compare password");
+    });
+  });
+});

--- a/tests/utils/phoneUtils.test.ts
+++ b/tests/utils/phoneUtils.test.ts
@@ -1,0 +1,42 @@
+import { validatePhoneProviderMatch } from "../../src/utils/phoneUtils";
+
+describe("phoneUtils", () => {
+  describe("validatePhoneProviderMatch", () => {
+    it("should return valid for a matching mtn number", () => {
+      const result = validatePhoneProviderMatch("+237677123456", "mtn");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching airtel number", () => {
+      const result = validatePhoneProviderMatch("+256701234567", "airtel");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching orange number", () => {
+      const result = validatePhoneProviderMatch("+237651234567", "orange");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid even if phone number does not start with +", () => {
+      const result = validatePhoneProviderMatch("237677123456", "mtn");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should handle case-insensitive provider string", () => {
+      const result = validatePhoneProviderMatch("+237677123456", "MTN");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return invalid for an unsupported provider", () => {
+      const result = validatePhoneProviderMatch("+237677123456", "unknown");
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("Unsupported provider: unknown");
+    });
+
+    it("should return invalid for a phone number that does not match the provider", () => {
+      const result = validatePhoneProviderMatch("+256701234567", "mtn");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("does not belong to the MTN network");
+    });
+  });
+});

--- a/tests/utils/readOnlyDetector.test.ts
+++ b/tests/utils/readOnlyDetector.test.ts
@@ -1,0 +1,62 @@
+import { isReadOnlyQuery, getQueryCommand } from "../../src/utils/readOnlyDetector";
+
+describe("readOnlyDetector", () => {
+  describe("isReadOnlyQuery", () => {
+    it("should return true for a basic SELECT statement", () => {
+      expect(isReadOnlyQuery("SELECT * FROM users;")).toBe(true);
+    });
+
+    it("should return true for a WITH ... SELECT statement", () => {
+      expect(isReadOnlyQuery("WITH cte AS (SELECT * FROM users) SELECT * FROM cte;")).toBe(true);
+    });
+
+    it("should return false for an INSERT statement", () => {
+      expect(isReadOnlyQuery("INSERT INTO users (name) VALUES ('John');")).toBe(false);
+    });
+
+    it("should return false for an UPDATE statement", () => {
+      expect(isReadOnlyQuery("UPDATE users SET name = 'John' WHERE id = 1;")).toBe(false);
+    });
+
+    it("should return false for a DELETE statement", () => {
+      expect(isReadOnlyQuery("DELETE FROM users WHERE id = 1;")).toBe(false);
+    });
+
+    it("should return false if SELECT contains a write pattern like UPDATE", () => {
+      // Technically this might be a false positive depending on the context (e.g. column name 'update_time'),
+      // but testing the current behavior
+      expect(isReadOnlyQuery("SELECT id FROM updates;")).toBe(false);
+    });
+
+    it("should return false for transaction boundaries like BEGIN", () => {
+      expect(isReadOnlyQuery("BEGIN;")).toBe(false);
+      expect(isReadOnlyQuery("COMMIT;")).toBe(false);
+    });
+
+    it("should handle empty or null values", () => {
+      expect(isReadOnlyQuery("")).toBe(false);
+      // @ts-expect-error Testing invalid input
+      expect(isReadOnlyQuery(null)).toBe(false);
+    });
+  });
+
+  describe("getQueryCommand", () => {
+    it("should extract SELECT", () => {
+      expect(getQueryCommand("SELECT * FROM users")).toBe("SELECT");
+    });
+
+    it("should extract INSERT", () => {
+      expect(getQueryCommand("INSERT INTO users (name) VALUES ('x')")).toBe("INSERT");
+    });
+
+    it("should extract UPDATE", () => {
+      expect(getQueryCommand("UPDATE users SET x=1")).toBe("UPDATE");
+    });
+
+    it("should return UNKNOWN for empty or invalid query", () => {
+      expect(getQueryCommand("")).toBe("UNKNOWN");
+      // @ts-expect-error Testing invalid input
+      expect(getQueryCommand(null)).toBe("UNKNOWN");
+    });
+  });
+});

--- a/tests/utils/redact.test.ts
+++ b/tests/utils/redact.test.ts
@@ -1,0 +1,88 @@
+import { redact, isSensitiveKey, REDACTED } from "../../src/utils/redact";
+
+describe("redact utility", () => {
+  describe("isSensitiveKey", () => {
+    it("should return true for sensitive keys", () => {
+      expect(isSensitiveKey("password")).toBe(true);
+      expect(isSensitiveKey("accessToken")).toBe(true);
+      expect(isSensitiveKey("API_KEY")).toBe(true);
+      expect(isSensitiveKey("X-Api-Key")).toBe(true);
+      expect(isSensitiveKey("newPassword")).toBe(true);
+      expect(isSensitiveKey("cvv")).toBe(true);
+    });
+
+    it("should return false for non-sensitive keys", () => {
+      expect(isSensitiveKey("username")).toBe(false);
+      expect(isSensitiveKey("email")).toBe(false);
+      expect(isSensitiveKey("id")).toBe(false);
+      expect(isSensitiveKey("status")).toBe(false);
+    });
+  });
+
+  describe("redact", () => {
+    it("should redact plain objects", () => {
+      const input = {
+        username: "johndoe",
+        password: "secretpassword",
+        nested: {
+          token: "abc123token",
+          public: "info"
+        }
+      };
+
+      const result = redact(input);
+      expect(result).toEqual({
+        username: "johndoe",
+        password: REDACTED,
+        nested: {
+          token: REDACTED,
+          public: "info"
+        }
+      });
+    });
+
+    it("should redact arrays", () => {
+      const input = [
+        { password: "123", id: 1 },
+        { token: "abc", id: 2 }
+      ];
+
+      const result = redact(input);
+      expect(result).toEqual([
+        { password: REDACTED, id: 1 },
+        { token: REDACTED, id: 2 }
+      ]);
+    });
+
+    it("should redact error objects", () => {
+      const err = new Error("Something went wrong") as any;
+      err.code = 500;
+      err.password = "secret";
+
+      const result: any = redact(err);
+      expect(result.message).toBe("Something went wrong");
+      expect(result.code).toBe(500);
+      expect(result.password).toBe(REDACTED);
+      expect(result.stack).toBeDefined();
+    });
+
+    it("should parse and redact stringified JSON", () => {
+      const input = JSON.stringify({ password: "123", name: "John" });
+      const result = redact(input);
+      
+      expect(typeof result).toBe("string");
+      expect(JSON.parse(result as string)).toEqual({
+        password: REDACTED,
+        name: "John"
+      });
+    });
+
+    it("should return primitives as-is", () => {
+      expect(redact("regular string")).toBe("regular string");
+      expect(redact(123)).toBe(123);
+      expect(redact(true)).toBe(true);
+      expect(redact(null)).toBe(null);
+      expect(redact(undefined)).toBe(undefined);
+    });
+  });
+});

--- a/tests/utils/transactionFilters.test.ts
+++ b/tests/utils/transactionFilters.test.ts
@@ -1,0 +1,141 @@
+import { Request, Response, NextFunction } from "express";
+import {
+  TransactionStatus,
+  parseStatusFilter,
+  buildStatusWhereClause,
+  validateTransactionFilters,
+  getPaginationInfo,
+} from "../../src/utils/transactionFilters";
+
+describe("transactionFilters", () => {
+  describe("parseStatusFilter", () => {
+    it("should return empty array for undefined or empty string", () => {
+      expect(parseStatusFilter(undefined)).toEqual([]);
+      expect(parseStatusFilter("")).toEqual([]);
+    });
+
+    it("should parse a single valid status", () => {
+      expect(parseStatusFilter("pending")).toEqual([TransactionStatus.Pending]);
+    });
+
+    it("should parse multiple valid statuses", () => {
+      expect(parseStatusFilter("pending,completed")).toEqual([
+        TransactionStatus.Pending,
+        TransactionStatus.Completed,
+      ]);
+    });
+
+    it("should throw an error for invalid statuses", () => {
+      expect(() => parseStatusFilter("pending,unknown")).toThrow(/Invalid status values: unknown/);
+    });
+  });
+
+  describe("buildStatusWhereClause", () => {
+    it("should return empty string for empty array", () => {
+      expect(buildStatusWhereClause([])).toBe("");
+    });
+
+    it("should return empty string if all statuses are selected", () => {
+      const allStatuses = Object.values(TransactionStatus) as TransactionStatus[];
+      expect(buildStatusWhereClause(allStatuses)).toBe("");
+    });
+
+    it("should build IN clause for specific statuses", () => {
+      expect(buildStatusWhereClause([TransactionStatus.Pending])).toBe("status IN ('pending')");
+      expect(buildStatusWhereClause([TransactionStatus.Pending, TransactionStatus.Completed])).toBe(
+        "status IN ('pending', 'completed')"
+      );
+    });
+  });
+
+  describe("validateTransactionFilters middleware", () => {
+    let mockReq: Partial<Request>;
+    let mockRes: Partial<Response>;
+    let mockNext: NextFunction;
+
+    beforeEach(() => {
+      mockReq = { query: {} };
+      mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+      mockNext = jest.fn();
+    });
+
+    it("should apply default values", () => {
+      validateTransactionFilters(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect((mockReq as any).transactionFilters).toEqual({
+        statuses: [],
+        limit: 50,
+        offset: 0,
+        reference: undefined,
+      });
+    });
+
+    it("should parse provided valid values", () => {
+      mockReq.query = { status: "pending,failed", limit: "20", offset: "10", reference: "ref123" };
+      validateTransactionFilters(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect((mockReq as any).transactionFilters).toEqual({
+        statuses: [TransactionStatus.Pending, TransactionStatus.Failed],
+        limit: 20,
+        offset: 10,
+        reference: "ref123",
+      });
+    });
+
+    it("should cap limit at 1000", () => {
+      mockReq.query = { limit: "2000" };
+      validateTransactionFilters(mockReq as Request, mockRes as Response, mockNext);
+
+      expect((mockReq as any).transactionFilters.limit).toBe(1000);
+    });
+
+    it("should return 400 for invalid limit", () => {
+      mockReq.query = { limit: "-5" };
+      validateTransactionFilters(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({ error: "Invalid limit parameter" }));
+    });
+
+    it("should return 400 for invalid offset", () => {
+      mockReq.query = { offset: "-5" };
+      validateTransactionFilters(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({ error: "Invalid offset parameter" }));
+    });
+
+    it("should return 400 for invalid status", () => {
+      mockReq.query = { status: "invalid" };
+      validateTransactionFilters(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith(expect.objectContaining({ error: "Invalid status parameter" }));
+    });
+  });
+
+  describe("getPaginationInfo", () => {
+    it("should calculate correct pagination info", () => {
+      const info = getPaginationInfo(100, 20, 0);
+      expect(info).toEqual({
+        total: 100,
+        limit: 20,
+        offset: 0,
+        hasMore: true,
+        totalPages: 5,
+        currentPage: 1,
+      });
+    });
+
+    it("should handle offset correctly", () => {
+      const info = getPaginationInfo(100, 20, 80);
+      expect(info.hasMore).toBe(false);
+      expect(info.currentPage).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses issue #909 by elevating the global Jest test coverage thresholds from legacy baseline levels to production-grade standards. It ensures that the codebase maintains a high level of stability and prevents regressions in future pull requests.

Closes #909 