### PR TITLE
feat(workers): add esbuild bundle optimization for well-known-cache worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ benchmarks/results/*.json
 .cache/
 
 secret.yaml
+
+# Worker build output
+workers/well-known-cache/dist/
+workers/well-known-cache/node_modules/

--- a/workers/well-known-cache/build.mjs
+++ b/workers/well-known-cache/build.mjs
@@ -1,0 +1,21 @@
+import { build } from 'esbuild';
+
+await build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  minify: true,
+  target: 'es2022',
+  format: 'esm',
+  outfile: 'dist/index.js',
+  // Tree-shake unused exports
+  treeShaking: true,
+  // Remove console.log in production (keep warn/error)
+  pure: ['console.log', 'console.debug', 'console.info'],
+  // Analyze bundle size
+  metafile: true,
+}).then((result) => {
+  const text = Object.entries(result.metafile.outputs)
+    .map(([file, info]) => `${file}: ${(info.bytes / 1024).toFixed(1)} KB`)
+    .join('\n');
+  console.log('Bundle sizes:\n' + text);
+});

--- a/workers/well-known-cache/package.json
+++ b/workers/well-known-cache/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "well-known-cache-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs",
+    "deploy": "npm run build && wrangler deploy --outdir dist",
+    "dev": "wrangler dev"
+  },
+  "devDependencies": {
+    "esbuild": "^0.21.0",
+    "@cloudflare/workers-types": "^4.20240925.0",
+    "wrangler": "^3.78.0"
+  }
+}


### PR DESCRIPTION
## Summary
Adds esbuild-based build optimization for the Cloudflare Worker to reduce bundle size and improve cold start times.

## Changes
- **build.mjs** — esbuild configuration with:
  - minify: true — whitespace, identifier, and syntax minification
  - treeShaking: true — eliminate dead code
  - target: es2022 — modern JS for Workers runtime (smaller than ES2017 default)
  - pure annotations for console.log/debug/info — strip debug logs in production
  - Bundle size reporting via metafile
- **package.json** — worker-specific scripts:
  - npm run build — runs esbuild optimization
  - npm run deploy — builds then deploys with wrangler deploy --outdir dist
  - npm run dev — local development with wrangler dev
- **.gitignore** — excludes dist/ and node_modules/ in worker directory

## Testing
```
cd workers/well-known-cache
npm install
npm run build
```
Check bundle size output in terminal.

Fixes #1048