### PR TITLE
feat: implement Multi-AZ Failover Strategy for ElastiCache Redis

### DIFF
--- a/terraform/modules/redis/main.tf
+++ b/terraform/modules/redis/main.tf
@@ -1,7 +1,7 @@
 # ──────────────────────────────────────────────────────────────────────────────
-# Redis Module – ElastiCache Redis 7
-# Managed Redis cluster matching the project's existing Redis 7 usage.
-# Used for distributed locks, session caching, and rate limiting.
+# Redis Module – ElastiCache Redis 7 with Multi-AZ Failover Strategy
+# Managed Redis cluster with automatic failover across multiple availability zones.
+# Used for distributed locks, session caching, and rate limiting with high availability.
 # ──────────────────────────────────────────────────────────────────────────────
 
 resource "aws_elasticache_subnet_group" "main" {
@@ -23,15 +23,40 @@ resource "aws_elasticache_parameter_group" "redis" {
     value = "allkeys-lru"
   }
 
+  parameter {
+    name  = "timeout"
+    value = "300"
+  }
+
+  parameter {
+    name  = "tcp-keepalive"
+    value = "60"
+  }
+
   tags = {
     Name        = "${var.project}-${var.environment}-redis-params"
     Environment = var.environment
   }
 }
 
+resource "aws_sns_topic" "redis_failover" {
+  name = "${var.project}-${var.environment}-redis-failover"
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-redis-failover"
+    Environment = var.environment
+  }
+}
+
+resource "aws_sns_topic_subscription" "redis_failover_email" {
+  topic_arn = aws_sns_topic.redis_failover.arn
+  protocol  = "email"
+  endpoint  = var.notification_email
+}
+
 resource "aws_elasticache_replication_group" "main" {
-  replication_group_id = "${var.project}-${var.environment}-redis"
-  description          = "Redis cluster for ${var.project} ${var.environment}"
+  replication_group_id       = "${var.project}-${var.environment}-redis"
+  replication_group_description = "Redis cluster for ${var.project} ${var.environment} with Multi-AZ failover"
 
   # Engine
   engine               = "redis"
@@ -39,7 +64,7 @@ resource "aws_elasticache_replication_group" "main" {
   node_type            = var.redis_node_type
   parameter_group_name = aws_elasticache_parameter_group.redis.name
 
-  # Cluster topology
+  # Cluster topology for Multi-AZ
   num_cache_clusters = var.redis_num_cache_clusters
 
   # Network
@@ -47,19 +72,75 @@ resource "aws_elasticache_replication_group" "main" {
   security_group_ids = [var.security_group_id]
   port               = 6379
 
-  # Reliability
-  automatic_failover_enabled = var.redis_num_cache_clusters > 1
+  # Multi-AZ Failover Strategy
+  automatic_failover_enabled = true
   multi_az_enabled           = var.redis_num_cache_clusters > 1
+
+  # Encryption
   at_rest_encryption_enabled = true
   transit_encryption_enabled = false # keep false to match redis:// (non-TLS) connection strings
+  auth_token_enabled         = false
 
-  # Maintenance
-  maintenance_window       = "sun:05:00-sun:06:00"
+  # Maintenance and backup
+  maintenance_window       = var.maintenance_window
   snapshot_retention_limit = var.environment == "production" ? 7 : 1
-  snapshot_window          = "02:00-03:00"
+  snapshot_window          = var.snapshot_window
+
+  # Notifications
+  notification_topic_arn = aws_sns_topic.redis_failover.arn
+
+  # Logging
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.redis_slow_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+    enabled          = true
+  }
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.redis_engine_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "engine-log"
+    enabled          = true
+  }
+
+  # Automatic failover and failover timeout
+  automatic_failover_enabled = true
+
+  # Apply immediately only for non-production environments
+  apply_immediately = var.environment != "production"
 
   tags = {
     Name        = "${var.project}-${var.environment}-redis"
+    Environment = var.environment
+    Strategy    = "Multi-AZ-Failover"
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.redis_slow_log,
+    aws_cloudwatch_log_group.redis_engine_log,
+    aws_sns_topic.redis_failover
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "redis_slow_log" {
+  name              = "/aws/elasticache/redis/${var.project}/${var.environment}/slow-log"
+  retention_in_days = var.environment == "production" ? 30 : 7
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-redis-slow-log"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_log_group" "redis_engine_log" {
+  name              = "/aws/elasticache/redis/${var.project}/${var.environment}/engine-log"
+  retention_in_days = var.environment == "production" ? 30 : 7
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-redis-engine-log"
     Environment = var.environment
   }
 }

--- a/terraform/modules/redis/outputs.tf
+++ b/terraform/modules/redis/outputs.tf
@@ -3,6 +3,11 @@ output "redis_endpoint" {
   value       = aws_elasticache_replication_group.main.primary_endpoint_address
 }
 
+output "redis_reader_endpoint" {
+  description = "Reader endpoint for read-only operations across replicas (available when Multi-AZ is enabled)"
+  value       = try(aws_elasticache_replication_group.main.reader_endpoint_address, "")
+}
+
 output "redis_port" {
   description = "Redis port"
   value       = 6379
@@ -11,4 +16,39 @@ output "redis_port" {
 output "redis_connection_url" {
   description = "Redis connection URL for the application"
   value       = "redis://${aws_elasticache_replication_group.main.primary_endpoint_address}:6379"
+}
+
+output "redis_replication_group_id" {
+  description = "Redis replication group ID"
+  value       = aws_elasticache_replication_group.main.id
+}
+
+output "redis_member_clusters" {
+  description = "List of member clusters in the replication group"
+  value       = aws_elasticache_replication_group.main.member_clusters
+}
+
+output "redis_automatic_failover_enabled" {
+  description = "Whether automatic failover is enabled"
+  value       = aws_elasticache_replication_group.main.automatic_failover_enabled
+}
+
+output "redis_multi_az_enabled" {
+  description = "Whether Multi-AZ is enabled"
+  value       = aws_elasticache_replication_group.main.multi_az_enabled
+}
+
+output "redis_notification_topic_arn" {
+  description = "SNS topic ARN for Redis failover notifications"
+  value       = aws_sns_topic.redis_failover.arn
+}
+
+output "redis_slow_log_group" {
+  description = "CloudWatch log group for Redis slow logs"
+  value       = aws_cloudwatch_log_group.redis_slow_log.name
+}
+
+output "redis_engine_log_group" {
+  description = "CloudWatch log group for Redis engine logs"
+  value       = aws_cloudwatch_log_group.redis_engine_log.name
 }

--- a/terraform/modules/redis/variables.tf
+++ b/terraform/modules/redis/variables.tf
@@ -9,7 +9,7 @@ variable "environment" {
 }
 
 variable "private_subnet_ids" {
-  description = "Private subnet IDs for the ElastiCache subnet group"
+  description = "Private subnet IDs for the ElastiCache subnet group (must span multiple AZs for Multi-AZ)"
   type        = list(string)
 }
 
@@ -25,7 +25,29 @@ variable "redis_node_type" {
 }
 
 variable "redis_num_cache_clusters" {
-  description = "Number of cache cluster nodes (>1 enables failover)"
+  description = "Number of cache cluster nodes (must be >= 2 for Multi-AZ failover)"
   type        = number
-  default     = 1
+  default     = 2
+  validation {
+    condition     = var.redis_num_cache_clusters >= 1
+    error_message = "Number of cache clusters must be at least 1."
+  }
+}
+
+variable "notification_email" {
+  description = "Email address for Redis failover notifications"
+  type        = string
+  default     = ""
+}
+
+variable "maintenance_window" {
+  description = "Maintenance window for Redis updates"
+  type        = string
+  default     = "sun:05:00-sun:06:00"
+}
+
+variable "snapshot_window" {
+  description = "Snapshot window for Redis backups"
+  type        = string
+  default     = "02:00-03:00"
 }


### PR DESCRIPTION
Closes #908 
Summary
This implementation adds a comprehensive Multi-AZ Failover Strategy for ElastiCache Redis, ensuring high availability and automatic recovery during node failures across multiple availability zones.

What's Changed
Core Multi-AZ Features:

Enabled automatic failover with explicit configuration
Multi-AZ replication across minimum 2 nodes in different AZs
SNS notifications for failover events with email subscriptions
CloudWatch structured logging (JSON format) for:
Slow-log: Performance monitoring of slow commands
Engine-log: Redis engine events and troubleshooting
Configurable log retention (30 days production, 7 days staging)
Enhanced Configuration:

Parameter group improvements: timeout (300s) and tcp-keepalive (60s)
Reader endpoint for read-only operations across replicas
Configurable maintenance and snapshot windows
Input validation for minimum cluster count
New Outputs:

redis_reader_endpoint - Read-only endpoint
redis_replication_group_id - Group identifier
redis_member_clusters - Cluster list
redis_automatic_failover_enabled - Failover status
redis_multi_az_enabled - Multi-AZ status
redis_notification_topic_arn - SNS topic
redis_slow_log_group & redis_engine_log_group - Log groups
Files Modified
terraform/modules/redis/main.tf - Enhanced with failover strategy
terraform/modules/redis/variables.tf - New variables added
terraform/modules/redis/outputs.tf - New outputs for monitoring