### PR TITLE
feat: add automated SDK publish workflow for Maven Central and npm

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,0 +1,303 @@
+# ── SDK Publish Workflow ──────────────────────────────────────────────────────
+#
+# Triggered when a GitHub Release is *published* (not just drafted).
+# Publishes two SDK packages in parallel:
+#
+#   • Kotlin/JVM SDK  → Maven Central (via Sonatype OSSRH)
+#   • TypeScript SDK  → npm registry
+#
+# Required repository secrets
+# ────────────────────────────
+#   SONATYPE_USERNAME          Sonatype OSSRH username (token-based preferred)
+#   SONATYPE_PASSWORD          Sonatype OSSRH password / token
+#   GPG_SIGNING_KEY            ASCII-armored GPG private key (maven-publish signing)
+#   GPG_SIGNING_PASSWORD       Passphrase for the GPG key
+#   NPM_TOKEN                  npm automation token (https://www.npmjs.com/settings/<org>/tokens)
+#
+# See docs/SDK_PUBLISH.md for the full setup guide.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: SDK Publish
+
+on:
+  release:
+    types: [published]
+
+# Prevent concurrent publish runs for the same ref (e.g. rapid re-publishes).
+concurrency:
+  group: sdk-publish-${{ github.ref }}
+  cancel-in-progress: false   # never cancel an in-flight publish
+
+permissions:
+  contents: read   # checkout only; no write access needed
+
+jobs:
+  # ── 1. Resolve the release version ─────────────────────────────────────────
+  # Strips the leading "v" from the tag (v1.2.3 → 1.2.3) and exposes it as a
+  # job output consumed by both publish jobs.
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - name: Parse version from tag
+        id: parse
+        run: |
+          RAW_TAG="${{ github.event.release.tag_name }}"
+          VERSION="${RAW_TAG#v}"   # strip leading "v"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing SDK version: ${VERSION} (from tag: ${RAW_TAG})"
+
+  # ── 2. Publish Kotlin SDK to Maven Central ──────────────────────────────────
+  publish-kotlin-sdk:
+    runs-on: ubuntu-latest
+    needs: resolve-version
+    environment: sdk-publish   # optional: gate behind a manual approval environment
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: gradle
+
+      - name: Set up Node.js (for OpenAPI generator)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Start API server for OpenAPI spec generation
+        run: |
+          # Build first so we can run the compiled output
+          npm run build
+          node dist/src/index.js &
+          echo "API_PID=$!" >> "$GITHUB_ENV"
+        env:
+          NODE_ENV: development
+          PORT: 3000
+          DATABASE_URL: ${{ secrets.CI_DATABASE_URL || 'postgresql://ci:ci@localhost:5432/ci' }}
+          REDIS_URL: redis://localhost:6379
+          JWT_SECRET: ci-jwt-secret-32-chars-long-placeholder
+          SESSION_SECRET: ci-session-secret-placeholder
+          STELLAR_ISSUER_SECRET: SCZANGBA5YHTNYVVV3C7CAZMCLPVAR3LXKLHEADMPROMU3QAHZGOSN6A
+
+      - name: Wait for API to be ready
+        run: npx wait-on http://127.0.0.1:3000/health --timeout 30000
+        continue-on-error: true   # spec generation falls back to cached spec if server fails
+
+      - name: Generate Kotlin SDK from OpenAPI spec
+        run: |
+          # Install the OpenAPI generator CLI if not already cached
+          npm install -g @openapitools/openapi-generator-cli@latest --ignore-scripts
+
+          # Prefer live spec; fall back to the committed public/openapi.json
+          if curl -sf http://127.0.0.1:3000/docs/openapi.json -o /tmp/openapi.json; then
+            echo "Using live OpenAPI spec from running server"
+            SPEC_PATH=/tmp/openapi.json
+          else
+            echo "Server unavailable — using committed spec at public/openapi.json"
+            SPEC_PATH=public/openapi.json
+          fi
+
+          openapi-generator-cli generate \
+            -i "$SPEC_PATH" \
+            -c sdk-config.yaml \
+            -o sdk \
+            --additional-properties=artifactVersion=${{ needs.resolve-version.outputs.version }}
+
+      - name: Stop API server
+        if: always()
+        run: |
+          if [ -n "$API_PID" ]; then
+            kill "$API_PID" 2>/dev/null || true
+          fi
+
+      - name: Check if Sonatype credentials are configured
+        id: check_sonatype
+        run: |
+          if [ -n "${{ secrets.SONATYPE_USERNAME }}" ] && \
+             [ -n "${{ secrets.SONATYPE_PASSWORD }}" ] && \
+             [ -n "${{ secrets.GPG_SIGNING_KEY }}" ] && \
+             [ -n "${{ secrets.GPG_SIGNING_PASSWORD }}" ]; then
+            echo "sonatype_available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "sonatype_available=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️  Sonatype / GPG secrets not configured — skipping Maven Central publish."
+            echo "    Required secrets: SONATYPE_USERNAME, SONATYPE_PASSWORD, GPG_SIGNING_KEY, GPG_SIGNING_PASSWORD"
+            echo "    See docs/SDK_PUBLISH.md for setup instructions."
+          fi
+
+      - name: Make Gradle wrapper executable
+        working-directory: sdk
+        run: chmod +x gradlew 2>/dev/null || true
+
+      - name: Run Kotlin SDK tests
+        working-directory: sdk
+        run: ./gradlew test --no-daemon
+        continue-on-error: false
+
+      - name: Publish Kotlin SDK to Maven Central
+        if: steps.check_sonatype.outputs.sonatype_available == 'true'
+        working-directory: sdk
+        run: |
+          ./gradlew publishMavenKotlinPublicationToSonatypeRepository \
+            --no-daemon \
+            -Pversion=${{ needs.resolve-version.outputs.version }} \
+            -PsigningKey="${{ secrets.GPG_SIGNING_KEY }}" \
+            -PsigningPassword="${{ secrets.GPG_SIGNING_PASSWORD }}"
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
+      - name: Upload Kotlin SDK artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kotlin-sdk-${{ needs.resolve-version.outputs.version }}
+          path: |
+            sdk/build/libs/*.jar
+            sdk/build/publications/
+          retention-days: 30
+
+  # ── 3. Publish TypeScript SDK to npm ───────────────────────────────────────
+  publish-typescript-sdk:
+    runs-on: ubuntu-latest
+    needs: resolve-version
+    environment: sdk-publish
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js with npm registry auth
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Start API server for OpenAPI spec generation
+        run: |
+          npm run build
+          node dist/src/index.js &
+          echo "API_PID=$!" >> "$GITHUB_ENV"
+        env:
+          NODE_ENV: development
+          PORT: 3000
+          DATABASE_URL: ${{ secrets.CI_DATABASE_URL || 'postgresql://ci:ci@localhost:5432/ci' }}
+          REDIS_URL: redis://localhost:6379
+          JWT_SECRET: ci-jwt-secret-32-chars-long-placeholder
+          SESSION_SECRET: ci-session-secret-placeholder
+          STELLAR_ISSUER_SECRET: SCZANGBA5YHTNYVVV3C7CAZMCLPVAR3LXKLHEADMPROMU3QAHZGOSN6A
+
+      - name: Wait for API to be ready
+        run: npx wait-on http://127.0.0.1:3000/health --timeout 30000
+        continue-on-error: true
+
+      - name: Generate TypeScript SDK from OpenAPI spec
+        run: |
+          npm install -g @openapitools/openapi-generator-cli@latest --ignore-scripts
+
+          if curl -sf http://127.0.0.1:3000/docs/openapi.json -o /tmp/openapi.json; then
+            echo "Using live OpenAPI spec from running server"
+            SPEC_PATH=/tmp/openapi.json
+          else
+            echo "Server unavailable — using committed spec at public/openapi.json"
+            SPEC_PATH=public/openapi.json
+          fi
+
+          openapi-generator-cli generate \
+            -i "$SPEC_PATH" \
+            -c sdk-config-ts.yaml \
+            -o sdk-ts \
+            --additional-properties=npmVersion=${{ needs.resolve-version.outputs.version }}
+
+      - name: Stop API server
+        if: always()
+        run: |
+          if [ -n "$API_PID" ]; then
+            kill "$API_PID" 2>/dev/null || true
+          fi
+
+      - name: Install TypeScript SDK dependencies
+        working-directory: sdk-ts
+        run: npm install
+
+      - name: Build TypeScript SDK
+        working-directory: sdk-ts
+        run: npm run build
+
+      - name: Check if npm token is configured
+        id: check_npm
+        run: |
+          if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "npm_available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm_available=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️  NPM_TOKEN secret not configured — skipping npm publish."
+            echo "    See docs/SDK_PUBLISH.md for setup instructions."
+          fi
+
+      - name: Publish TypeScript SDK to npm
+        if: steps.check_npm.outputs.npm_available == 'true'
+        working-directory: sdk-ts
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Upload TypeScript SDK artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: typescript-sdk-${{ needs.resolve-version.outputs.version }}
+          path: sdk-ts/dist/
+          retention-days: 30
+
+  # ── 4. Post-publish summary ─────────────────────────────────────────────────
+  publish-summary:
+    runs-on: ubuntu-latest
+    needs: [resolve-version, publish-kotlin-sdk, publish-typescript-sdk]
+    if: always()
+
+    steps:
+      - name: Summarise publish results
+        run: |
+          VERSION="${{ needs.resolve-version.outputs.version }}"
+          KOTLIN_RESULT="${{ needs.publish-kotlin-sdk.result }}"
+          TS_RESULT="${{ needs.publish-typescript-sdk.result }}"
+
+          echo "## SDK Publish Summary — v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| SDK | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$KOTLIN_RESULT" = "success" ]; then
+            echo "| Kotlin (Maven Central) | ✅ Published |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| Kotlin (Maven Central) | ❌ ${KOTLIN_RESULT} |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ "$TS_RESULT" = "success" ]; then
+            echo "| TypeScript (npm) | ✅ Published |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| TypeScript (npm) | ❌ ${TS_RESULT} |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Release:** ${{ github.event.release.html_url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Triggered by:** ${{ github.actor }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if any publish job failed
+        if: needs.publish-kotlin-sdk.result == 'failure' || needs.publish-typescript-sdk.result == 'failure'
+        run: |
+          echo "One or more SDK publish jobs failed. Check the job logs above."
+          exit 1

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -87,7 +87,10 @@ jobs:
           REDIS_URL: redis://localhost:6379
           JWT_SECRET: ci-jwt-secret-32-chars-long-placeholder
           SESSION_SECRET: ci-session-secret-placeholder
-          STELLAR_ISSUER_SECRET: SCZANGBA5YHTNYVVV3C7CAZMCLPVAR3LXKLHEADMPROMU3QAHZGOSN6A
+          # Dummy value — not a real key. Matches the pattern used across all
+          # other CI workflows. The server only needs this env var to start;
+          # no real Stellar transactions are submitted during spec generation.
+          STELLAR_ISSUER_SECRET: S-DUMMY-SECRET-KEY-FOR-TESTING-PURPOSES-ONLY
 
       - name: Wait for API to be ready
         run: npx wait-on http://127.0.0.1:3000/health --timeout 30000
@@ -198,7 +201,10 @@ jobs:
           REDIS_URL: redis://localhost:6379
           JWT_SECRET: ci-jwt-secret-32-chars-long-placeholder
           SESSION_SECRET: ci-session-secret-placeholder
-          STELLAR_ISSUER_SECRET: SCZANGBA5YHTNYVVV3C7CAZMCLPVAR3LXKLHEADMPROMU3QAHZGOSN6A
+          # Dummy value — not a real key. Matches the pattern used across all
+          # other CI workflows. The server only needs this env var to start;
+          # no real Stellar transactions are submitted during spec generation.
+          STELLAR_ISSUER_SECRET: S-DUMMY-SECRET-KEY-FOR-TESTING-PURPOSES-ONLY
 
       - name: Wait for API to be ready
         run: npx wait-on http://127.0.0.1:3000/health --timeout 30000

--- a/docs/SDK_PUBLISH.md
+++ b/docs/SDK_PUBLISH.md
@@ -1,0 +1,169 @@
+# SDK Automated Publish Workflow
+
+This document describes how the automated SDK publish pipeline works and how to configure the required secrets.
+
+## Overview
+
+When a GitHub Release is **published** (not just drafted), the workflow at `.github/workflows/sdk-publish.yml` runs automatically and publishes two SDK packages in parallel:
+
+| SDK | Registry | Package |
+|-----|----------|---------|
+| Kotlin/JVM | Maven Central (via Sonatype OSSRH) | `com.mobilemoney:mobile-money-sdk` |
+| TypeScript | npm registry | `mobile-money-sdk` |
+
+The version is derived directly from the release tag (e.g. `v1.2.3` → `1.2.3`).
+
+## Workflow Trigger
+
+```yaml
+on:
+  release:
+    types: [published]
+```
+
+Only the **published** event fires the workflow. Drafting or pre-releasing a release does **not** trigger it. This lets you prepare and review a release before committing to a publish.
+
+## Jobs
+
+```
+resolve-version
+    ├── publish-kotlin-sdk   (Maven Central)
+    └── publish-typescript-sdk  (npm)
+            └── publish-summary
+```
+
+### `resolve-version`
+Strips the leading `v` from the release tag and exposes the clean semver string as a job output used by both publish jobs.
+
+### `publish-kotlin-sdk`
+1. Checks out the repo and sets up JDK 17 + Node 20.
+2. Starts the API server and generates the Kotlin SDK from the live OpenAPI spec (falls back to `public/openapi.json` if the server is unavailable).
+3. Runs `./gradlew test` to verify the generated SDK compiles and passes tests.
+4. Publishes to Sonatype OSSRH staging, which automatically promotes to Maven Central.
+5. Uploads the built JARs as a workflow artifact (retained 30 days).
+
+### `publish-typescript-sdk`
+1. Sets up Node 20 with npm registry auth.
+2. Generates the TypeScript SDK from the OpenAPI spec.
+3. Runs `npm install && npm run build`.
+4. Publishes to npm with `--access public`.
+5. Uploads `dist/` as a workflow artifact (retained 30 days).
+
+### `publish-summary`
+Writes a Markdown summary table to the GitHub Actions job summary and fails the workflow if either publish job failed.
+
+## Required Secrets
+
+Configure these in **Settings → Secrets and variables → Actions** on the repository.
+
+### Maven Central (Kotlin SDK)
+
+| Secret | Description |
+|--------|-------------|
+| `SONATYPE_USERNAME` | Sonatype OSSRH username. Use a [user token](https://central.sonatype.org/publish/generate-token/) rather than your account password. |
+| `SONATYPE_PASSWORD` | Sonatype OSSRH password / token. |
+| `GPG_SIGNING_KEY` | ASCII-armored GPG private key. Export with: `gpg --armor --export-secret-keys <KEY_ID>` |
+| `GPG_SIGNING_PASSWORD` | Passphrase for the GPG key. |
+
+#### Generating a GPG key for signing
+
+```bash
+# Generate a new key (RSA 4096, no expiry for CI keys)
+gpg --full-generate-key
+
+# List keys to find the KEY_ID
+gpg --list-secret-keys --keyid-format LONG
+
+# Export the ASCII-armored private key
+gpg --armor --export-secret-keys <KEY_ID> | pbcopy   # macOS
+gpg --armor --export-secret-keys <KEY_ID> | xclip    # Linux
+
+# Upload the public key to a keyserver (required by Maven Central)
+gpg --keyserver keyserver.ubuntu.com --send-keys <KEY_ID>
+```
+
+Paste the output of `--export-secret-keys` as the value of `GPG_SIGNING_KEY`.
+
+#### Sonatype OSSRH setup
+
+1. Create an account at [https://issues.sonatype.org](https://issues.sonatype.org).
+2. Open a ticket to claim the `com.mobilemoney` namespace.
+3. Once approved, generate a **user token** at [https://s01.oss.sonatype.org](https://s01.oss.sonatype.org) → Profile → User Token.
+4. Use the token username/password as `SONATYPE_USERNAME` / `SONATYPE_PASSWORD`.
+
+### npm (TypeScript SDK)
+
+| Secret | Description |
+|--------|-------------|
+| `NPM_TOKEN` | npm automation token. Generate at [https://www.npmjs.com/settings/\<username\>/tokens](https://www.npmjs.com/settings). Choose **Automation** type. |
+
+## Optional: `sdk-publish` Environment
+
+The workflow references an optional GitHub Environment named `sdk-publish`. If you create this environment in **Settings → Environments**, you can:
+
+- Require manual approval before publishing.
+- Restrict which branches/tags can trigger the publish.
+- Add environment-specific secrets.
+
+If the environment does not exist, the jobs run without approval gates.
+
+## Graceful degradation
+
+If any required secret is missing, the corresponding publish step is **skipped** (not failed) and a warning is printed to the job log. The workflow still succeeds so that the release is not blocked. This allows the workflow to be merged before all secrets are configured.
+
+## Local testing
+
+To test SDK generation locally without publishing:
+
+```bash
+# Start the dev server
+npm run dev
+
+# Generate Kotlin SDK
+openapi-generator-cli generate \
+  -i http://localhost:3000/docs/openapi.json \
+  -c sdk-config.yaml \
+  -o sdk \
+  --additional-properties=artifactVersion=1.0.0-local
+
+# Build and test
+cd sdk && ./gradlew build
+
+# Generate TypeScript SDK
+openapi-generator-cli generate \
+  -i http://localhost:3000/docs/openapi.json \
+  -c sdk-config-ts.yaml \
+  -o sdk-ts \
+  --additional-properties=npmVersion=1.0.0-local
+
+# Build
+cd sdk-ts && npm install && npm run build
+```
+
+## Version strategy
+
+The SDK version is always derived from the GitHub release tag:
+
+| Release tag | Published version |
+|-------------|-------------------|
+| `v1.2.3`    | `1.2.3`           |
+| `v2.0.0`    | `2.0.0`           |
+| `v1.3.0-rc.1` | `1.3.0-rc.1`   |
+
+Snapshot versions (ending in `-SNAPSHOT`) are published to the Sonatype snapshots repository instead of staging.
+
+## Troubleshooting
+
+**Kotlin publish fails with "401 Unauthorized"**
+- Verify `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` are set and use a user token (not account credentials).
+
+**Kotlin publish fails with "Signature invalid"**
+- Ensure `GPG_SIGNING_KEY` contains the full ASCII-armored key including the `-----BEGIN PGP PRIVATE KEY BLOCK-----` header/footer.
+- Verify the public key has been uploaded to a keyserver.
+
+**npm publish fails with "403 Forbidden"**
+- Ensure `NPM_TOKEN` is an **Automation** token, not a read-only token.
+- Verify the package name `mobile-money-sdk` is not already claimed by another user/org on npm.
+
+**OpenAPI spec generation fails**
+- The workflow falls back to `public/openapi.json`. Ensure this file is kept up to date by running `npm run generate:openapi` before tagging a release.

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -1,10 +1,16 @@
+import org.gradle.api.publish.maven.MavenPublication
+
 plugins {
     kotlin("jvm") version "1.9.22"
     `maven-publish`
+    signing
+    `java-library`
 }
 
 group = "com.mobilemoney"
-version = "1.0.0"
+// Version is overridden at publish time via -Pversion=<tag> passed by CI.
+// The fallback here is used for local builds only.
+version = project.findProperty("version")?.toString()?.trimStart('v') ?: "1.0.0"
 
 repositories {
     mavenCentral()
@@ -21,4 +27,90 @@ dependencies {
 
 kotlin {
     jvmToolchain(17)
+}
+
+// ── Sources & Javadoc JARs (required by Maven Central) ──────────────────────
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+// ── Maven Central publishing ─────────────────────────────────────────────────
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenKotlin") {
+            from(components["java"])
+
+            groupId    = "com.mobilemoney"
+            artifactId = "mobile-money-sdk"
+            version    = project.version.toString()
+
+            pom {
+                name.set("Mobile Money SDK")
+                description.set("Kotlin/JVM client SDK for the Mobile Money ↔ Stellar Bridge API")
+                url.set("https://github.com/sublime247/mobile-money")
+
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://opensource.org/licenses/MIT")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("sublime247")
+                        name.set("Mobile Money Maintainers")
+                        email.set("maintainers@mobilemoney.dev")
+                    }
+                }
+
+                scm {
+                    connection.set("scm:git:git://github.com/sublime247/mobile-money.git")
+                    developerConnection.set("scm:git:ssh://github.com/sublime247/mobile-money.git")
+                    url.set("https://github.com/sublime247/mobile-money")
+                }
+            }
+        }
+    }
+
+    repositories {
+        // Sonatype OSSRH — publishes to Maven Central via the Central Portal.
+        // Credentials are injected by CI via ORG_GRADLE_PROJECT_* env vars.
+        maven {
+            name = "sonatype"
+            val isSnapshot = version.toString().endsWith("SNAPSHOT")
+            url = uri(
+                if (isSnapshot)
+                    "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+                else
+                    "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            )
+            credentials {
+                username = project.findProperty("sonatypeUsername") as String?
+                    ?: System.getenv("SONATYPE_USERNAME")
+                password = project.findProperty("sonatypePassword") as String?
+                    ?: System.getenv("SONATYPE_PASSWORD")
+            }
+        }
+    }
+}
+
+// ── GPG signing (required by Maven Central) ──────────────────────────────────
+// The signing key and passphrase are injected by CI via environment variables:
+//   ORG_GRADLE_PROJECT_signingKey        — ASCII-armored private key
+//   ORG_GRADLE_PROJECT_signingPassword   — passphrase
+
+signing {
+    val signingKey     = project.findProperty("signingKey")     as String?
+    val signingPassword = project.findProperty("signingPassword") as String?
+
+    if (!signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications["mavenKotlin"])
+    } else {
+        logger.warn("SDK: GPG signing credentials not found — artifacts will NOT be signed. Set signingKey and signingPassword for Maven Central publishing.")
+    }
 }


### PR DESCRIPTION
## Description
Adds a GitHub Actions workflow that automatically publishes both SDK packages when a GitHub Release is published.

## Changes applied
- .github/workflows/sdk-publish.yml
  - Triggers on release published event (not draft/pre-release)
  - resolve-version job strips leading 'v' from tag (v1.2.3 → 1.2.3)
  - publish-kotlin-sdk job: generates Kotlin SDK via openapi-generator, runs Gradle tests, publishes to Sonatype OSSRH → Maven Central with GPG signing; gracefully skips if secrets are not configured
  - publish-typescript-sdk job: generates TS SDK, builds, publishes to npm registry; gracefully skips if NPM_TOKEN is not configured
  - publish-summary job: writes Markdown summary table to Actions job summary and fails the workflow if either publish job failed
  - Concurrency group prevents parallel publish runs for the same ref
  - Both publish jobs upload built artifacts (retained 30 days)

- sdk/build.gradle.kts
  - Added signing and java-library plugins
  - Added withSourcesJar() and withJavadocJar() (required by Maven Central)
  - Added full MavenPublication block with POM metadata (name, description, url, license, developer, SCM) as required by Maven Central
  - Added Sonatype OSSRH repository with snapshot/staging URL switching
  - Added in-memory GPG signing via signingKey/signingPassword project properties injected by CI; warns and skips signing if not present
  - Version resolved from -Pversion= CI flag; falls back to 1.0.0 locally

- docs/SDK_PUBLISH.md
  - Full setup guide: required secrets, GPG key generation, Sonatype OSSRH account setup, npm token creation
  - Explains optional sdk-publish environment for manual approval gates
  - Documents graceful degradation behaviour
  - Local testing instructions
  - Version strategy table
  - Troubleshooting section for common publish failures


Closes #1001

