### PR TITLE
Implement Xero contact syncing and mapping pipeline

### DIFF
--- a/migrations/20260601_create_accounting_contact_mappings.sql
+++ b/migrations/20260601_create_accounting_contact_mappings.sql
@@ -1,0 +1,13 @@
+-- Create accounting contact mappings table
+CREATE TABLE IF NOT EXISTS accounting_contact_mappings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider_type VARCHAR(20) NOT NULL CHECK (provider_type IN ('quickbooks', 'xero')),
+    tenant_id VARCHAR(200), -- Xero tenant id (organization) if applicable
+    external_id VARCHAR(200) NOT NULL, -- External provider's contact identifier
+    external_email VARCHAR(200),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounting_contact_mappings_user_id ON accounting_contact_mappings(user_id);
+CREATE INDEX IF NOT EXISTS idx_accounting_contact_mappings_provider_tenant ON accounting_contact_mappings(provider_type, tenant_id);

--- a/src/services/__tests__/accountingContactSync.test.ts
+++ b/src/services/__tests__/accountingContactSync.test.ts
@@ -1,0 +1,74 @@
+import { AccountingService, AccountingProvider } from "../accounting";
+import { pool } from "../../config/database";
+
+jest.mock("../../config/database");
+jest.mock("axios");
+jest.mock("uuid");
+
+const mockPool = pool as jest.Mocked<typeof pool>;
+const mockAxios = require("axios");
+const mockUuid = require("uuid");
+
+describe("AccountingService.syncContactForUser", () => {
+  let accountingService: AccountingService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUuid.v4.mockReturnValue("test-uuid-123");
+    process.env.XERO_CLIENT_ID = "test-xero-client-id";
+    process.env.XERO_CLIENT_SECRET = "test-xero-client-secret";
+    process.env.XERO_REDIRECT_URI = "http://localhost:3000/auth/xero/callback";
+    accountingService = new AccountingService();
+  });
+
+  it("reuses an existing Xero contact matched by email", async () => {
+    const userRow = [{ id: "user-1", first_name: "Alice", last_name: "Smith", email: "alice@example.com" }];
+    const xeroConnection = [{ id: "conn-1", user_id: "user-1", provider: AccountingProvider.XERO, tenant_id: "tenant-1", access_token: "token", refresh_token: "r", expires_at: new Date(), is_active: true, created_at: new Date(), updated_at: new Date() }];
+
+    // 1: fetch user
+    mockPool.query.mockResolvedValueOnce({ rows: userRow });
+    // 2: getUserConnections
+    mockPool.query.mockResolvedValueOnce({ rows: xeroConnection });
+    // 3: check existing mapping -> none
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+    // 4: axios.get contacts returns a matching contact
+    mockAxios.get.mockResolvedValue({ data: { Contacts: [ { ContactID: "contact-123", EmailAddress: "alice@example.com" } ] } });
+    // 5: insert mapping
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+    await accountingService.syncContactForUser("user-1");
+
+    // Ensure we looked up contacts and inserted mapping
+    expect(mockAxios.get).toHaveBeenCalled();
+    expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO accounting_contact_mappings"), expect.any(Array));
+  });
+
+  it("creates a new Xero contact when none match the email", async () => {
+    const userRow = [{ id: "user-2", first_name: "Bob", last_name: "Jones", email: "bob@example.com" }];
+    const xeroConnection = [{ id: "conn-2", user_id: "user-2", provider: AccountingProvider.XERO, tenant_id: "tenant-2", access_token: "token2", refresh_token: "r2", expires_at: new Date(), is_active: true, created_at: new Date(), updated_at: new Date() }];
+
+    mockPool.query.mockResolvedValueOnce({ rows: userRow });
+    mockPool.query.mockResolvedValueOnce({ rows: xeroConnection });
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+    // No existing contacts
+    mockAxios.get.mockResolvedValue({ data: { Contacts: [] } });
+
+    // Creating contact returns created contact
+    mockAxios.post.mockResolvedValue({ data: { Contacts: [ { ContactID: "new-contact-1" } ] } });
+
+    // Insert mapping result
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+    await accountingService.syncContactForUser("user-2");
+
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      "https://api.xero.com/api.xro/2.0/Contacts",
+      expect.any(Object),
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+
+    expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO accounting_contact_mappings"), expect.any(Array));
+  });
+});

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -2,7 +2,7 @@ import { pool } from "../config/database";
 import { redisClient } from "../config/redis";
 import axios from "axios";
 import { v4 as uuidv4 } from "uuid";
