### PR TITLE
feat: format benchmark output as Markdown comparison table

### DIFF
--- a/tests/load/autocannon/benchmark.js
+++ b/tests/load/autocannon/benchmark.js
@@ -12,9 +12,43 @@ async function runBenchmark(url, options = {}) {
   return result;
 }
 
+/**
+ * Format benchmark results as a Markdown comparison table.
+ * @param {Array} results - Array of benchmark result objects
+ * @returns {string} Markdown-formatted table string
+ */
+function formatMarkdownTable(results) {
+  if (!results.length) return 'No benchmark results to display.';
+
+  const headers = Object.keys(results[0]);
+  const headerRow = `| ${headers.join(' | ')} |`;
+  const separatorRow = `| ${headers.map(() => '---').join(' | ')} |`;
+
+  const dataRows = results.map(row => {
+    const values = headers.map(h => {
+      const val = row[h];
+      if (typeof val === 'number') {
+        return val.toLocaleString('en-US', { maximumFractionDigits: 2 });
+      }
+      return val;
+    });
+    return `| ${values.join(' | ')} |`;
+  });
+
+  return [headerRow, separatorRow, ...dataRows].join('\n');
+}
+
+/**
+ * Format a timestamp for display.
+ */
+function formatTimestamp() {
+  return new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+}
+
 async function main() {
   const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
   console.log(`Starting benchmarks against: ${baseUrl}`);
+  console.log(`Timestamp: ${formatTimestamp()}\n`);
 
   const scenarios = [
     { name: 'Health Check (Baseline)', path: '/health', connections: 50, duration: 10 },
@@ -34,9 +68,11 @@ async function main() {
     
     results.push({
       Scenario: scenario.name,
-      RPS: res.requests.average,
-      'Latency p95': res.latency.p95,
-      'Latency p99': res.latency.p99,
+      'RPS (avg)': res.requests.average,
+      'RPS (total)': res.requests.total,
+      'Latency p50 (ms)': res.latency.p50,
+      'Latency p95 (ms)': res.latency.p95,
+      'Latency p99 (ms)': res.latency.p99,
       Errors: res.errors,
       Timeouts: res.timeouts,
     });
@@ -44,10 +80,40 @@ async function main() {
     console.log(autocannon.printResult(res));
   }
 
-  // Write summary to JSON for reporting
-  const reportPath = path.join(__dirname, 'last_benchmark_result.json');
-  fs.writeFileSync(reportPath, JSON.stringify(results, null, 2));
-  console.log(`\nBenchmark results saved to: ${reportPath}`);
+  // Generate Markdown table
+  const markdownTable = formatMarkdownTable(results);
+  const markdownReport = `# Benchmark Results
+
+**Date:** ${formatTimestamp()}  
+**Target:** ${baseUrl}
+
+## Summary
+
+${markdownTable}
+
+## Methodology
+
+- Tool: [autocannon](https://github.com/mcollina/autocannon)
+- Each scenario runs for 10 seconds
+- Connection counts vary by endpoint complexity
+
+---
+*Generated automatically by benchmark.js*
+`;
+
+  // Write summary to JSON for programmatic use
+  const jsonPath = path.join(__dirname, 'last_benchmark_result.json');
+  fs.writeFileSync(jsonPath, JSON.stringify(results, null, 2));
+  console.log(`\nJSON results saved to: ${jsonPath}`);
+
+  // Write Markdown report for human readability
+  const mdPath = path.join(__dirname, 'last_benchmark_result.md');
+  fs.writeFileSync(mdPath, markdownReport);
+  console.log(`Markdown report saved to: ${mdPath}`);
+
+  // Print the table to console as well
+  console.log('\n## Benchmark Comparison Table\n');
+  console.log(markdownTable);
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Summary

Adds a formatted Markdown comparison table to the autocannon benchmark output, making results easy to read and share.

## Changes

- Added `formatMarkdownTable()` helper function that generates clean tabular output
- Added `p50` latency metric alongside existing p95/p99
- Added `RPS (total)` column for total requests metric
- Benchmark now writes both JSON (`last_benchmark_result.json`) and Markdown (`last_benchmark_result.md`) reports
- Table is printed to console after all benchmarks complete

## Example Output

| Scenario | RPS (avg) | RPS (total) | Latency p50 (ms) | Latency p95 (ms) | Latency p99 (ms) | Errors | Timeouts |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Health Check (Baseline) | 12,345 | 123,450 | 3.2 | 8.5 | 15.1 | 0 | 0 |

## Testing

- Run: `node tests/load/autocannon/benchmark.js`
- Verify `last_benchmark_result.md` is created with formatted table
- Verify `last_benchmark_result.json` still contains raw data

Fixes #1009