### PR TITLE
feat(auth): add granular auth rate limits

### DIFF
--- a/src/middleware/__tests__/authRateLimit.test.ts
+++ b/src/middleware/__tests__/authRateLimit.test.ts
@@ -1,0 +1,68 @@
+import express from "express";
+import request from "supertest";
+import { createAuthRateLimiter } from "../authRateLimit";
+
+const previousEnableAuthRateLimitTests =
+  process.env.ENABLE_AUTH_RATE_LIMIT_TESTS;
+
+const createTestApp = () => {
+  const app = express();
+
+  app.post(
+    "/login",
+    createAuthRateLimiter({
+      windowMs: 60 * 1000,
+      limit: 2,
+      message: "Too many test login attempts",
+    }),
+    (_req, res) => res.json({ ok: true }),
+  );
+
+  app.post(
+    "/register",
+    createAuthRateLimiter({
+      windowMs: 60 * 1000,
+      limit: 1,
+      message: "Too many test registration attempts",
+    }),
+    (_req, res) => res.json({ ok: true }),
+  );
+
+  return app;
+};
+
+describe("auth rate limiters", () => {
+  beforeAll(() => {
+    process.env.ENABLE_AUTH_RATE_LIMIT_TESTS = "true";
+  });
+
+  afterAll(() => {
+    if (previousEnableAuthRateLimitTests === undefined) {
+      delete process.env.ENABLE_AUTH_RATE_LIMIT_TESTS;
+      return;
+    }
+
+    process.env.ENABLE_AUTH_RATE_LIMIT_TESTS = previousEnableAuthRateLimitTests;
+  });
+
+  it("limits login requests while keeping registration in a separate bucket", async () => {
+    const app = createTestApp();
+
+    await request(app).post("/login").expect(200);
+    await request(app).post("/login").expect(200);
+
+    const blockedLogin = await request(app).post("/login").expect(429);
+    expect(blockedLogin.body).toEqual({
+      error: "Too Many Requests",
+      message: "Too many test login attempts",
+    });
+
+    await request(app).post("/register").expect(200);
+
+    const blockedRegister = await request(app).post("/register").expect(429);
+    expect(blockedRegister.body).toEqual({
+      error: "Too Many Requests",
+      message: "Too many test registration attempts",
+    });
+  });
+});

--- a/src/middleware/authRateLimit.ts
+++ b/src/middleware/authRateLimit.ts
@@ -1,18 +1,48 @@
 import rateLimit from "express-rate-limit";
 
-/**
- * Rate limiter for authentication routes (Login/Register)
- * Limit: 5 attempts per 15 minutes per IP
- */
-export const authRateLimiter = process.env.NODE_ENV === "test"
-  ? (req: any, res: any, next: any) => next()
-  : rateLimit({
-      windowMs: 15 * 60 * 1000, // 15 minutes
-      max: 5, // 5 attempts
-      standardHeaders: true,
-      legacyHeaders: false,
-      message: {
-        error: "Too Many Requests",
-        message: "Too many authentication attempts from this IP, please try again after 15 minutes",
-      },
-    });
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+export const AUTH_RATE_LIMITS = {
+  login: {
+    windowMs: FIFTEEN_MINUTES_MS,
+    limit: 5,
+    message:
+      "Too many login attempts from this IP, please try again after 15 minutes",
+  },
+  register: {
+    windowMs: ONE_HOUR_MS,
+    limit: 3,
+    message:
+      "Too many registration attempts from this IP, please try again after 1 hour",
+  },
+};
+
+type AuthRateLimiterConfig = {
+  windowMs: number;
+  limit: number;
+  message: string;
+};
+
+const skipRateLimitInTests = () =>
+  process.env.NODE_ENV === "test" &&
+  process.env.ENABLE_AUTH_RATE_LIMIT_TESTS !== "true";
+
+export const createAuthRateLimiter = (config: AuthRateLimiterConfig) =>
+  rateLimit({
+    windowMs: config.windowMs,
+    limit: config.limit,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: skipRateLimitInTests,
+    message: {
+      error: "Too Many Requests",
+      message: config.message,
+    },
+  });
+
+export const loginRateLimiter = createAuthRateLimiter(AUTH_RATE_LIMITS.login);
+export const registerRateLimiter = createAuthRateLimiter(
+  AUTH_RATE_LIMITS.register,
+);
+export const authRateLimiter = loginRateLimiter;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -15,7 +15,7 @@ import { hashPassword } from '../utils/password';
 import { redisClient } from '../config/redis';
 import { TransactionModel } from '../models/transaction';
 import { EmailService } from '../services/email';
-import { authRateLimiter } from '../middleware/authRateLimit';
+import { loginRateLimiter, registerRateLimiter } from '../middleware/authRateLimit';
 
 const emailService = new EmailService();
 
@@ -34,7 +34,7 @@ export const registerSchema = z.object({
 /**
  * POST /api/auth/register
  */
-authRoutes.post('/register', authRateLimiter, validateRequest(registerSchema), async (req: Request, res: Response) => {
+authRoutes.post('/register', registerRateLimiter, validateRequest(registerSchema), async (req: Request, res: Response) => {
   const { phone_number, password } = req.body as z.infer<typeof registerSchema>;
   try {
     const passwordHash = await hashPassword(password);
@@ -62,7 +62,7 @@ authRoutes.use('/sso/oidc', createOIDCRouter());
  * Enforces account lockout after 5 failed attempts within 10 minutes.
  * Sends an email notification when an account is locked.
  */
-authRoutes.post('/login', authRateLimiter, async (req: Request, res: Response) => {
+authRoutes.post('/login', loginRateLimiter, async (req: Request, res: Response) => {
   const { phone_number } = req.body;
 
   if (!phone_number) {


### PR DESCRIPTION
Closes #892

---

Implemented granular rate limiting for authentication endpoints using express-rate-limit to help prevent brute-force attacks.