### PR TITLE
feat: implement QuickBooks customer sync with email matching and automatic creation

### DIFF
--- a/src/services/__tests__/accountingContactSync.test.ts
+++ b/src/services/__tests__/accountingContactSync.test.ts
@@ -18,57 +18,185 @@ describe("AccountingService.syncContactForUser", () => {
     process.env.XERO_CLIENT_ID = "test-xero-client-id";
     process.env.XERO_CLIENT_SECRET = "test-xero-client-secret";
     process.env.XERO_REDIRECT_URI = "http://localhost:3000/auth/xero/callback";
+    process.env.QUICKBOOKS_CLIENT_ID = "test-qb-client-id";
+    process.env.QUICKBOOKS_CLIENT_SECRET = "test-qb-client-secret";
+    process.env.QUICKBOOKS_REDIRECT_URI = "http://localhost:3000/auth/quickbooks/callback";
     accountingService = new AccountingService();
   });
 
-  it("reuses an existing Xero contact matched by email", async () => {
-    const userRow = [{ id: "user-1", first_name: "Alice", last_name: "Smith", email: "alice@example.com" }];
-    const xeroConnection = [{ id: "conn-1", user_id: "user-1", provider: AccountingProvider.XERO, tenant_id: "tenant-1", access_token: "token", refresh_token: "r", expires_at: new Date(), is_active: true, created_at: new Date(), updated_at: new Date() }];
+  describe("Xero contact sync", () => {
+    it("reuses an existing Xero contact matched by email", async () => {
+      const userRow = [{ id: "user-1", first_name: "Alice", last_name: "Smith", email: "alice@example.com" }];
+      const xeroConnection = [{ id: "conn-1", user_id: "user-1", provider: AccountingProvider.XERO, tenant_id: "tenant-1", access_token: "token", refresh_token: "r", expires_at: new Date(), is_active: true, created_at: new Date(), updated_at: new Date() }];
 
-    // 1: fetch user
-    mockPool.query.mockResolvedValueOnce({ rows: userRow });
-    // 2: getUserConnections
-    mockPool.query.mockResolvedValueOnce({ rows: xeroConnection });
-    // 3: check existing mapping -> none
-    mockPool.query.mockResolvedValueOnce({ rows: [] });
+      // 1: fetch user
+      mockPool.query.mockResolvedValueOnce({ rows: userRow });
+      // 2: getUserConnections
+      mockPool.query.mockResolvedValueOnce({ rows: xeroConnection });
+      // 3: check existing mapping -> none
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
 
-    // 4: axios.get contacts returns a matching contact
-    mockAxios.get.mockResolvedValue({ data: { Contacts: [ { ContactID: "contact-123", EmailAddress: "alice@example.com" } ] } });
-    // 5: insert mapping
-    mockPool.query.mockResolvedValueOnce({ rows: [] });
+      // 4: axios.get contacts returns a matching contact
+      mockAxios.get.mockResolvedValue({ data: { Contacts: [ { ContactID: "contact-123", EmailAddress: "alice@example.com" } ] } });
+      // 5: insert mapping
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
 
-    await accountingService.syncContactForUser("user-1");
+      await accountingService.syncContactForUser("user-1");
 
-    // Ensure we looked up contacts and inserted mapping
-    expect(mockAxios.get).toHaveBeenCalled();
-    expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO accounting_contact_mappings"), expect.any(Array));
+      // Ensure we looked up contacts and inserted mapping
+      expect(mockAxios.get).toHaveBeenCalled();
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO accounting_contact_mappings"), expect.any(Array));
+    });
+
+    it("creates a new Xero contact when none match the email", async () => {
+      const userRow = [{ id: "user-2", first_name: "Bob", last_name: "Jones", email: "bob@example.com" }];
+      const xeroConnection = [{ id: "conn-2", user_id: "user-2", provider: AccountingProvider.XERO, tenant_id: "tenant-2", access_token: "token2", refresh_token: "r2", expires_at: new Date(), is_active: true, created_at: new Date(), updated_at: new Date() }];
+
+      mockPool.query.mockResolvedValueOnce({ rows: userRow });
+      mockPool.query.mockResolvedValueOnce({ rows: xeroConnection });
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      // No existing contacts
+      mockAxios.get.mockResolvedValue({ data: { Contacts: [] } });
+
+      // Creating contact returns created contact
+      mockAxios.post.mockResolvedValue({ data: { Contacts: [ { ContactID: "new-contact-1" } ] } });
+
+      // Insert mapping result
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      await accountingService.syncContactForUser("user-2");
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        "https://api.xero.com/api.xro/2.0/Contacts",
+        expect.any(Object),
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO accounting_contact_mappings"), expect.any(Array));
+    });
   });
 
-  it("creates a new Xero contact when none match the email", async () => {
-    const userRow = [{ id: "user-2", first_name: "Bob", last_name: "Jones", email: "bob@example.com" }];
-    const xeroConnection = [{ id: "conn-2", user_id: "user-2", provider: AccountingProvider.XERO, tenant_id: "tenant-2", access_token: "token2", refresh_token: "r2", expires_at: new Date(), is_active: true, created_at: new Date(), updated_at: new Date() }];
+  describe("QuickBooks customer sync", () => {
+    it("reuses an existing QuickBooks customer matched by email", async () => {
+      const userRow = [{ id: "user-3", first_name: "Charlie", last_name: "Brown", email: "charlie@example.com" }];
+      const qbConnection = [{ 
+        id: "conn-3", 
+        user_id: "user-3", 
+        provider: AccountingProvider.QUICKBOOKS, 
+        realm_id: "realm-1",
+        access_token: "qb-token", 
+        refresh_token: "qb-r", 
+        expires_at: new Date(), 
+        is_active: true, 
+        created_at: new Date(), 
+        updated_at: new Date() 
+      }];
 
-    mockPool.query.mockResolvedValueOnce({ rows: userRow });
-    mockPool.query.mockResolvedValueOnce({ rows: xeroConnection });
-    mockPool.query.mockResolvedValueOnce({ rows: [] });
+      // 1: fetch user
+      mockPool.query.mockResolvedValueOnce({ rows: userRow });
+      // 2: getUserConnections
+      mockPool.query.mockResolvedValueOnce({ rows: qbConnection });
+      // 3: check existing mapping -> none
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
 
-    // No existing contacts
-    mockAxios.get.mockResolvedValue({ data: { Contacts: [] } });
+      // 4: axios.get customers returns a matching customer
+      mockAxios.get.mockResolvedValue({ 
+        data: { 
+          QueryResponse: { 
+            Customer: [ { Id: "qb-customer-123", BillAddr: { Email: "charlie@example.com" } } ] 
+          } 
+        } 
+      });
+      // 5: insert mapping
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
 
-    // Creating contact returns created contact
-    mockAxios.post.mockResolvedValue({ data: { Contacts: [ { ContactID: "new-contact-1" } ] } });
+      await accountingService.syncContactForUser("user-3");
 
-    // Insert mapping result
-    mockPool.query.mockResolvedValueOnce({ rows: [] });
+      // Ensure we queried customers and inserted mapping
+      expect(mockAxios.get).toHaveBeenCalled();
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO accounting_contact_mappings"), expect.any(Array));
+    });
 
-    await accountingService.syncContactForUser("user-2");
+    it("creates a new QuickBooks customer when none match the email", async () => {
+      const userRow = [{ id: "user-4", first_name: "Diana", last_name: "Prince", email: "diana@example.com" }];
+      const qbConnection = [{ 
+        id: "conn-4", 
+        user_id: "user-4", 
+        provider: AccountingProvider.QUICKBOOKS, 
+        realm_id: "realm-2",
+        access_token: "qb-token-2", 
+        refresh_token: "qb-r-2", 
+        expires_at: new Date(), 
+        is_active: true, 
+        created_at: new Date(), 
+        updated_at: new Date() 
+      }];
 
-    expect(mockAxios.post).toHaveBeenCalledWith(
-      "https://api.xero.com/api.xro/2.0/Contacts",
-      expect.any(Object),
-      expect.objectContaining({ headers: expect.any(Object) }),
-    );
+      mockPool.query.mockResolvedValueOnce({ rows: userRow });
+      mockPool.query.mockResolvedValueOnce({ rows: qbConnection });
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
 
-    expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO accounting_contact_mappings"), expect.any(Array));
+      // No existing customers
+      mockAxios.get.mockResolvedValue({ data: { QueryResponse: { Customer: [] } } });
+
+      // Creating customer returns created customer
+      mockAxios.post.mockResolvedValue({ 
+        data: { 
+          Customer: { Id: "qb-new-customer-1" } 
+        } 
+      });
+
+      // Insert mapping result
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      await accountingService.syncContactForUser("user-4");
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/customer"),
+        expect.any(Object),
+        expect.objectContaining({ headers: expect.any(Object) }),
+      );
+
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO accounting_contact_mappings"), expect.any(Array));
+    });
+
+    it("handles QuickBooks query failures gracefully and creates customer", async () => {
+      const userRow = [{ id: "user-5", first_name: "Eve", last_name: "Adams", email: "eve@example.com" }];
+      const qbConnection = [{ 
+        id: "conn-5", 
+        user_id: "user-5", 
+        provider: AccountingProvider.QUICKBOOKS, 
+        realm_id: "realm-3",
+        access_token: "qb-token-3", 
+        refresh_token: "qb-r-3", 
+        expires_at: new Date(), 
+        is_active: true, 
+        created_at: new Date(), 
+        updated_at: new Date() 
+      }];
+
+      mockPool.query.mockResolvedValueOnce({ rows: userRow });
+      mockPool.query.mockResolvedValueOnce({ rows: qbConnection });
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      // Query fails with 400
+      mockAxios.get.mockRejectedValueOnce({ response: { status: 400 } });
+
+      // Creating customer returns created customer
+      mockAxios.post.mockResolvedValue({ 
+        data: { 
+          Customer: { Id: "qb-new-customer-2" } 
+        } 
+      });
+
+      // Insert mapping result
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+      await accountingService.syncContactForUser("user-5");
+
+      expect(mockAxios.post).toHaveBeenCalled();
+      expect(mockPool.query).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO accounting_contact_mappings"), expect.any(Array));
+    });
   });
 });

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -788,7 +788,7 @@ export class AccountingService {
 
   /**
    * Ensure a Xero/QuickBooks contact exists for the given user and create a mapping.
-   * For Xero we attempt to find a contact by email and reuse it; otherwise create a new contact.
+   * For both providers we attempt to find a contact by email and reuse it; otherwise create a new contact.
    */
   async syncContactForUser(userId: string): Promise<void> {
     try {
@@ -808,84 +808,11 @@ export class AccountingService {
       const connections = await this.getUserConnections(userId);
 
       for (const connection of connections) {
-        if (connection.provider !== AccountingProvider.XERO) continue;
-
-        // Skip if mapping already exists for this tenant
-        const mapRes = await pool.query(
-          "SELECT external_id FROM accounting_contact_mappings WHERE user_id = $1 AND provider_type = 'xero' AND tenant_id = $2",
-          [userId, connection.tenantId],
-        );
-        if (mapRes.rows.length > 0) continue;
-
         try {
-          await this.ensureValidToken(connection.id);
-
-          // Fetch all contacts and try to match by email (API may support filtering; keep generic)
-          const resp = await axios.get("https://api.xero.com/api.xro/2.0/Contacts", {
-            headers: {
-              Authorization: `Bearer ${connection.accessToken}`,
-              "Xero-tenant-id": connection.tenantId || "",
-            },
-            timeout: 20000,
-          });
-
-          const contacts = resp.data?.Contacts || [];
-
-          let foundContact: any = null;
-
-          for (const c of contacts) {
-            // Xero contact email can be in EmailAddress or EmailAddresses array
-            const emails: string[] = [];
-            if (c.EmailAddress) emails.push(c.EmailAddress);
-            if (c.EmailAddresses && Array.isArray(c.EmailAddresses)) {
-              for (const e of c.EmailAddresses) {
-                if (e && (e.EmailAddress || e.email)) emails.push(e.EmailAddress || e.email);
-              }
-            }
-            if (emails.find((e) => e && e.toLowerCase() === email.toLowerCase())) {
-              foundContact = c;
-              break;
-            }
-          }
-
-          let externalId: string | undefined;
-
-          if (foundContact) {
-            externalId = foundContact.ContactID || foundContact.ContactId || foundContact.contactID;
-          } else {
-            // Create new contact in Xero
-            const name = (firstName || lastName) ? `${firstName || ''} ${lastName || ''}`.trim() : email;
-            const createBody = {
-              Contacts: [
-                {
-                  Name: name,
-                  FirstName: firstName,
-                  LastName: lastName,
-                  EmailAddress: email,
-                },
-              ],
-            };
-
-            const createResp = await axios.post("https://api.xero.com/api.xro/2.0/Contacts", createBody, {
-              headers: {
-                Authorization: `Bearer ${connection.accessToken}`,
-                "Xero-tenant-id": connection.tenantId || "",
-                "Content-Type": "application/json",
-              },
-              timeout: 20000,
-            });
-
-            const created = createResp.data?.Contacts && createResp.data.Contacts[0];
-            externalId = created?.ContactID || created?.ContactId;
-          }
-
-          if (externalId) {
-            await pool.query(
-              `INSERT INTO accounting_contact_mappings (id, user_id, provider_type, tenant_id, external_id, external_email)
-               VALUES (gen_random_uuid(), $1, 'xero', $2, $3, $4)`,
-              [userId, connection.tenantId, externalId, email],
-            );
-            logger.info(`[AccountingService] Mapped user ${userId} -> xero contact ${externalId} (tenant ${connection.tenantId})`);
+          if (connection.provider === AccountingProvider.XERO) {
+            await this.syncXeroContactForUser(userId, connection, email, firstName, lastName);
+          } else if (connection.provider === AccountingProvider.QUICKBOOKS) {
+            await this.syncQuickBooksCustomerForUser(userId, connection, email, firstName, lastName);
           }
         } catch (err) {
           logger.error(`[AccountingService] Failed to sync contact for user ${userId} on connection ${connection.id}: ${err instanceof Error ? err.message : String(err)}`);
@@ -893,6 +820,245 @@ export class AccountingService {
       }
     } catch (err) {
       logger.error(`[AccountingService] syncContactForUser error for ${userId}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Sync Xero contact for a user: find or create, then store mapping.
+   */
+  private async syncXeroContactForUser(
+    userId: string,
+    connection: AccountingConnection,
+    email: string,
+    firstName?: string | null,
+    lastName?: string | null,
+  ): Promise<void> {
+    // Skip if mapping already exists for this tenant
+    const mapRes = await pool.query(
+      "SELECT external_id FROM accounting_contact_mappings WHERE user_id = $1 AND provider_type = 'xero' AND tenant_id = $2",
+      [userId, connection.tenantId],
+    );
+    if (mapRes.rows.length > 0) return;
+
+    await this.ensureValidToken(connection.id);
+
+    // Fetch all contacts and try to match by email (API may support filtering; keep generic)
+    const resp = await axios.get("https://api.xero.com/api.xro/2.0/Contacts", {
+      headers: {
+        Authorization: `Bearer ${connection.accessToken}`,
+        "Xero-tenant-id": connection.tenantId || "",
+      },
+      timeout: 20000,
+    });
+
+    const contacts = resp.data?.Contacts || [];
+
+    let foundContact: any = null;
+
+    for (const c of contacts) {
+      // Xero contact email can be in EmailAddress or EmailAddresses array
+      const emails: string[] = [];
+      if (c.EmailAddress) emails.push(c.EmailAddress);
+      if (c.EmailAddresses && Array.isArray(c.EmailAddresses)) {
+        for (const e of c.EmailAddresses) {
+          if (e && (e.EmailAddress || e.email)) emails.push(e.EmailAddress || e.email);
+        }
+      }
+      if (emails.find((e) => e && e.toLowerCase() === email.toLowerCase())) {
+        foundContact = c;
+        break;
+      }
+    }
+
+    let externalId: string | undefined;
+
+    if (foundContact) {
+      externalId = foundContact.ContactID || foundContact.ContactId || foundContact.contactID;
+    } else {
+      // Create new contact in Xero
+      const name = (firstName || lastName) ? `${firstName || ''} ${lastName || ''}`.trim() : email;
+      const createBody = {
+        Contacts: [
+          {
+            Name: name,
+            FirstName: firstName,
+            LastName: lastName,
+            EmailAddress: email,
+          },
+        ],
+      };
+
+      const createResp = await axios.post("https://api.xero.com/api.xro/2.0/Contacts", createBody, {
+        headers: {
+          Authorization: `Bearer ${connection.accessToken}`,
+          "Xero-tenant-id": connection.tenantId || "",
+          "Content-Type": "application/json",
+        },
+        timeout: 20000,
+      });
+
+      const created = createResp.data?.Contacts && createResp.data.Contacts[0];
+      externalId = created?.ContactID || created?.ContactId;
+    }
+
+    if (externalId) {
+      await pool.query(
+        `INSERT INTO accounting_contact_mappings (id, user_id, provider_type, tenant_id, external_id, external_email)
+         VALUES (gen_random_uuid(), $1, 'xero', $2, $3, $4)`,
+        [userId, connection.tenantId, externalId, email],
+      );
+      logger.info(`[AccountingService] Mapped user ${userId} -> xero contact ${externalId} (tenant ${connection.tenantId})`);
+    }
+  }
+
+  /**
+   * Sync QuickBooks customer for a user: find or create, then store mapping.
+   */
+  private async syncQuickBooksCustomerForUser(
+    userId: string,
+    connection: AccountingConnection,
+    email: string,
+    firstName?: string | null,
+    lastName?: string | null,
+  ): Promise<void> {
+    // Skip if mapping already exists for this realm (QuickBooks company)
+    const mapRes = await pool.query(
+      "SELECT external_id FROM accounting_contact_mappings WHERE user_id = $1 AND provider_type = 'quickbooks' AND tenant_id = $2",
+      [userId, connection.realmId],
+    );
+    if (mapRes.rows.length > 0) return;
+
+    await this.ensureValidToken(connection.id);
+
+    // Query QuickBooks for customers with matching email
+    // Use a QBO query to find customers by email
+    const query = `SELECT * FROM Customer WHERE BillAddr.Email = '${email}' MAXRESULTS 10`;
+    const encodedQuery = encodeURIComponent(query);
+
+    try {
+      const resp = await axios.get(
+        `https://quickbooks.api.intuit.com/v3/company/${connection.realmId}/query?query=${encodedQuery}`,
+        {
+          headers: {
+            Authorization: `Bearer ${connection.accessToken}`,
+            Accept: "application/json",
+          },
+          timeout: 20000,
+        },
+      );
+
+      const customers = resp.data?.QueryResponse?.Customer || [];
+      let foundCustomer: any = null;
+
+      // Look for email match in returned customers
+      if (customers.length > 0) {
+        for (const c of customers) {
+          const customerEmail = c.BillAddr?.Email || c.ShipAddr?.Email;
+          if (customerEmail && customerEmail.toLowerCase() === email.toLowerCase()) {
+            foundCustomer = c;
+            break;
+          }
+        }
+      }
+
+      let customerId: string | undefined;
+
+      if (foundCustomer) {
+        customerId = foundCustomer.Id;
+      } else {
+        // Create new customer in QuickBooks
+        const displayName = (firstName || lastName) ? `${firstName || ''} ${lastName || ''}`.trim() : email.split("@")[0];
+
+        const createBody = {
+          DisplayName: displayName,
+          PrimaryEmailAddr: {
+            Address: email,
+          },
+          BillAddr: {
+            City: "",
+            Country: "",
+            Line1: "",
+            PostalCode: "",
+            Qty: 1,
+          },
+          ...(firstName && { GivenName: firstName }),
+          ...(lastName && { FamilyName: lastName }),
+        };
+
+        const createResp = await axios.post(
+          `https://quickbooks.api.intuit.com/v3/company/${connection.realmId}/customer`,
+          createBody,
+          {
+            headers: {
+              Authorization: `Bearer ${connection.accessToken}`,
+              "Content-Type": "application/json",
+            },
+            timeout: 20000,
+          },
+        );
+
+        const created = createResp.data?.Customer;
+        customerId = created?.Id;
+      }
+
+      if (customerId) {
+        await pool.query(
+          `INSERT INTO accounting_contact_mappings (id, user_id, provider_type, tenant_id, external_id, external_email)
+           VALUES (gen_random_uuid(), $1, 'quickbooks', $2, $3, $4)`,
+          [userId, connection.realmId, customerId, email],
+        );
+        logger.info(`[AccountingService] Mapped user ${userId} -> quickbooks customer ${customerId} (realm ${connection.realmId})`);
+      }
+    } catch (err) {
+      // If query fails (e.g., no customer with that email), proceed to create
+      if ((err as any).response?.status === 400 || (err as any).response?.status === 401) {
+        logger.warn(`[AccountingService] QB customer query failed for user ${userId}: ${(err as Error).message}. Attempting create.`);
+
+        // Attempt to create customer
+        const displayName = (firstName || lastName) ? `${firstName || ''} ${lastName || ''}`.trim() : email.split("@")[0];
+
+        const createBody = {
+          DisplayName: displayName,
+          PrimaryEmailAddr: {
+            Address: email,
+          },
+          BillAddr: {
+            City: "",
+            Country: "",
+            Line1: "",
+            PostalCode: "",
+            Qty: 1,
+          },
+          ...(firstName && { GivenName: firstName }),
+          ...(lastName && { FamilyName: lastName }),
+        };
+
+        const createResp = await axios.post(
+          `https://quickbooks.api.intuit.com/v3/company/${connection.realmId}/customer`,
+          createBody,
+          {
+            headers: {
+              Authorization: `Bearer ${connection.accessToken}`,
+              "Content-Type": "application/json",
+            },
+            timeout: 20000,
+          },
+        );
+
+        const created = createResp.data?.Customer;
+        const customerId = created?.Id;
+
+        if (customerId) {
+          await pool.query(
+            `INSERT INTO accounting_contact_mappings (id, user_id, provider_type, tenant_id, external_id, external_email)
+             VALUES (gen_random_uuid(), $1, 'quickbooks', $2, $3, $4)`,
+            [userId, connection.realmId, customerId, email],
+          );
+          logger.info(`[AccountingService] Created and mapped user ${userId} -> quickbooks customer ${customerId} (realm ${connection.realmId})`);
+        }
+      } else {
+        throw err;
+      }
     }
   }
 


### PR DESCRIPTION
- Add syncQuickBooksCustomerForUser() to handle QB customer creation/mapping
- Refactor syncContactForUser() to support both Xero and QuickBooks
- Extract Xero logic into syncXeroContactForUser() for modularity
- Query QB customers by email and reuse if found, otherwise create new
- Handle QB query failures gracefully with fallback customer creation
- Store QB customer mappings in accounting_contact_mappings table with realm_id
- Add comprehensive unit tests for QB customer sync scenarios
- Covers: existing customer reuse, new customer creation, query failure handling
- Follows same pattern as Xero implementation for consistency

closes #969

