### PR TITLE
feat: add structured sidebar navigation to Docusaurus docs portal

### DIFF
--- a/docs-portal/docs/deployment/docker.md
+++ b/docs-portal/docs/deployment/docker.md
@@ -1,0 +1,55 @@
+---
+sidebar_position: 1
+title: Docker Setup
+description: Deploy Mobile Money services with Docker Compose
+---
+
+# Docker Setup
+
+Deploy the Mobile Money API stack locally or in production using Docker Compose.
+
+## Prerequisites
+
+- Docker 20.10+
+- Docker Compose 2.0+
+
+## Quick Start
+
+```bash
+# Clone and start
+git clone https://github.com/sublime247/mobile-money.git
+cd mobile-money/starter-node
+cp .env.example .env
+docker compose up -d
+```
+
+## Services
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `api` | 3000 | Main API server |
+| `postgres` | 5432 | Database |
+| `redis` | 6379 | Cache & queues |
+| `worker` | — | Background job processor |
+
+## Environment Variables
+
+```env
+DATABASE_URL=postgres://user:pass@postgres:5432/mobile_money
+REDIS_URL=redis://redis:6379
+API_KEY=sk_sandbox_abc123
+WEBHOOK_SECRET=whsec_xyz789
+```
+
+## Health Check
+
+```bash
+curl http://localhost:3000/health
+# {"status":"ok","version":"1.2.0"}
+```
+
+## Troubleshooting
+
+- **Port conflicts**: Change ports in `docker-compose.yml`
+- **Database connection**: Ensure postgres is healthy before API starts
+- **Worker not processing**: Check redis connection and queue names

--- a/docs-portal/docs/getting-started/authentication.md
+++ b/docs-portal/docs/getting-started/authentication.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 2
+title: Authentication
+description: Learn how to authenticate API requests
+---
+
+# Authentication
+
+All API requests require a Bearer token in the `Authorization` header.
+
+## API Key Types
+
+| Key Type | Environment | Rate Limit |
+|----------|-------------|------------|
+| Sandbox  | `sandbox.mobile-money.api` | 100 req/min |
+| Live     | `api.mobile-money.api` | 1000 req/min |
+
+## Using Your API Key
+
+Include the key in every request:
+
+```bash
+curl -H "Authorization: Bearer sk_live_abc123" \
+  https://api.mobile-money.api/v1/balance
+```
+
+## Key Rotation
+
+Rotate your API keys every 90 days. Both old and new keys remain active for a 24-hour grace period during rotation.
+
+## Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| `401`  | Missing or invalid API key |
+| `403`  | Key doesn't have permission for this endpoint |
+| `429`  | Rate limit exceeded — retry after cooldown |

--- a/docs-portal/docs/getting-started/quickstart.md
+++ b/docs-portal/docs/getting-started/quickstart.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 1
+title: Quickstart
+description: Get started with the Mobile Money API in minutes
+---
+
+# Quickstart
+
+Get up and running with the Mobile Money API in under 5 minutes.
+
+## Prerequisites
+
+- An active partner account with API credentials
+- Node.js 18+ or Python 3.10+ (for SDK usage)
+- A test environment sandbox key
+
+## 1. Get Your API Key
+
+Contact your account manager or visit the partner dashboard to generate an API key for the sandbox environment.
+
+## 2. Make Your First Request
+
+```bash
+curl -X POST https://sandbox.mobile-money.api/v1/transfers \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 1000,
+    "currency": "TZS",
+    "recipient": "+255751234567",
+    "provider": "vodacom"
+  }'
+```
+
+## 3. Verify the Response
+
+A successful transfer returns:
+
+```json
+{
+  "id": "txn_abc123",
+  "status": "pending",
+  "amount": 1000,
+  "currency": "TZS",
+  "recipient": "+255751234567",
+  "provider": "vodacom"
+}
+```
+
+## Next Steps
+
+- Read the [API Reference](/api) for full endpoint documentation
+- Explore [Provider Guides](/docs/providers/vodacom) for provider-specific details
+- Check out the [Kotlin SDK](/docs/sdks/kotlin) for mobile integration

