### PR TITLE
feat: implement contract state expiration and rental reclaims

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -53,6 +53,9 @@ impl EscrowContract {
                 released: false,
             },
         );
+
+        // Extend the TTL of the instance storage to set up state renewal rules
+        env.storage().instance().extend_ttl(1000, 10000);
     }
 
     /// Release funds to the beneficiary. Only the arbiter may call this.
@@ -67,6 +70,8 @@ impl EscrowContract {
 
         state.released = true;
         env.storage().instance().set(&ESCROW, &state);
+
+        env.storage().instance().extend_ttl(1000, 10000);
     }
 
     /// Refund funds to the depositor. Only the arbiter may call this.
@@ -81,11 +86,15 @@ impl EscrowContract {
 
         state.released = true;
         env.storage().instance().set(&ESCROW, &state);
+
+        env.storage().instance().extend_ttl(1000, 10000);
     }
 
     /// Return current escrow state (read-only).
     pub fn get_state(env: Env) -> EscrowState {
-        env.storage().instance().get(&ESCROW).expect("not initialised")
+        let state = env.storage().instance().get(&ESCROW).expect("not initialised");
+        env.storage().instance().extend_ttl(1000, 10000);
+        state
     }
 }
 

--- a/contracts/htlc/src/lib.rs
+++ b/contracts/htlc/src/lib.rs
@@ -60,6 +60,9 @@ impl HtlcContract {
                 refunded: false,
             },
         );
+
+        // Extend the TTL of the instance storage to set up state renewal rules
+        env.storage().instance().extend_ttl(1000, 10000);
     }
 
     /// Claim funds by providing the preimage.
@@ -79,6 +82,8 @@ impl HtlcContract {
 
         state.claimed = true;
         env.storage().instance().set(&HTLC, &state);
+
+        env.storage().instance().extend_ttl(1000, 10000);
     }
 
     /// Refund funds to the sender after the timelock has expired.
@@ -97,11 +102,15 @@ impl HtlcContract {
 
         state.refunded = true;
         env.storage().instance().set(&HTLC, &state);
+
+        env.storage().instance().extend_ttl(1000, 10000);
     }
 
     /// Return current HTLC state (read-only).
     pub fn get_state(env: Env) -> HtlcState {
-        env.storage().instance().get(&HTLC).expect("not initialised")
+        let state = env.storage().instance().get(&HTLC).expect("not initialised");
+        env.storage().instance().extend_ttl(1000, 10000);
+        state
     }
 }
 


### PR DESCRIPTION
Closes #982

---

Configure instance storage state renewal rules inside escrow and HTLC contract initializations and read/write interactions using extend_ttl.

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
