### PR TITLE
feat: integrate Stellar network management with Horizon node rotation…

### DIFF
--- a/.env.config.example
+++ b/.env.config.example
@@ -51,6 +51,8 @@ ENABLE_SLOW_QUERY_LOGGING=false
 # ===== STELLAR CONFIGURATION =====
 # Stellar network configuration
 STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+# Single URL or comma-separated list (primary first, then fallbacks) for
+# automatic Horizon node rotation/failover.
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
 # ===== THIRD-PARTY INTEGRATIONS =====

--- a/.env.example
+++ b/.env.example
@@ -114,7 +114,15 @@ SENDGRID_LOCKOUT_TEMPLATE_ID=
 # Stellar Network
 # ---------------------------------------------------------------------------
 STELLAR_NETWORK=testnet
+# Horizon endpoint(s). Accepts a single URL or a comma-separated list of URLs
+# (primary first, then fallbacks). Requests automatically fail over to the next
+# node when the active one is down or rate-limiting us.
+# Example: https://horizon-testnet.stellar.org,https://horizon-testnet.stellar.example.com
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+# Consecutive failures before a Horizon node is taken out of rotation.
+HORIZON_MAX_CONSECUTIVE_FAILURES=3
+# How long (ms) a node stays out of rotation after being marked down.
+HORIZON_COOLDOWN_MS=30000
 STELLAR_ISSUER_SECRET=YOUR_STELLAR_SECRET_KEY
 STELLAR_RECEIVING_ACCOUNT=GABC... # Anchor's receiving account for SEP-31
 STELLAR_ASSET_CODE=USDC

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -57,7 +57,7 @@ export const env = cleanEnv(process.env, {
   }),
   STELLAR_HORIZON_URL: str({
     default: "https://horizon-testnet.stellar.org",
-    desc: "Stellar Horizon server URL",
+    desc: "Stellar Horizon server URL, or a comma-separated list of URLs (primary first, then fallbacks) for automatic node rotation/failover",
   }),
   STELLAR_NETWORK: str({
     default: "testnet",

--- a/src/config/stellar.ts
+++ b/src/config/stellar.ts
@@ -1,4 +1,5 @@
 import * as StellarSdk from "stellar-sdk";
+import { HorizonPool } from "../stellar/horizonPool";
 
 export const STELLAR_NETWORKS = {
   TESTNET: "testnet",
@@ -57,11 +58,50 @@ export const logStellarNetwork = () => {
   }
 };
 
-export const getStellarServer = () => {
+/**
+ * Resolve the ordered list of Horizon URLs for the active network.
+ *
+ * `STELLAR_HORIZON_URL` may be a single URL or a comma-separated list of URLs
+ * (primary first, then fallbacks). When unset we fall back to the public
+ * Horizon endpoint for the configured network.
+ */
+export const getHorizonUrls = (): string[] => {
   const network = (process.env.STELLAR_NETWORK ||
     STELLAR_NETWORKS.TESTNET) as StellarNetwork;
-  const horizonUrl = HORIZON_URLS[network];
-  return new StellarSdk.Horizon.Server(horizonUrl);
+
+  const configured = process.env.STELLAR_HORIZON_URL;
+  const urls = (configured ?? HORIZON_URLS[network])
+    .split(",")
+    .map((u) => u.trim())
+    .filter((u) => u.length > 0);
+
+  // Guard against a misconfigured value (e.g. trailing comma / all blanks).
+  return urls.length > 0 ? urls : [HORIZON_URLS[network]];
+};
+
+// Lazily-built pool, keyed by the resolved URL list so a changed
+// configuration (mainly in tests) rebuilds the pool.
+let horizonPool: HorizonPool | null = null;
+let horizonPoolKey: string | null = null;
+
+const getHorizonPool = (): HorizonPool => {
+  const urls = getHorizonUrls();
+  const key = urls.join(",");
+  if (!horizonPool || horizonPoolKey !== key) {
+    horizonPool = new HorizonPool(urls);
+    horizonPoolKey = key;
+  }
+  return horizonPool;
+};
+
+/**
+ * Returns a Horizon server backed by the rotation pool. The returned object is
+ * API-compatible with `StellarSdk.Horizon.Server` but transparently retries
+ * failed requests on alternative nodes when the active node is down or
+ * rate-limiting us.
+ */
+export const getStellarServer = (): StellarSdk.Horizon.Server => {
+  return getHorizonPool().getProxiedServer();
 };
 
 export const getNetworkPassphrase = () => {

--- a/src/routes/stellar.ts
+++ b/src/routes/stellar.ts
@@ -1,7 +1,8 @@
 import { Router, Request, Response } from "express";
 import { sep24RateLimiter as stellarRateLimiter } from "../middleware/rateLimit";
 import NodeCache from "node-cache";
-import { StrKey, Horizon } from "stellar-sdk";
+import { StrKey } from "stellar-sdk";
+import { getStellarServer } from "../config/stellar";
 
 const router = Router();
 
@@ -11,10 +12,8 @@ const cache = new NodeCache({ stdTTL: 300 });
 // Rate limiter (per IP)
 const limiter = stellarRateLimiter;
 
-// Horizon server
-const server = new Horizon.Server(
-  process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org",
-);
+// Horizon server (pooled — automatic round-robin failover across nodes)
+const server = getStellarServer();
 
 router.get(
   "/balance/:address",

--- a/src/services/stellarExporter.ts
+++ b/src/services/stellarExporter.ts
@@ -1,9 +1,8 @@
 import { Gauge, register } from 'prom-client';
-import * as StellarSdk from 'stellar-sdk';
+import { getStellarServer } from '../config/stellar';
 
-// Use environment variables for network routing to support dev/prod parity
-const HORIZON_URL = process.env.STELLAR_HORIZON_URL || 'https://horizon.stellar.org';
-const server = new StellarSdk.Horizon.Server(HORIZON_URL);
+// Pooled server with automatic round-robin failover across Horizon nodes.
+const server = getStellarServer();
 const HOT_WALLET_PUBLIC_KEY = process.env.STELLAR_HOT_WALLET_PUBLIC_KEY;
 
 // 1. Define the Prometheus Gauge

--- a/src/stellar/__tests__/horizonPool.test.ts
+++ b/src/stellar/__tests__/horizonPool.test.ts
@@ -1,0 +1,221 @@
+// Silence structured logging during tests.
+jest.mock("../../utils/logger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// Mock the metrics so we can assert on them. Factories are hoisted above
+// imports, so the jest.fn()s must be created inside the factory and read back
+// via the (mocked) module import below.
+jest.mock("../../utils/metrics", () => ({
+  horizonNodeFailuresTotal: { inc: jest.fn(), set: jest.fn() },
+  horizonNodeHealth: { inc: jest.fn(), set: jest.fn() },
+  horizonRequestFailoverTotal: { inc: jest.fn(), set: jest.fn() },
+}));
+
+// Replace the real Horizon.Server with controllable fakes keyed by URL.
+jest.mock("stellar-sdk", () => {
+  const actual = jest.requireActual("stellar-sdk");
+  return {
+    ...actual,
+    Horizon: { ...actual.Horizon, Server: jest.fn() },
+  };
+});
+
+import * as StellarSdk from "stellar-sdk";
+import { HorizonPool, isFailoverEligible } from "../horizonPool";
+import {
+  horizonNodeFailuresTotal,
+  horizonNodeHealth,
+  horizonRequestFailoverTotal,
+} from "../../utils/metrics";
+
+interface FakeServer {
+  url: string;
+  loadAccount: jest.Mock;
+  transactions: jest.Mock;
+}
+
+const servers: Record<string, FakeServer> = {};
+
+function makeFakeServer(url: string): FakeServer {
+  return {
+    url,
+    loadAccount: jest.fn(),
+    transactions: jest.fn(),
+  };
+}
+
+/** A failover-eligible error (HTTP 503). */
+function serverError(): Error {
+  return Object.assign(new Error("service unavailable"), {
+    response: { status: 503 },
+  });
+}
+
+/** A non-failover error (HTTP 404). */
+function notFound(): Error {
+  return Object.assign(new Error("not found"), {
+    name: "NotFoundError",
+    response: { status: 404 },
+  });
+}
+
+const URLS = ["https://a.example", "https://b.example", "https://c.example"];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  for (const url of URLS) {
+    servers[url] = makeFakeServer(url);
+  }
+  (StellarSdk.Horizon.Server as unknown as jest.Mock).mockImplementation(
+    (url: string) => servers[url],
+  );
+});
+
+describe("isFailoverEligible", () => {
+  it("retries on 429, 5xx and network errors", () => {
+    expect(isFailoverEligible({ response: { status: 429 } })).toBe(true);
+    expect(isFailoverEligible({ response: { status: 503 } })).toBe(true);
+    expect(isFailoverEligible({ code: "ECONNREFUSED" })).toBe(true);
+    expect(isFailoverEligible({ name: "NetworkError" })).toBe(true);
+  });
+
+  it("does not retry on deterministic 4xx errors", () => {
+    expect(isFailoverEligible({ response: { status: 400 } })).toBe(false);
+    expect(isFailoverEligible({ response: { status: 404 } })).toBe(false);
+    expect(isFailoverEligible(null)).toBe(false);
+  });
+});
+
+describe("HorizonPool", () => {
+  it("rotates round-robin across healthy nodes on success", async () => {
+    const pool = new HorizonPool(URLS);
+    servers[URLS[0]].loadAccount.mockResolvedValue("acct");
+    servers[URLS[1]].loadAccount.mockResolvedValue("acct");
+    servers[URLS[2]].loadAccount.mockResolvedValue("acct");
+
+    const proxy = pool.getProxiedServer();
+    await proxy.loadAccount("G1");
+    await proxy.loadAccount("G2");
+    await proxy.loadAccount("G3");
+
+    expect(servers[URLS[0]].loadAccount).toHaveBeenCalledTimes(1);
+    expect(servers[URLS[1]].loadAccount).toHaveBeenCalledTimes(1);
+    expect(servers[URLS[2]].loadAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails over to an alternative node on a 5xx error", async () => {
+    const pool = new HorizonPool(URLS);
+    servers[URLS[0]].loadAccount.mockRejectedValue(serverError());
+    servers[URLS[1]].loadAccount.mockResolvedValue("ok");
+
+    const result = await pool.getProxiedServer().loadAccount("G1");
+
+    expect(result).toBe("ok");
+    expect(servers[URLS[0]].loadAccount).toHaveBeenCalledTimes(1);
+    expect(servers[URLS[1]].loadAccount).toHaveBeenCalledTimes(1);
+    expect(horizonNodeFailuresTotal.inc).toHaveBeenCalledWith({
+      node: URLS[0],
+      error_type: "server_error",
+    });
+    expect(horizonRequestFailoverTotal.inc).toHaveBeenCalledWith({
+      from_node: URLS[0],
+      to_node: URLS[1],
+      operation: "loadAccount",
+    });
+  });
+
+  it("does not fail over on a deterministic 4xx error", async () => {
+    const pool = new HorizonPool(URLS);
+    servers[URLS[0]].loadAccount.mockRejectedValue(notFound());
+
+    await expect(pool.getProxiedServer().loadAccount("G1")).rejects.toThrow(
+      "not found",
+    );
+    expect(servers[URLS[1]].loadAccount).not.toHaveBeenCalled();
+    expect(horizonRequestFailoverTotal.inc).not.toHaveBeenCalled();
+  });
+
+  it("removes a node from rotation after repeated failures and recovers it", async () => {
+    const pool = new HorizonPool(URLS, {
+      maxConsecutiveFailures: 2,
+      cooldownMs: 10_000,
+    });
+    // Node A always fails; B succeeds.
+    servers[URLS[0]].loadAccount.mockRejectedValue(serverError());
+    servers[URLS[1]].loadAccount.mockResolvedValue("ok");
+    servers[URLS[2]].loadAccount.mockResolvedValue("ok");
+
+    const proxy = pool.getProxiedServer();
+    await proxy.loadAccount("G1"); // hits A (fail) -> B
+    // Cursor now at C; advance back to A by exhausting rotation.
+    await proxy.loadAccount("G2"); // C
+    await proxy.loadAccount("G3"); // A (fail, 2nd) -> disabled -> B
+
+    expect(horizonNodeHealth.set).toHaveBeenCalledWith({ node: URLS[0] }, 0);
+
+    // A is in cooldown now: a subsequent call must skip it entirely.
+    servers[URLS[0]].loadAccount.mockClear();
+    servers[URLS[1]].loadAccount.mockClear();
+    await proxy.loadAccount("G4");
+    expect(servers[URLS[0]].loadAccount).not.toHaveBeenCalled();
+  });
+
+  it("transparently fails over builder chains (transactions().call())", async () => {
+    const pool = new HorizonPool(URLS);
+
+    // Node A's builder chain throws at call(); node B's resolves.
+    const makeChain = (result: unknown, err?: Error) => {
+      const builder: any = {};
+      builder.forAccount = jest.fn(() => builder);
+      builder.limit = jest.fn(() => builder);
+      builder.order = jest.fn(() => builder);
+      builder.call = jest.fn(() =>
+        err ? Promise.reject(err) : Promise.resolve(result),
+      );
+      return builder;
+    };
+    servers[URLS[0]].transactions.mockReturnValue(
+      makeChain(undefined, serverError()),
+    );
+    servers[URLS[1]].transactions.mockReturnValue(
+      makeChain({ records: [] }),
+    );
+
+    const proxy = pool.getProxiedServer();
+    const res = await proxy
+      .transactions()
+      .forAccount("G1")
+      .limit(10)
+      .order("desc")
+      .call();
+
+    expect(res).toEqual({ records: [] });
+    expect(servers[URLS[0]].transactions).toHaveBeenCalledTimes(1);
+    expect(servers[URLS[1]].transactions).toHaveBeenCalledTimes(1);
+    expect(horizonRequestFailoverTotal.inc).toHaveBeenCalledWith({
+      from_node: URLS[0],
+      to_node: URLS[1],
+      operation: "transactions.call",
+    });
+  });
+
+  it("throws the last error when every node fails", async () => {
+    const pool = new HorizonPool(URLS);
+    for (const url of URLS) {
+      servers[url].loadAccount.mockRejectedValue(serverError());
+    }
+    await expect(pool.getProxiedServer().loadAccount("G1")).rejects.toThrow(
+      "service unavailable",
+    );
+    // Every node was attempted.
+    for (const url of URLS) {
+      expect(servers[url].loadAccount).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("requires at least one URL", () => {
+    expect(() => new HorizonPool([])).toThrow(/at least one/i);
+  });
+});

--- a/src/stellar/horizonPool.ts
+++ b/src/stellar/horizonPool.ts
@@ -1,0 +1,377 @@
+import * as StellarSdk from "stellar-sdk";
+import logger from "../utils/logger";
+import {
+  horizonNodeFailuresTotal,
+  horizonNodeHealth,
+  horizonRequestFailoverTotal,
+} from "../utils/metrics";
+
+/**
+ * Horizon client rotation & automated failover.
+ *
+ * The Stellar integration historically depended on a single Horizon URL. If
+ * that node went down or rate-limited us, every Stellar operation failed. This
+ * module manages a *pool* of Horizon servers and rotates between them
+ * round-robin, automatically retrying a failed request on an alternative node.
+ *
+ * Failover is transparent: `getPooledServer()` returns a Proxy that quacks like
+ * a `StellarSdk.Horizon.Server`. Direct calls (`loadAccount`, `submitTransaction`,
+ * …) and builder chains (`server.transactions().forAccount(id).call()`) are
+ * recorded and replayed against the next healthy node when the active one fails,
+ * so existing call sites get failover without any code changes.
+ */
+
+// Server methods that perform network I/O directly and should be retried.
+const DIRECT_METHODS = new Set<string>([
+  "loadAccount",
+  "submitTransaction",
+  "submitAsyncTransaction",
+  "fetchBaseFee",
+  "fetchTimebounds",
+  "feeStats",
+  "root",
+]);
+
+// Server methods that return a CallBuilder. The returned builder is wrapped so
+// the whole chain can be replayed on an alternative node when `.call()` fails.
+const BUILDER_METHODS = new Set<string>([
+  "accounts",
+  "transactions",
+  "operations",
+  "payments",
+  "effects",
+  "ledgers",
+  "offers",
+  "orderbook",
+  "trades",
+  "assets",
+  "claimableBalances",
+  "liquidityPools",
+  "tradeAggregation",
+  "strictReceivePaths",
+  "strictSendPaths",
+  "paths",
+]);
+
+interface HorizonNode {
+  url: string;
+  server: StellarSdk.Horizon.Server;
+  consecutiveFailures: number;
+  /** Epoch ms before which the node is considered down (cooldown). */
+  downUntil: number;
+}
+
+export interface HorizonPoolConfig {
+  /** Consecutive failover-eligible failures before a node is taken out of rotation. */
+  maxConsecutiveFailures: number;
+  /** How long (ms) a node stays out of rotation after being marked down. */
+  cooldownMs: number;
+}
+
+const DEFAULT_CONFIG: HorizonPoolConfig = {
+  maxConsecutiveFailures: parseInt(
+    process.env.HORIZON_MAX_CONSECUTIVE_FAILURES || "3",
+    10,
+  ),
+  cooldownMs: parseInt(process.env.HORIZON_COOLDOWN_MS || "30000", 10),
+};
+
+/**
+ * Decide whether an error means "this node is unhealthy, try another" rather
+ * than "this request is bad, retrying won't help".
+ *
+ * Failover-eligible: network/connection errors, timeouts, HTTP 429 (rate
+ * limited) and 5xx (server errors). NOT eligible: 4xx like 400/404 (e.g.
+ * tx_failed, account not found) which are deterministic across nodes.
+ */
+export function isFailoverEligible(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const err = error as {
+    response?: { status?: number };
+    code?: string;
+    name?: string;
+    message?: string;
+  };
+
+  const status = err.response?.status;
+  if (typeof status === "number") {
+    if (status === 429) return true;
+    if (status >= 500) return true;
+    // Any other HTTP response (4xx) is a deterministic client error.
+    return false;
+  }
+
+  // No HTTP response → network-level failure (connection refused, reset,
+  // DNS, timeout, etc.). These are exactly the cases another node may serve.
+  const code = err.code ?? "";
+  if (
+    [
+      "ECONNREFUSED",
+      "ECONNRESET",
+      "ETIMEDOUT",
+      "ENOTFOUND",
+      "EAI_AGAIN",
+      "EPIPE",
+      "ECONNABORTED",
+    ].includes(code)
+  ) {
+    return true;
+  }
+
+  const name = err.name ?? "";
+  const message = err.message ?? "";
+  // stellar-sdk throws NetworkError when no response was received.
+  if (name === "NetworkError") return true;
+  if (/timeout|network|socket hang up/i.test(message)) return true;
+
+  return false;
+}
+
+export class HorizonPool {
+  private readonly nodes: HorizonNode[];
+  private readonly config: HorizonPoolConfig;
+  private cursor = 0;
+  /** Cached transparent-failover proxy. */
+  private proxy: StellarSdk.Horizon.Server | null = null;
+
+  constructor(urls: string[], config: Partial<HorizonPoolConfig> = {}) {
+    if (urls.length === 0) {
+      throw new Error("HorizonPool requires at least one Horizon URL");
+    }
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.nodes = urls.map((url) => ({
+      url,
+      server: new StellarSdk.Horizon.Server(url),
+      consecutiveFailures: 0,
+      downUntil: 0,
+    }));
+    // Initialise health gauge so all nodes are visible in Prometheus.
+    for (const node of this.nodes) {
+      horizonNodeHealth.set({ node: node.url }, 1);
+    }
+  }
+
+  /** URLs in the pool, in configured order. */
+  get urls(): string[] {
+    return this.nodes.map((n) => n.url);
+  }
+
+  /**
+   * Build the ordered list of nodes to try for one request: healthy nodes
+   * first (round-robin starting at the cursor), then any down nodes as a
+   * last resort so the pool degrades gracefully instead of failing hard when
+   * every node is in cooldown (half-open probing).
+   */
+  private candidateOrder(): HorizonNode[] {
+    const now = Date.now();
+    const rotated: HorizonNode[] = [];
+    for (let i = 0; i < this.nodes.length; i++) {
+      rotated.push(this.nodes[(this.cursor + i) % this.nodes.length]);
+    }
+    const healthy = rotated.filter((n) => n.downUntil <= now);
+    const down = rotated.filter((n) => n.downUntil > now);
+    return healthy.length > 0 ? [...healthy, ...down] : rotated;
+  }
+
+  private markSuccess(node: HorizonNode): void {
+    if (node.consecutiveFailures > 0 || node.downUntil > 0) {
+      logger.info(
+        { horizon_node: node.url },
+        "Horizon node recovered, back in rotation",
+      );
+    }
+    node.consecutiveFailures = 0;
+    node.downUntil = 0;
+    horizonNodeHealth.set({ node: node.url }, 1);
+  }
+
+  private markFailure(
+    node: HorizonNode,
+    operation: string,
+    error: unknown,
+  ): void {
+    node.consecutiveFailures += 1;
+    const errorType = classifyError(error);
+    horizonNodeFailuresTotal.inc({ node: node.url, error_type: errorType });
+
+    const willDisable =
+      node.consecutiveFailures >= this.config.maxConsecutiveFailures;
+    if (willDisable) {
+      node.downUntil = Date.now() + this.config.cooldownMs;
+      horizonNodeHealth.set({ node: node.url }, 0);
+    }
+
+    logger.warn(
+      {
+        horizon_node: node.url,
+        operation,
+        error_type: errorType,
+        consecutive_failures: node.consecutiveFailures,
+        disabled: willDisable,
+        cooldown_ms: willDisable ? this.config.cooldownMs : undefined,
+        err: error instanceof Error ? error.message : String(error),
+      },
+      willDisable
+        ? "Horizon node failed and was removed from rotation"
+        : "Horizon node request failed",
+    );
+  }
+
+  /**
+   * Run `fn` against pool nodes, retrying on an alternative node when the
+   * active one fails with a failover-eligible error. Resolves with the first
+   * success; rejects with the last error if every node is exhausted (or
+   * immediately on a non-failover error).
+   */
+  async execute<T>(
+    fn: (server: StellarSdk.Horizon.Server) => Promise<T>,
+    operation = "request",
+  ): Promise<T> {
+    const candidates = this.candidateOrder();
+    let lastError: unknown;
+
+    for (let i = 0; i < candidates.length; i++) {
+      const node = candidates[i];
+      try {
+        const result = await fn(node.server);
+        this.markSuccess(node);
+        // Advance the round-robin cursor past the node that served the request.
+        this.cursor = (this.nodes.indexOf(node) + 1) % this.nodes.length;
+        return result;
+      } catch (error) {
+        lastError = error;
+        if (!isFailoverEligible(error)) {
+          // Deterministic error (bad request, not found, …) — another node
+          // would return the same thing. Don't penalise the node, just throw.
+          throw error;
+        }
+        this.markFailure(node, operation, error);
+        const next = candidates[i + 1];
+        if (next) {
+          horizonRequestFailoverTotal.inc({
+            from_node: node.url,
+            to_node: next.url,
+            operation,
+          });
+          logger.warn(
+            {
+              operation,
+              from_node: node.url,
+              to_node: next.url,
+            },
+            "Retrying Horizon request on alternative node",
+          );
+        }
+      }
+    }
+
+    logger.error(
+      { operation, nodes: this.urls.length },
+      "All Horizon nodes failed for request",
+    );
+    throw lastError;
+  }
+
+  /** The currently-preferred underlying server (for streaming / passthrough). */
+  getActiveServer(): StellarSdk.Horizon.Server {
+    return this.candidateOrder()[0].server;
+  }
+
+  /**
+   * A `StellarSdk.Horizon.Server`-compatible Proxy that transparently routes
+   * network operations through {@link execute}. Returned object is cached.
+   */
+  getProxiedServer(): StellarSdk.Horizon.Server {
+    if (!this.proxy) {
+      this.proxy = this.buildServerProxy();
+    }
+    return this.proxy;
+  }
+
+  private buildServerProxy(): StellarSdk.Horizon.Server {
+    const pool = this;
+    const target = this.getActiveServer();
+
+    return new Proxy(target, {
+      get(_t, prop: string | symbol) {
+        if (typeof prop !== "string") {
+          return Reflect.get(pool.getActiveServer(), prop);
+        }
+
+        if (DIRECT_METHODS.has(prop)) {
+          return (...args: unknown[]) =>
+            pool.execute(
+              (server) => (server as any)[prop](...args),
+              prop,
+            );
+        }
+
+        if (BUILDER_METHODS.has(prop)) {
+          return (...args: unknown[]) =>
+            pool.buildBuilderProxy([{ method: prop, args }]);
+        }
+
+        // Anything else (properties, helpers like serverURL) → delegate to the
+        // active server. These don't perform retriable network I/O.
+        const active = pool.getActiveServer() as any;
+        const value = active[prop];
+        return typeof value === "function" ? value.bind(active) : value;
+      },
+    });
+  }
+
+  /**
+   * Wrap a CallBuilder chain so configuration calls are recorded and `.call()`
+   * is replayed against an alternative node on failure. `.stream()` is built on
+   * the active server (long-lived streams aren't retried).
+   */
+  private buildBuilderProxy(chain: Array<{ method: string; args: unknown[] }>): any {
+    const pool = this;
+
+    const replay = (server: StellarSdk.Horizon.Server) => {
+      let builder: any = (server as any)[chain[0].method](...chain[0].args);
+      for (let i = 1; i < chain.length; i++) {
+        builder = builder[chain[i].method](...chain[i].args);
+      }
+      return builder;
+    };
+
+    const operation = `${chain[0].method}.call`;
+
+    return new Proxy(function () {}, {
+      get(_t, prop: string | symbol) {
+        if (prop === "call") {
+          return (...args: unknown[]) =>
+            pool.execute((server) => replay(server).call(...args), operation);
+        }
+        if (prop === "stream") {
+          return (...args: unknown[]) =>
+            replay(pool.getActiveServer()).stream(...args);
+        }
+        if (typeof prop !== "string") {
+          return undefined;
+        }
+        // Chainable config method (limit, order, cursor, forAccount, …): record
+        // it and return a new recording builder.
+        return (...args: unknown[]) =>
+          pool.buildBuilderProxy([...chain, { method: prop, args }]);
+      },
+    });
+  }
+}
+
+function classifyError(error: unknown): string {
+  if (!error || typeof error !== "object") return "unknown";
+  const err = error as {
+    response?: { status?: number };
+    code?: string;
+    name?: string;
+  };
+  const status = err.response?.status;
+  if (status === 429) return "rate_limited";
+  if (typeof status === "number" && status >= 500) return "server_error";
+  if (err.code) return err.code.toLowerCase();
+  if (err.name === "NetworkError") return "network_error";
+  return "network_error";
+}

--- a/src/stellar/sep24.ts
+++ b/src/stellar/sep24.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import { sep24RateLimiter } from "../middleware/rateLimit";
 import { v4 as uuidv4 } from "uuid";
 import { Transaction, Keypair, StrKey } from "stellar-sdk";
-import { getStellarServer, getNetworkPassphrase, STELLAR_NETWORKS } from "../config/stellar";
+import { getStellarServer, getNetworkPassphrase, getHorizonUrls, STELLAR_NETWORKS } from "../config/stellar";
 import { enqueueSepWebhook } from "../services/stellar/webhooks";
 
 
@@ -130,7 +130,7 @@ export const getSep24Config = () => ({
       sep6_enabled: true,
       deposits_enabled: true,
       withdrawals_enabled: true,
-      transfer_server: process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org",
+      transfer_server: getHorizonUrls()[0],
       sep24_enabled: true,
       min_amount: 1,
       max_amount: 1000000,

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -88,6 +88,28 @@ export const providerCircuitBreakerState = new Gauge({
   registers: [register],
 });
 
+// Horizon node rotation / failover metrics
+export const horizonNodeFailuresTotal = new Counter({
+  name: "horizon_node_failures_total",
+  help: "Total number of failed Horizon requests, labelled per node",
+  labelNames: ["node", "error_type"],
+  registers: [register],
+});
+
+export const horizonNodeHealth = new Gauge({
+  name: "horizon_node_health",
+  help: "Current Horizon node health (1=in rotation, 0=removed/cooldown)",
+  labelNames: ["node"],
+  registers: [register],
+});
+
+export const horizonRequestFailoverTotal = new Counter({
+  name: "horizon_request_failover_total",
+  help: "Total number of Horizon requests retried on an alternative node",
+  labelNames: ["from_node", "to_node", "operation"],
+  registers: [register],
+});
+
 export const healthCheckResponseTimeSeconds = new Histogram({
   name: "health_check_response_time_seconds",
   help: "Duration of provider health checks in seconds",


### PR DESCRIPTION
New — [src/stellar/horizonPool.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/stellar/horizonPool.ts): A HorizonPool that holds N Horizon servers, rotates round-robin, tracks per-node consecutive failures with a cooldown window, and exposes getProxiedServer() — a Proxy that is API-compatible with StellarSdk.Horizon.Server. It transparently records and replays both direct calls (loadAccount, submitTransaction, …) and builder chains (server.transactions().forAccount(id).call()) onto the next healthy node when the active one fails. isFailoverEligible() retries only on 429/5xx/network errors; deterministic 4xx throw immediately.

[src/config/stellar.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/config/stellar.ts): getHorizonUrls() parses STELLAR_HORIZON_URL as a comma-separated list (primary first, then fallbacks); getStellarServer() now returns the pooled, failover-backed server — so all ~25 existing call sites get failover with no changes.

[src/utils/metrics.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/utils/metrics.ts): horizon_node_failures_total{node,error_type}, horizon_node_health{node}, horizon_request_failover_total{from_node,to_node,operation}.
Closes #840 

Logging: structured Pino logs on each failure, failover hop, recovery, and full-pool exhaustion.

Also: routed the two direct new Horizon.Server(...) sites ([stellarExporter.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/services/stellarExporter.ts), [routes/stellar.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/routes/stellar.ts)) through the pool; fixed [sep24.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/stellar/sep24.ts) transfer_server to use the primary URL; documented the new vars in .env.example, .env.config.example, env.ts.

Verification
New tests pass: 9/9 in [horizonPool.test.ts](vscode-webview://18le14bbcnup0faq7onjubvlhcsfs6c5826q0r6uq991n36o2prd/src/stellar/__tests__/horizonPool.test.ts) (rotation, 5xx failover, 4xx no-failover, cooldown/recovery, builder-chain failover, all-nodes-fail, error classification).
Typecheck clean for all touched files (the only tsc errors are 5 pre-existing syntax errors in untouched index.ts/gdprService.ts).
No regressions: stashed vs. restored runs of the stellar suites are identical (9 failed / 39 tests — all pre-existing 401/auth issues).
Reverted the npm install lockfile artifacts so the diff is just the feature.
Acceptance criteria
✅ Calls auto-retry on alternative nodes when the active one fails (transparent proxy across all call sites).
✅ Node failures tracked + logged with structured Pino logs.
✅ Prometheus failure counts per node, plus per-node health and failover counters.
Two design notes worth knowing: submitTransaction failover relies on Stellar's idempotency-by-tx-hash (resubmitting the same signed tx is safe); long-lived .stream() calls intentionally bind to the active node and are not failed over. I haven't committed — let me know if you'd like me to.