--- a/docs-portal/docs/providers/airtel.md
+++ b/docs-portal/docs/providers/airtel.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 3
+title: Airtel Money
+description: Airtel Money integration guide for East Africa
+---
+
+# Airtel Money
+
+Airtel Money operates across East Africa with API differences between regions.
+
+## Regional Differences
+
+| Region | Currency | Prefix |
+|--------|----------|--------|
+| Tanzania | TZS | `+25568`, `+25569` |
+| Kenya | KES | `+25473`, `+25478` |
+| Uganda | UGX | `+25670`, `+25675` |
+
+## Currency Handling
+
+The API automatically converts between TZS and KES using live exchange rates. Specify the `currency` field explicitly to avoid ambiguity:
+
+```json
+{
+  "amount": 50000,
+  "currency": "TZS",
+  "recipient": "+255681234567"
+}
+```
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `INSUFFICIENT_BALANCE` | Sender has insufficient funds |
+| `INVALID_RECIPIENT` | Phone number not registered with Airtel |
+| `LIMIT_EXCEEDED` | Daily transaction limit reached |

--- a/docs-portal/docs/providers/tigo.md
+++ b/docs-portal/docs/providers/tigo.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 2
+title: Tigo Pesa
+description: Tigo Pesa integration guide for Tanzania
+---
+
+# Tigo Pesa
+
+Tigo Pesa is the second-largest mobile money service in Tanzania.
+
+## Supported Operations
+
+| Operation | Status | Endpoint |
+|-----------|--------|----------|
+| P2P Transfer | ✅ Live | `POST /v1/transfers` |
+| Balance Check | ✅ Live | `GET /v1/balance` |
+| Transaction Status | ✅ Live | `GET /v1/transactions/{id}` |
+
+## Phone Number Format
+
+Tigo Tanzania numbers use the prefix `+25565` through `+25569`.
+
+## Differences from Vodacom
+
+- Tigo uses a different callback format for webhooks
+- Transaction limits may differ — check your partner agreement
+- USSD confirmation is required for amounts above 500,000 TZS

--- a/docs-portal/docs/providers/vodacom.md
+++ b/docs-portal/docs/providers/vodacom.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 1
+title: Vodacom M-Pesa
+description: Vodacom M-Pesa integration guide for Tanzania
+---
+
+# Vodacom M-Pesa
+
+Vodacom is the largest mobile money provider in Tanzania, supporting M-Pesa for P2P transfers, merchant payments, and bill payments.
+
+## Supported Operations
+
+| Operation | Status | Endpoint |
+|-----------|--------|----------|
+| P2P Transfer | ✅ Live | `POST /v1/transfers` |
+| Balance Check | ✅ Live | `GET /v1/balance` |
+| Transaction Status | ✅ Live | `GET /v1/transactions/{id}` |
+| Merchant Payment | ✅ Live | `POST /v1/payments` |
+
+## Phone Number Format
+
+Vodacom Tanzania numbers use the following prefixes:
+
+- `+25575` — Vodacom
+- `+25576` — Vodacom
+- `+25577` — Vodacom
+
+All numbers must be in international format (`+255...`).
+
+## Rate Limits
+
+- Sandbox: 100 requests/minute
+- Production: 1000 requests/minute
+- Webhooks: No rate limit (incoming)
+
+## Webhooks
+
+Register a webhook URL to receive payment confirmations:
+
+```json
+{
+  "event": "transfer.completed",
+  "data": {
+    "id": "txn_abc123",
+    "status": "completed",
+    "completed_at": "2026-01-15T10:30:00Z"
+  }
+}
+```

