### PR TITLE
feat: enforce Tanzania mobile number format validation with Tigo/Vodacom prefix checking

### DIFF
--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { StellarService } from "../services/stellar/stellarService";
 import { MobileMoneyService } from "../services/mobilemoney/mobileMoneyService";
 import { maskPhoneNumber } from "../utils/masking";
-import { validatePhoneProviderMatch } from "../utils/phoneUtils";
+import { validatePhoneProviderMatch, isTanzaniaNumber, validateTanzaniaProviderMatch } from "../utils/phoneUtils";
 import {
   Transaction,
   TransactionModel,
@@ -416,7 +416,14 @@ async function processTransactionRequest(
     }
 
     // Recipient Mobile Network Validation
-    const networkMatch = validatePhoneProviderMatch(phoneNumber, provider);
+    let networkMatch: { valid: boolean; error?: string };
+    if (isTanzaniaNumber(phoneNumber)) {
+      // Use Tanzania-specific validation with operator prefix checking
+      networkMatch = validateTanzaniaProviderMatch(phoneNumber, provider);
+    } else {
+      // Use existing validation for other regions (Uganda, Rwanda, Cameroon, Ghana, etc.)
+      networkMatch = validatePhoneProviderMatch(phoneNumber, provider);
+    }
     if (!networkMatch.valid) {
       return res.status(400).json({
         error: networkMatch.error,

--- a/src/utils/__tests__/phoneUtils.test.ts
+++ b/src/utils/__tests__/phoneUtils.test.ts
@@ -1,13 +1,222 @@
-import { formatPhoneForProvider } from "../phoneUtils";
+import {
+  formatPhoneForProvider,
+  validatePhoneProviderMatch,
+  isTanzaniaNumber,
+  validateTanzaniaPhoneNumber,
+  validateTanzaniaProviderMatch,
+  TANZANIA_PROVIDER_PREFIXES,
+} from "../phoneUtils";
 
 describe("formatPhoneForProvider", () => {
   it("normalizes Airtel Cameroon numbers to national format", () => {
-    expect(formatPhoneForProvider("+237670000000", "airtel")).toBe("670000000");
+    expect(formatPhoneForProvider("+237****0000", "airtel")).toBe("670000000");
     expect(formatPhoneForProvider("237670000000", "airtel")).toBe("670000000");
     expect(formatPhoneForProvider("670000000", "airtel")).toBe("670000000");
   });
 
   it("keeps E.164 format for other providers", () => {
-    expect(formatPhoneForProvider("+237670000000", "mtn")).toBe("+237670000000");
+    expect(formatPhoneForProvider("+237****0000", "mtn")).toBe("+237****0000");
+  });
+});
+
+describe("phoneUtils", () => {
+  describe("validatePhoneProviderMatch", () => {
+    it("should validate MTN Uganda numbers", () => {
+      const result = validatePhoneProviderMatch("+256****4567", "mtn");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject mismatched provider", () => {
+      const result = validatePhoneProviderMatch("+256****4567", "airtel");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("does not belong to");
+    });
+  });
+
+  describe("isTanzaniaNumber", () => {
+    it("should identify Tanzania numbers with + prefix", () => {
+      expect(isTanzaniaNumber("+255****4567")).toBe(true);
+    });
+
+    it("should identify Tanzania numbers without + prefix", () => {
+      expect(isTanzaniaNumber("255751234567")).toBe(true);
+    });
+
+    it("should reject non-Tanzania numbers", () => {
+      expect(isTanzaniaNumber("+256****4567")).toBe(false);
+      expect(isTanzaniaNumber("+237****4567")).toBe(false);
+    });
+  });
+
+  describe("validateTanzaniaPhoneNumber", () => {
+    describe("Vodacom Tanzania", () => {
+      const vodacomNumbers = [
+        "+255****4567",
+        "+255****4567",
+        "+255****4567",
+        "+255****4567",
+      ];
+
+      vodacomNumbers.forEach((phone) => {
+        it(`should validate Vodacom number ${phone}`, () => {
+          const result = validateTanzaniaPhoneNumber(phone);
+          expect(result.valid).toBe(true);
+          expect(result.operator).toBe("vodacom");
+          expect(result.normalized).toBe(phone);
+        });
+      });
+    });
+
+    describe("Tigo (Mixx by Yas) Tanzania", () => {
+      const tigoNumbers = ["+255****4567", "+255****4567", "+255****4567"];
+
+      tigoNumbers.forEach((phone) => {
+        it(`should validate Tigo number ${phone}`, () => {
+          const result = validateTanzaniaPhoneNumber(phone);
+          expect(result.valid).toBe(true);
+          expect(result.operator).toBe("tigo");
+        });
+      });
+    });
+
+    describe("Airtel Tanzania", () => {
+      const airtelNumbers = ["+255****4567", "+255****4567"];
+
+      airtelNumbers.forEach((phone) => {
+        it(`should validate Airtel number ${phone}`, () => {
+          const result = validateTanzaniaPhoneNumber(phone);
+          expect(result.valid).toBe(true);
+          expect(result.operator).toBe("airtel");
+        });
+      });
+    });
+
+    describe("Halotel Tanzania", () => {
+      const halotelNumbers = ["+255****4567", "+255****4567"];
+
+      halotelNumbers.forEach((phone) => {
+        it(`should validate Halotel number ${phone}`, () => {
+          const result = validateTanzaniaPhoneNumber(phone);
+          expect(result.valid).toBe(true);
+          expect(result.operator).toBe("halotel");
+        });
+      });
+    });
+
+    describe("TTCL Tanzania", () => {
+      it("should validate TTCL number", () => {
+        const result = validateTanzaniaPhoneNumber("+255****4567");
+        expect(result.valid).toBe(true);
+        expect(result.operator).toBe("ttcl");
+      });
+    });
+
+    describe("Local format", () => {
+      it("should accept local format 0751234567", () => {
+        const result = validateTanzaniaPhoneNumber("0751234567");
+        expect(result.valid).toBe(true);
+        expect(result.operator).toBe("vodacom");
+        expect(result.normalized).toBe("+255****4567");
+      });
+
+      it("should accept local format 0681234567", () => {
+        const result = validateTanzaniaPhoneNumber("0681234567");
+        expect(result.valid).toBe(true);
+        expect(result.operator).toBe("airtel");
+        expect(result.normalized).toBe("+255****4567");
+      });
+    });
+
+    describe("Error cases", () => {
+      it("should reject numbers with invalid length (too short)", () => {
+        const result = validateTanzaniaPhoneNumber("+255****2345");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain("must be");
+      });
+
+      it("should reject numbers with invalid length (too long)", () => {
+        const result = validateTanzaniaPhoneNumber("+255****7890");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain("must be");
+      });
+
+      it("should reject non-numeric characters", () => {
+        const result = validateTanzaniaPhoneNumber("+25575abc4567");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain("only digits");
+      });
+
+      it("should reject numbers with invalid prefix", () => {
+        const result = validateTanzaniaPhoneNumber("+255****4567");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain("not a recognized");
+      });
+
+      it("should reject numbers with wrong country code", () => {
+        const result = validateTanzaniaPhoneNumber("+256****4567");
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain("Expected Tanzania country code");
+      });
+    });
+  });
+
+  describe("validateTanzaniaProviderMatch", () => {
+    it("should match Vodacom number with vodacom provider", () => {
+      const result = validateTanzaniaProviderMatch("+255****4567", "vodacom");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should match Airtel Tanzania number with airtel provider", () => {
+      const result = validateTanzaniaProviderMatch("+255****4567", "airtel");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should match Tigo number with tigo provider", () => {
+      const result = validateTanzaniaProviderMatch("+255****4567", "tigo");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject Vodacom number with airtel provider", () => {
+      const result = validateTanzaniaProviderMatch("+255****4567", "airtel");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("VODACOM");
+      expect(result.error).toContain("AIRTEL");
+    });
+
+    it("should reject Airtel Tanzania number with vodacom provider", () => {
+      const result = validateTanzaniaProviderMatch("+255****4567", "vodacom");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("AIRTEL");
+      expect(result.error).toContain("VODACOM");
+    });
+
+    it("should reject invalid Tanzania numbers", () => {
+      const result = validateTanzaniaProviderMatch("+255****4567", "vodacom");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("not a recognized");
+    });
+
+    it("should work with local format", () => {
+      const result = validateTanzaniaProviderMatch("0751234567", "vodacom");
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("TANZANIA_PROVIDER_PREFIXES", () => {
+    it("should have all expected operators", () => {
+      expect(TANZANIA_PROVIDER_PREFIXES).toHaveProperty("vodacom");
+      expect(TANZANIA_PROVIDER_PREFIXES).toHaveProperty("tigo");
+      expect(TANZANIA_PROVIDER_PREFIXES).toHaveProperty("airtel");
+      expect(TANZANIA_PROVIDER_PREFIXES).toHaveProperty("halotel");
+      expect(TANZANIA_PROVIDER_PREFIXES).toHaveProperty("ttcl");
+    });
+
+    it("should have correct number of prefixes per operator", () => {
+      expect(TANZANIA_PROVIDER_PREFIXES.vodacom).toHaveLength(4);
+      expect(TANZANIA_PROVIDER_PREFIXES.tigo).toHaveLength(3);
+      expect(TANZANIA_PROVIDER_PREFIXES.airtel).toHaveLength(2);
+      expect(TANZANIA_PROVIDER_PREFIXES.halotel).toHaveLength(2);
+      expect(TANZANIA_PROVIDER_PREFIXES.ttcl).toHaveLength(1);
+    });
   });
 });

--- a/src/utils/phoneUtils.ts
+++ b/src/utils/phoneUtils.ts
@@ -10,11 +10,21 @@ interface ProviderPhoneFormatConfig {
 
 /**
  * Standard mapping of prefixes to Mobile Network Operators.
- * These are common prefixes for regions like Uganda/Rwanda/Cameroon/Ghana.
+ * These are common prefixes for regions like Uganda/Rwanda/Cameroon/Ghana/Tanzania.
  */
 const PROVIDER_PREFIXES: Record<MobileProvider, string[]> = {
   mtn: ["23767", "23768", "25677", "25678", "23324", "23354", "23355", "23359"],
-  airtel: ["23766", "25670", "25675", "23326", "23356", "23357"],
+  airtel: [
+    "23766",
+    "25670",
+    "25675",
+    "23326",
+    "23356",
+    "23357",
+    // Tanzania Airtel prefixes
+    "25568",
+    "25569",
+  ],
   orange: ["23765", "23769", "22507", "22177"],
 };
 
@@ -58,6 +68,37 @@ function parseFlexiblePhoneNumber(
 
   return null;
 }
+
+/**
+ * Tanzania Mobile Network Operator prefixes.
+ * Country code: +255
+ *
+ * Vodacom Tanzania: 075x, 076x, 077x, 078x
+ * Tigo (Mixx by Yas): 065x, 067x, 071x
+ * Airtel Tanzania: 068x, 069x
+ * Halotel: 062x, 063x
+ * TTCL: 073x
+ */
+export const TANZANIA_PROVIDER_PREFIXES: Record<string, string[]> = {
+  vodacom: ["25575", "25576", "25577", "25578"],
+  tigo: ["25565", "25567", "25571"],
+  airtel: ["25568", "25569"],
+  halotel: ["25562", "25563"],
+  ttcl: ["25573"],
+};
+
+/** All valid Tanzania mobile prefixes combined */
+const ALL_TANZANIA_PREFIXES: string[] = Object.values(
+  TANZANIA_PROVIDER_PREFIXES,
+).flat();
+
+/**
+ * Tanzania phone number length constraints.
+ * Tanzania numbers: +255 followed by 9 digits (total 12 digits with country code).
+ * Local format: 0 followed by 9 digits (10 digits total).
+ */
+const TANZANIA_TOTAL_DIGITS_WITH_CC = 12; // +255 XXX XXX XXX
+const TANZANIA_LOCAL_DIGITS = 10; // 0XX XXX XXX
 
 /**
  * Validates if a phone number belongs to the specified provider.
@@ -110,4 +151,140 @@ export function formatPhoneForProvider(
   }
 
   return config.output === "national" ? parsed.nationalNumber : parsed.number;
+}
+
+/**
+ * Checks if a phone number is a Tanzania number (+255 prefix).
+ * @param phoneNumber E.164 formatted number (e.g., +25575...)
+ */
+export function isTanzaniaNumber(phoneNumber: string): boolean {
+  const sanitized = phoneNumber.replace(/^\+/, "");
+  return sanitized.startsWith("255");
+}
+
+/**
+ * Validates a Tanzania phone number format and identifies the operator.
+ *
+ * Accepts:
+ * - E.164 format: +255XXXXXXXXX
+ * - Local format with leading zero: 0XXXXXXXXX
+ *
+ * Rejects:
+ * - Wrong length (must be 9 digits after country code)
+ * - Invalid prefix (not a recognized Tanzania MNO prefix)
+ *
+ * @param phoneNumber Phone number in E.164 or local format
+ * @returns Validation result with operator name if valid
+ */
+export function validateTanzaniaPhoneNumber(phoneNumber: string): {
+  valid: boolean;
+  operator?: string;
+  normalized?: string;
+  error?: string;
+} {
+  // Strip whitespace and leading +
+  let sanitized = phoneNumber.replace(/^\+/, "").trim();
+
+  // Handle local format (0XX XXX XXX → 255XX XXX XXX)
+  if (sanitized.startsWith("0") && sanitized.length === TANZANIA_LOCAL_DIGITS) {
+    sanitized = "255" + sanitized.substring(1);
+  }
+
+  // Reject non-numeric characters
+  if (!/^\d+$/.test(sanitized)) {
+    return {
+      valid: false,
+      error: `Tanzania phone number must contain only digits. Got: ${phoneNumber}`,
+    };
+  }
+
+  // Validate length: +255 followed by 9 digits
+  if (sanitized.length !== TANZANIA_TOTAL_DIGITS_WITH_CC) {
+    return {
+      valid: false,
+      error: `Tanzania phone number must be ${TANZANIA_TOTAL_DIGITS_WITH_CC} digits (including country code 255) or ${TANZANIA_LOCAL_DIGITS} digits in local format. Got ${sanitized.length} digits: ${phoneNumber}`,
+    };
+  }
+
+  // Validate country code
+  if (!sanitized.startsWith("255")) {
+    return {
+      valid: false,
+      error: `Expected Tanzania country code 255. Got: ${phoneNumber}`,
+    };
+  }
+
+  // Validate prefix against known Tanzania MNO prefixes
+  const matchedOperator = Object.entries(TANZANIA_PROVIDER_PREFIXES).find(
+    ([, prefixes]) =>
+      prefixes.some((prefix) => sanitized.startsWith(prefix)),
+  );
+
+  if (!matchedOperator) {
+    // Extract the prefix for error message (first 5 digits = country code + operator code)
+    const prefix = sanitized.substring(0, 5);
+    const validPrefixes = ALL_TANZANIA_PREFIXES.map((p) => p.substring(3)).join(
+      ", ",
+    );
+    return {
+      valid: false,
+      error: `Tanzania phone number prefix ${prefix} is not a recognized mobile operator prefix. Valid prefixes: ${validPrefixes}`,
+    };
+  }
+
+  const [operator] = matchedOperator;
+
+  return {
+    valid: true,
+    operator,
+    normalized: `+${sanitized}`,
+  };
+}
+
+/**
+ * Validates Tanzania phone number matches the expected provider.
+ *
+ * Maps Tanzania operators to platform providers:
+ * - vodacom, tigo, halotel, ttcl → treated as generic mobile
+ * - airtel → maps to "airtel" provider
+ *
+ * @param phoneNumber E.164 formatted Tanzania number
+ * @param provider The expected provider
+ * @returns Validation result
+ */
+export function validateTanzaniaProviderMatch(
+  phoneNumber: string,
+  provider: string,
+): { valid: boolean; error?: string } {
+  const result = validateTanzaniaPhoneNumber(phoneNumber);
+
+  if (!result.valid) {
+    return { valid: false, error: result.error };
+  }
+
+  const operator = result.operator!.toLowerCase();
+  const expectedProvider = provider.toLowerCase();
+
+  // Direct match for Airtel
+  if (expectedProvider === "airtel" && operator === "airtel") {
+    return { valid: true };
+  }
+
+  // For other Tanzania operators (Vodacom, Tigo, etc.), accept if provider matches or is generic
+  if (["vodacom", "tigo", "halotel", "ttcl"].includes(operator)) {
+    // These are Tanzania-specific operators; allow if provider is one of them
+    if (expectedProvider === operator) {
+      return { valid: true };
+    }
+    // Also allow if provider is generic "mobile" or the platform doesn't distinguish
+    return {
+      valid: false,
+      error: `Phone number belongs to ${operator.toUpperCase()} Tanzania, but expected ${expectedProvider.toUpperCase()}.`,
+    };
+  }
+
+  return {
+    valid: false,
+    error: `Unknown Tanzania operator for ${phoneNumber}.`,
+  };
 }


### PR DESCRIPTION
Fixes #1039

## Summary
Implements Tanzania-specific mobile phone number validation with operator prefix checking for all major Tanzanian mobile network operators.

## Changes
- **New Tanzania provider prefix mappings** for 5 operators:
  - **Vodacom**: +25575, +25576, +25577, +25578
  - **Tigo (Mixx by Yas)**: +25565, +25567, +25571
  - **Airtel Tanzania**: +25568, +25569
  - **Halotel**: +25562, +25563
  - **TTCL**: +25573
- **** — validates E.164 format (+255XXXXXXXXX) and local format (0XXXXXXXXX), identifies operator
- **** — validates phone number belongs to the expected provider's prefix band
- **Transaction controller integration** — Tanzania numbers automatically route to Tanzania-specific validation
- **Comprehensive tests** — 20+ test cases covering all operators, local format, and error scenarios

## Testing
- ✅ All Vodacom prefixes (075, 076, 077, 078) validated correctly
- ✅ All Tigo prefixes (065, 067, 071) validated correctly
- ✅ Airtel Tanzania prefixes (068, 069) validated correctly
- ✅ Local format (0XXXXXXXXX) auto-normalized to E.164
- ✅ Invalid prefixes rejected with descriptive error messages
- ✅ Wrong-length numbers rejected with format guidance
- ✅ Non-numeric characters rejected

## Technical Details
- Country code: +255
- Number format: +255 + 9 digits (12 total) or 0 + 9 digits (10 total local)
- Prefix validation ensures numbers belong to active Tanzania MNO allocations
- Backward compatible — existing validation for other regions unchanged