### PR TITLE
fix: standardize worker error response layouts

### DIFF
--- a/workers/well-known-cache/src/index.ts
+++ b/workers/well-known-cache/src/index.ts
@@ -6,6 +6,29 @@ const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Headers": "Content-Type",
 };
 
+interface ErrorResponse {
+  status: number;
+  error: string;
+  message: string;
+  timestamp: string;
+}
+
+function errorResponse(status: number, error: string, message: string): Response {
+  const body: ErrorResponse = {
+    status,
+    error,
+    message,
+    timestamp: new Date().toISOString(),
+  };
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...CORS_HEADERS,
+    },
+  });
+}
+
 function cacheControlFor(pathname: string): string {
   return pathname.endsWith("/stellar.toml")
     ? "public, max-age=3600, stale-while-revalidate=86400"
@@ -18,26 +41,51 @@ export default {
       return new Response(null, { status: 204, headers: CORS_HEADERS });
     }
 
-    const url = new URL(request.url);
-    const cache = caches.default;
-
-    const cached = await cache.match(request);
-    if (cached) {
-      const res = new Response(cached.body, cached);
-      res.headers.set("cf-cache-status", "HIT");
-      for (const [k, v] of Object.entries(CORS_HEADERS)) res.headers.set(k, v);
-      return res;
+    if (!["GET", "HEAD"].includes(request.method)) {
+      return errorResponse(
+        405,
+        "Method Not Allowed",
+        `HTTP method ${request.method} is not supported. Use GET or HEAD.`
+      );
     }
 
-    const origin = await fetch(request);
-    if (!origin.ok) return origin;
+    let url: URL;
+    try {
+      url = new URL(request.url);
+    } catch {
+      return errorResponse(400, "Bad Request", "Invalid request URL.");
+    }
 
-    const res = new Response(origin.body, origin);
-    res.headers.set("Cache-Control", cacheControlFor(url.pathname));
-    res.headers.set("cf-cache-status", "MISS");
-    for (const [k, v] of Object.entries(CORS_HEADERS)) res.headers.set(k, v);
+    try {
+      const cache = caches.default;
 
-    await cache.put(request, res.clone());
-    return res;
+      const cached = await cache.match(request);
+      if (cached) {
+        const res = new Response(cached.body, cached);
+        res.headers.set("cf-cache-status", "HIT");
+        for (const [k, v] of Object.entries(CORS_HEADERS)) res.headers.set(k, v);
+        return res;
+      }
+
+      const origin = await fetch(request);
+      if (!origin.ok) {
+        return errorResponse(
+          origin.status,
+          origin.statusText || "Upstream Error",
+          `Origin server returned ${origin.status} for ${url.pathname}.`
+        );
+      }
+
+      const res = new Response(origin.body, origin);
+      res.headers.set("Cache-Control", cacheControlFor(url.pathname));
+      res.headers.set("cf-cache-status", "MISS");
+      for (const [k, v] of Object.entries(CORS_HEADERS)) res.headers.set(k, v);
+
+      await cache.put(request, res.clone());
+      return res;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "An unexpected error occurred.";
+      return errorResponse(502, "Bad Gateway", `Failed to fetch origin: ${message}`);
+    }
   },
 } satisfies ExportedHandler;


### PR DESCRIPTION
## Summary
Standardizes error responses in the Cloudflare Worker to follow REST JSON guidelines.

## Changes
- Add `errorResponse` helper returning JSON with `status`, `error`, `message`, `timestamp`
- Add 405 Method Not Allowed for unsupported HTTP methods
- Add 400 Bad Request for invalid URLs
- Replace raw origin passthrough with structured JSON error on upstream failure
- Add try/catch with 502 Bad Gateway for unexpected errors
- All error responses include CORS headers and `Content-Type: application/json`

## Error Response Format
```json
{
  "status": 405,
  "error": "Method Not Allowed",
  "message": "HTTP method POST is not supported. Use GET or HEAD.",
  "timestamp": "2026-05-30T00:00:00.000Z"
}
```

## Testing
- Error responses return proper JSON structure
- CORS headers present on all responses
- Cache behavior unchanged for successful requests

Fixes #1050