### PR TITLE
feat: add Vodacom and Tigo Tanzania phone number validation (Fixes #1039)

### DIFF
--- a/src/utils/__tests__/phoneUtils.test.ts
+++ b/src/utils/__tests__/phoneUtils.test.ts
@@ -1,4 +1,4 @@
-import { formatPhoneForProvider } from "../phoneUtils";
+import { formatPhoneForProvider, validatePhoneProviderMatch } from "../phoneUtils";
 
 describe("formatPhoneForProvider", () => {
   it("normalizes Airtel Cameroon numbers to national format", () => {
@@ -9,5 +9,38 @@ describe("formatPhoneForProvider", () => {
 
   it("keeps E.164 format for other providers", () => {
     expect(formatPhoneForProvider("+237670000000", "mtn")).toBe("+237670000000");
+  });
+});
+
+describe("Tanzania provider validation", () => {
+  it("validates Vodacom Tanzania prefixes (74x, 75x, 76x)", () => {
+    expect(validatePhoneProviderMatch("+255740123456", "vodacom").valid).toBe(true);
+    expect(validatePhoneProviderMatch("+255750999888", "vodacom").valid).toBe(true);
+    expect(validatePhoneProviderMatch("+255760111222", "vodacom").valid).toBe(true);
+    expect(validatePhoneProviderMatch("255740123456", "vodacom").valid).toBe(true);
+    // Invalid: Tigo number rejected on Vodacom
+    expect(validatePhoneProviderMatch("+255650123456", "vodacom").valid).toBe(false);
+    expect(validatePhoneProviderMatch("+255690123456", "vodacom").valid).toBe(false);
+    // Invalid: non-Tanzania prefix
+    expect(validatePhoneProviderMatch("+256770123456", "vodacom").valid).toBe(false);
+  });
+
+  it("validates Tigo Tanzania prefixes (65x-69x)", () => {
+    expect(validatePhoneProviderMatch("+255650123456", "tigo").valid).toBe(true);
+    expect(validatePhoneProviderMatch("+255660123456", "tigo").valid).toBe(true);
+    expect(validatePhoneProviderMatch("+255670123456", "tigo").valid).toBe(true);
+    expect(validatePhoneProviderMatch("+255680123456", "tigo").valid).toBe(true);
+    expect(validatePhoneProviderMatch("+255690123456", "tigo").valid).toBe(true);
+    // Invalid: Vodacom number rejected on Tigo
+    expect(validatePhoneProviderMatch("+255740123456", "tigo").valid).toBe(false);
+  });
+
+  it("formats Vodacom Tanzania numbers in E.164", () => {
+    expect(formatPhoneForProvider("+255740123456", "vodacom")).toBe("+255740123456");
+    expect(formatPhoneForProvider("255740123456", "vodacom")).toBe("+255740123456");
+  });
+
+  it("formats Tigo Tanzania numbers in E.164", () => {
+    expect(formatPhoneForProvider("+255650123456", "tigo")).toBe("+255650123456");
   });
 });

--- a/src/utils/phoneUtils.ts
+++ b/src/utils/phoneUtils.ts
@@ -1,6 +1,6 @@
 import { parsePhoneNumberFromString, type CountryCode } from "libphonenumber-js";
 
-export type MobileProvider = "mtn" | "airtel" | "orange";
+export type MobileProvider = "mtn" | "airtel" | "orange" | "vodacom" | "tigo";
 type PhoneOutputFormat = "e164" | "national";
 
 interface ProviderPhoneFormatConfig {
@@ -16,6 +16,10 @@ const PROVIDER_PREFIXES: Record<MobileProvider, string[]> = {
   mtn: ["23767", "23768", "25677", "25678", "23324", "23354", "23355", "23359"],
   airtel: ["23766", "25670", "25675", "23326", "23356", "23357"],
   orange: ["23765", "23769", "22507", "22177"],
+  // Tanzania — Vodacom: +255 74x, 75x, 76x
+  vodacom: ["25574", "25575", "25576"],
+  // Tanzania — Tigo: +255 65x, 66x, 67x, 68x, 69x
+  tigo: ["25565", "25566", "25567", "25568", "25569"],
 };
 
 const PROVIDER_PHONE_FORMATS: Record<MobileProvider, ProviderPhoneFormatConfig> = {
@@ -29,6 +33,14 @@ const PROVIDER_PHONE_FORMATS: Record<MobileProvider, ProviderPhoneFormatConfig> 
   },
   orange: {
     defaultRegion: "CM",
+    output: "e164",
+  },
+  vodacom: {
+    defaultRegion: "TZ",
+    output: "e164",
+  },
+  tigo: {
+    defaultRegion: "TZ",
     output: "e164",
   },
 };


### PR DESCRIPTION
## Summary
Adds phone number validation for Vodacom and Tigo mobile money providers in Tanzania.

## Changes
- **phoneUtils.ts**: Extended MobileProvider type with vodacom and tigo
  - Vodacom TZ prefixes: +255 74x, 75x, 76x
  - Tigo TZ prefixes: +255 65x, 66x, 67x, 68x, 69x
  - Added TZ (Tanzania) region config for libphonenumber-js
- **phoneUtils.test.ts**: Added test suite for Tanzania provider validation
  - Prefix matching (valid and invalid numbers)
  - E.164 formatting for both providers
  - Cross-provider rejection (Tigo number rejected on Vodacom and vice versa)

## Technical Details
- Uses 5-digit E.164 prefix matching (e.g., "25574" for +255 74x)
- Integrates with existing libphonenumber-js parsing via parseFlexiblePhoneNumber
- Follows existing PROVIDER_PREFIXES and PROVIDER_PHONE_FORMATS patterns

Fixes #1039