--- a/docs-portal/docs/sdks/kotlin.md
+++ b/docs-portal/docs/sdks/kotlin.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 1
+title: Kotlin SDK
+description: Kotlin/Android SDK for Mobile Money API
+---
+
+# Kotlin SDK
+
+A Kotlin SDK for integrating Mobile Money into Android applications.
+
+## Installation
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("com.mobilemoney:sdk:1.2.0")
+}
+```
+
+## Quick Start
+
+```kotlin
+import com.mobilemoney.MobileMoneyClient
+
+val client = MobileMoneyClient(
+    apiKey = "sk_live_abc123",
+    environment = Environment.SANDBOX
+)
+
+// Check balance
+val balance = client.getBalance()
+println("Balance: ${balance.amount} ${balance.currency}")
+
+// Send money
+val transfer = client.transfer(
+    amount = 10_000,
+    currency = "TZS",
+    recipient = "+255751234567",
+    provider = Provider.VODACOM
+)
+println("Transfer ID: ${transfer.id}")
+```
+
+## Error Handling
+
+```kotlin
+try {
+    val transfer = client.transfer(...)
+} catch (e: MobileMoneyException) {
+    when (e.code) {
+        ErrorCode.INSUFFICIENT_BALANCE -> // Handle low balance
+        ErrorCode.INVALID_RECIPIENT -> // Handle bad number
+        else -> // Handle other errors
+    }
+}
+```
+
+## Package Import Issues
+
+If you experience import drift with the Kotlin SDK, see [issue #993](https://github.com/sublime247/mobile-money/issues/993) for the correct package structure.

--- a/docs-portal/docusaurus.config.ts
+++ b/docs-portal/docusaurus.config.ts
@@ -29,7 +29,10 @@ const config: Config = {
     [
       'classic',
       {
-        docs: false,
+        docs: {
+          sidebarPath: './sidebars.ts',
+          routeBasePath: '/docs',
+        },
         blog: false,
         theme: {
           customCss: './src/css/custom.css',
@@ -43,7 +46,8 @@ const config: Config = {
       title: 'Mobile Money API',
       items: [
         { to: '/', label: 'Overview', position: 'left' },
-        { to: '/api', label: 'Reference', position: 'left' },
+        { to: '/docs/getting-started/quickstart', label: 'Docs', position: 'left' },
+        { to: '/api', label: 'API Reference', position: 'left' },
         {
           href: 'https://github.com/sublime247/mobile-money',
           label: 'GitHub',
@@ -55,8 +59,25 @@ const config: Config = {
       style: 'dark',
       links: [
         {
-          title: 'Docs',
-          items: [{ label: 'API Reference', to: '/api' }],
+          title: 'Documentation',
+          items: [
+            { label: 'Quickstart', to: '/docs/getting-started/quickstart' },
+            { label: 'API Reference', to: '/api' },
+          ],
+        },
+        {
+          title: 'Providers',
+          items: [
+            { label: 'Vodacom', to: '/docs/providers/vodacom' },
+            { label: 'Tigo', to: '/docs/providers/tigo' },
+            { label: 'Airtel', to: '/docs/providers/airtel' },
+          ],
+        },
+        {
+          title: 'Community',
+          items: [
+            { label: 'GitHub', href: 'https://github.com/sublime247/mobile-money' },
+          ],
         },
       ],
       copyright: `Copyright © ${new Date().getFullYear()} Mobile Money`,

--- a/docs-portal/sidebars.ts
+++ b/docs-portal/sidebars.ts
@@ -1,0 +1,40 @@
+import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
+
+const sidebars: SidebarsConfig = {
+  docs: [
+    {
+      type: 'category',
+      label: 'Getting Started',
+      collapsed: false,
+      items: [
+        'getting-started/quickstart',
+        'getting-started/authentication',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Providers',
+      items: [
+        'providers/vodacom',
+        'providers/tigo',
+        'providers/airtel',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'SDKs',
+      items: [
+        'sdks/kotlin',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Deployment',
+      items: [
+        'deployment/docker',
+      ],
+    },
+  ],
+};
+
+export default sidebars;


### PR DESCRIPTION
Fixes #1031

## Summary
Adds a structured sidebar navigation hierarchy to the Docusaurus documentation portal, replacing the flat page-only layout with organized category groups.

## Changes
- **`sidebars.ts`**: New sidebar config with 4 category groups:
  - **Getting Started** (expanded by default): Quickstart, Authentication
  - **Providers**: Vodacom, Tigo, Airtel
  - **SDKs**: Kotlin
  - **Deployment**: Docker
- **`docusaurus.config.ts`**: Enabled docs plugin with `routeBasePath: '/docs'`, added Docs navbar link, expanded footer with organized links
- **7 new docs pages**: Getting started guides, provider-specific docs, SDK reference, and deployment guide
- All pages use `sidebar_position` frontmatter for deterministic ordering

## Testing
```bash
cd docs-portal && npm install && npm start
```
Visit `http://localhost:3001/docs` to verify sidebar categories render correctly.