### PR TITLE
fix: enable esbuild minification for worker bundle size reduction

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,13 @@ name               = "well-known-cache"
 main               = "workers/well-known-cache/src/index.ts"
 compatibility_date = "2024-09-23"
 
+# Esbuild size optimizations — minimize bundle for faster worker startup
+minify = true
+# Preserve names for stack traces in production debugging (set false for max minification)
+# keep_names = false
+# Source maps for debugging (disable in production for smaller output)
+# source_maps = false
+
 # Replace "yourdomain.com" with your actual domain before deploying.
 routes = [
   { pattern = "*yourdomain.com/.well-known/*", zone_name = "yourdomain.com" }


### PR DESCRIPTION
Fixes #1048

## Summary

Enable wrangler's built-in esbuild minification to reduce the well-known-cache worker bundle size and accelerate cold starts.

## Changes

- Add `minify = true` to `wrangler.toml` — enables esbuild's minification pipeline including dead code elimination, tree-shaking, and identifier mangling

## Testing

- Run `npx wrangler deploy --dry-run` to verify the worker builds successfully with minification enabled
- Compare bundle size before and after: `npx wrangler deploy --outdir dist` and check file sizes

## Technical Details

Cloudflare Workers uses esbuild internally for bundling. The `minify = true` option enables:
- **Dead code elimination** — removes unused code paths
- **Tree-shaking** — eliminates unused exports
- **Identifier mangling** — shortens variable/function names
- **Whitespace removal** — compresses output

This reduces the worker bundle size, resulting in faster cold starts and reduced memory usage.