### PR TITLE
feat(starter): verify webhook signature using raw body and timing-saf…

### DIFF
--- a/bridge-starter-node/src/app.ts
+++ b/bridge-starter-node/src/app.ts
@@ -4,7 +4,14 @@ import { config } from "./config/env";
 
 const app = express();
 
-app.use(express.json());
+// Preserve raw request body buffer for signature verification middleware.
+app.use(
+  express.json({
+    verify: (req: any, _res, buf: Buffer) => {
+      req.rawBody = buf;
+    },
+  }),
+);
 
 app.get("/", (req: Request, res: Response) => {
   res.send("Bridge Starter API running 🚀");

--- a/bridge-starter-node/src/middleware/auth.ts
+++ b/bridge-starter-node/src/middleware/auth.ts
@@ -1,0 +1,60 @@
+import { Request, Response, NextFunction } from "express";
+import crypto from "crypto";
+import { config } from "../config/env";
+
+function getRawBody(req: Request): Buffer {
+  // body parsers can attach a raw body buffer to the request (app.ts config).
+  // Fallback to JSON.stringify for environments that don't provide rawBody.
+  const anyReq = req as any;
+  if (anyReq.rawBody && Buffer.isBuffer(anyReq.rawBody)) {
+    return anyReq.rawBody as Buffer;
+  }
+
+  // If no rawBody is available, fall back to stable string encoding of req.body
+  try {
+    return Buffer.from(JSON.stringify(req.body));
+  } catch (e) {
+    return Buffer.from("");
+  }
+}
+
+export const verifyWebhookSignature = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const signatureHeader = (req.headers["x-bridge-signature"] ||
+    req.headers["x-bridge-signature-256"]) as string | undefined;
+
+  if (!signatureHeader) {
+    return res.status(401).json({ error: "Missing signature header" });
+  }
+
+  if (!config.webhookSecret) {
+    console.error("WEBHOOK_SECRET not configured; rejecting webhook request");
+    return res.status(500).json({ error: "Server misconfigured" });
+  }
+
+  const raw = getRawBody(req);
+  const expected = crypto
+    .createHmac("sha256", config.webhookSecret)
+    .update(raw)
+    .digest("hex");
+
+  try {
+    const sigBuf = Buffer.from(signatureHeader, "utf8");
+    const expectedBuf = Buffer.from(expected, "utf8");
+    if (
+      sigBuf.length === expectedBuf.length &&
+      crypto.timingSafeEqual(sigBuf, expectedBuf)
+    ) {
+      return next();
+    }
+  } catch (e) {
+    // fall through to unauthorized below
+  }
+
+  return res.status(401).json({ error: "Invalid signature" });
+};
+
+export default verifyWebhookSignature;

--- a/bridge-starter-node/src/routes/webhook.ts
+++ b/bridge-starter-node/src/routes/webhook.ts
@@ -1,12 +1,12 @@
 import { Router, Request, Response } from "express";
-import { verifySignature } from "../middleware/verifySignature";
+import verifyWebhookSignature from "../middleware/auth";
 import { WebhookEvent, PaymentData } from "../types/webhook";
 
 const router = Router();
 
 router.post(
   "/webhook",
-  verifySignature,
+  verifyWebhookSignature,
   (req: Request, res: Response) => {
     const event = req.body as WebhookEvent<PaymentData>;
 


### PR DESCRIPTION
This change adds proper verification for webhook signatures in the bridge starter Node template.

closes #995 

Summary
- Implements verification middleware in `bridge-starter-node/src/middleware/auth.ts`.
- Ensures the server preserves the raw request body by updating `bridge-starter-node/src/app.ts` so the HMAC is computed over the exact bytes received.
- Replaces the route middleware usage in `bridge-starter-node/src/routes/webhook.ts` to use the new verification middleware.

What it does
- Computes HMAC-SHA256 over the raw request body using the `WEBHOOK_SECRET` (from `bridge-starter-node/src/config/env.ts`).
- Accepts signature headers `x-bridge-signature` (or `x-bridge-signature-256`).
- Uses `crypto.timingSafeEqual` to compare the expected and provided signatures to mitigate timing attacks.
- Returns:
  - 401 when signature is missing or invalid,
  - 500 if `WEBHOOK_SECRET` is not configured.

Files changed
- `bridge-starter-node/src/middleware/auth.ts` (new) — middleware `verifyWebhookSignature`
- `bridge-starter-node/src/app.ts` — preserve `rawBody` buffer for signature verification
- `bridge-starter-node/src/routes/webhook.ts` — use `verifyWebhookSignature`

Configuration
- Ensure `WEBHOOK_SECRET` is set in the bridge starter environment (e.g., `.env`).

Testing
1. Start the bridge starter server:
   cd bridge-starter-node
   npm install
   npm run dev

2. Compute HMAC for a payload (example using `node`):
   payload='{"type":"payment.success","data":{"id":"123"}}'
   sig=$(node -e "const crypto=require('crypto'); const s=crypto.createHmac('sha256', process.env.WEBHOOK_SECRET||'secret').update(process.argv[1]).digest('hex'); console.log(s)" "$payload")

3. Send webhook:
   curl -X POST http://localhost:3000/api/webhook \
     -H "Content-Type: application/json" \
     -H "x-bridge-signature: $sig" \
     -d "$payload"

Expected: 200 when signature matches, 401 otherwise.

Notes
- The middleware falls back to JSON.stringify(req.body) if raw body is unavailable, but the server-side raw body preservation added in `app.ts` is the recommended configuration.