-import { encryptField, decryptField } from "../utils/encryption";
+import { encryptField, decryptField, decrypt } from "../utils/encryption";
 import {
   addAccountingTokenRefreshJob,
   removeAccountingTokenRefreshJob,
@@ -784,6 +784,116 @@ export class AccountingService {
     );
 
     return result.rows;
+  }
+
+  /**
+   * Ensure a Xero/QuickBooks contact exists for the given user and create a mapping.
+   * For Xero we attempt to find a contact by email and reuse it; otherwise create a new contact.
+   */
+  async syncContactForUser(userId: string): Promise<void> {
+    try {
+      // Load user data
+      const userRes = await pool.query("SELECT id, first_name, last_name, email FROM users WHERE id = $1", [userId]);
+      if (userRes.rows.length === 0) return;
+      const row = userRes.rows[0];
+      const email = decrypt(row.email) as string | null | undefined;
+      const firstName = decryptField(row.first_name) as string | null | undefined;
+      const lastName = decryptField(row.last_name) as string | null | undefined;
+
+      if (!email) {
+        logger.info(`[AccountingService] Skipping contact sync for user ${userId}: no email`);
+        return;
+      }
+
+      const connections = await this.getUserConnections(userId);
+
+      for (const connection of connections) {
+        if (connection.provider !== AccountingProvider.XERO) continue;
+
+        // Skip if mapping already exists for this tenant
+        const mapRes = await pool.query(
+          "SELECT external_id FROM accounting_contact_mappings WHERE user_id = $1 AND provider_type = 'xero' AND tenant_id = $2",
+          [userId, connection.tenantId],
+        );
+        if (mapRes.rows.length > 0) continue;
+
+        try {
+          await this.ensureValidToken(connection.id);
+
+          // Fetch all contacts and try to match by email (API may support filtering; keep generic)
+          const resp = await axios.get("https://api.xero.com/api.xro/2.0/Contacts", {
+            headers: {
+              Authorization: `Bearer ${connection.accessToken}`,
+              "Xero-tenant-id": connection.tenantId || "",
+            },
+            timeout: 20000,
+          });
+
+          const contacts = resp.data?.Contacts || [];
+
+          let foundContact: any = null;
+
+          for (const c of contacts) {
+            // Xero contact email can be in EmailAddress or EmailAddresses array
+            const emails: string[] = [];
+            if (c.EmailAddress) emails.push(c.EmailAddress);
+            if (c.EmailAddresses && Array.isArray(c.EmailAddresses)) {
+              for (const e of c.EmailAddresses) {
+                if (e && (e.EmailAddress || e.email)) emails.push(e.EmailAddress || e.email);
+              }
+            }
+            if (emails.find((e) => e && e.toLowerCase() === email.toLowerCase())) {
+              foundContact = c;
+              break;
+            }
+          }
+
+          let externalId: string | undefined;
+
+          if (foundContact) {
+            externalId = foundContact.ContactID || foundContact.ContactId || foundContact.contactID;
+          } else {
+            // Create new contact in Xero
+            const name = (firstName || lastName) ? `${firstName || ''} ${lastName || ''}`.trim() : email;
+            const createBody = {
+              Contacts: [
+                {
+                  Name: name,
+                  FirstName: firstName,
+                  LastName: lastName,
+                  EmailAddress: email,
+                },
+              ],
+            };
+
+            const createResp = await axios.post("https://api.xero.com/api.xro/2.0/Contacts", createBody, {
+              headers: {
+                Authorization: `Bearer ${connection.accessToken}`,
+                "Xero-tenant-id": connection.tenantId || "",
+                "Content-Type": "application/json",
+              },
+              timeout: 20000,
+            });
+
+            const created = createResp.data?.Contacts && createResp.data.Contacts[0];
+            externalId = created?.ContactID || created?.ContactId;
+          }
+
+          if (externalId) {
+            await pool.query(
+              `INSERT INTO accounting_contact_mappings (id, user_id, provider_type, tenant_id, external_id, external_email)
+               VALUES (gen_random_uuid(), $1, 'xero', $2, $3, $4)`,
+              [userId, connection.tenantId, externalId, email],
+            );
+            logger.info(`[AccountingService] Mapped user ${userId} -> xero contact ${externalId} (tenant ${connection.tenantId})`);
+          }
+        } catch (err) {
+          logger.error(`[AccountingService] Failed to sync contact for user ${userId} on connection ${connection.id}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    } catch (err) {
+      logger.error(`[AccountingService] syncContactForUser error for ${userId}: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   // Helper functions

--- a/src/services/kyc.ts
+++ b/src/services/kyc.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
 import { Pool } from 'pg';
 import { z } from 'zod';
+import { AccountingService } from './accounting';
 
 // KYC Provider: Entrust Identity Verification (formerly Onfido)
 // Documentation: https://documentation.identity.entrust.com/api/latest/
@@ -338,6 +339,15 @@ export class KYCService {
       await this.db.query(query, [kycLevel, userId]);
       
       console.log(`Updated KYC level for user ${userId} to ${kycLevel}`);
+      // If user reached a verified level, attempt to sync contact to accounting providers (Xero)
+      try {
+        if (kycLevel !== KYCLevel.NONE) {
+          const accountingSvc = new AccountingService();
+          await accountingSvc.syncContactForUser(userId);
+        }
+      } catch (err) {
+        console.error(`Failed to sync accounting contact after KYC update for user ${userId}: ${err instanceof Error ? err.message : String(err)}`);
+      }
     } catch (error) {
       console.error(`Failed to update user KYC level: ${error instanceof Error ? error.message : 'Unknown error'}`);
       throw error;


### PR DESCRIPTION
Implement Xero contact syncing during verification by adding a new accounting_contact_mappings migration and extending [AccountingService](https://psychic-space-cod-q7v667x4wvvpfpg9.github.dev/) with [syncContactForUser()](https://psychic-space-cod-q7v667x4wvvpfpg9.github.dev/), which finds or creates Xero contacts by email and persists tenant-scoped mappings. The KYC update path now triggers this sync after a user’s KYC level is raised, ensuring bridge user records are aligned with Xero Contacts. Also added focused Jest coverage for Xero contact reuse and creation cases.
closes #972 