### PR TITLE
Enable ILM for logs 30-day rollover, 90-day retention

### DIFF
--- a/docs/ELK_STACK.md
+++ b/docs/ELK_STACK.md
@@ -29,9 +29,30 @@ Endpoints:
 1. The Node app writes structured JSON to stdout/stderr and to
    `/var/log/mobile-money/app.log`.
 2. Filebeat tails that file and forwards NDJSON events to Logstash.
-3. Logstash applies the Elasticsearch template and writes daily indices named
-   `mobile-money-logs-YYYY.MM.dd`.
+3. Logstash applies the Elasticsearch template with ILM policy and writes to a managed
+   rollover alias (`mobile-money-logs`), creating new indices every 30 days.
 4. Kibana imports a starter dashboard automatically.
+
+## ILM Policy Setup
+
+Before running the ELK stack, deploy the ILM policy to Elasticsearch:
+
+**On Unix/Linux/macOS:**
+```bash
+sh elk/scripts/apply-ilm-policy.sh
+```
+
+**On Windows PowerShell:**
+```powershell
+powershell -File .\elk\scripts\apply-ilm-policy.ps1
+```
+
+For container Elasticsearch, set the URL:
+```bash
+ELASTICSEARCH_URL=http://elasticsearch:9200 sh elk/scripts/apply-ilm-policy.sh
+```
+
+The policy rolls logs over after 30 days and deletes them after 90 days to save storage.
 
 In local development, the structured log mirror also rolls by size into dated
 shards and compresses archived shards as `.gz` files so the working log

--- a/elk/ilm/mobile-money-logs-policy.json
+++ b/elk/ilm/mobile-money-logs-policy.json
@@ -1,0 +1,20 @@
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover": {
+            "max_age": "30d",
+            "max_size": "50gb"
+          }
+        }
+      },
+      "delete": {
+        "min_age": "90d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}

--- a/elk/logstash/pipeline/logstash.conf
+++ b/elk/logstash/pipeline/logstash.conf
@@ -20,8 +20,10 @@ filter {
 output {
   elasticsearch {
     hosts => ["http://elasticsearch:9200"]
-    index => "mobile-money-logs-%{+YYYY.MM.dd}"
-    ilm_enabled => false
+    index => "mobile-money-logs"
+    ilm_enabled => true
+    ilm_policy => "mobile-money-logs-policy"
+    ilm_rollover_alias => "mobile-money-logs"
     manage_template => true
     template => "/usr/share/logstash/templates/mobile-money-logs-template.json"
     template_name => "mobile-money-logs"

--- a/elk/logstash/templates/mobile-money-logs-template.json
+++ b/elk/logstash/templates/mobile-money-logs-template.json
@@ -4,7 +4,9 @@
     "settings": {
       "index.refresh_interval": "1s",
       "number_of_shards": 1,
-      "number_of_replicas": 0
+      "number_of_replicas": 0,
+      "index.lifecycle.name": "mobile-money-logs-policy",
+      "index.lifecycle.rollover_alias": "mobile-money-logs"
     },
     "mappings": {
       "dynamic_templates": [

--- a/elk/scripts/apply-ilm-policy.ps1
+++ b/elk/scripts/apply-ilm-policy.ps1
@@ -1,0 +1,20 @@
+param(
+  [string]$ElasticUrl = $(if ($env:ELASTICSEARCH_URL) { $env:ELASTICSEARCH_URL } else { 'http://localhost:9200' }),
+  [string]$PolicyFile = $(if ($env:POLICY_FILE) { $env:POLICY_FILE } else { Join-Path (Split-Path -Path $PSScriptRoot -Parent) 'ilm\mobile-money-logs-policy.json' })
+)
+
+Write-Host "Applying ILM policy from $PolicyFile to $ElasticUrl"
+
+while ($true) {
+  try {
+    Invoke-WebRequest -Uri $ElasticUrl -Method Head -UseBasicParsing -TimeoutSec 5 | Out-Null
+    break
+  } catch {
+    Write-Host "Waiting for Elasticsearch at $ElasticUrl..."
+    Start-Sleep -Seconds 5
+  }
+}
+
+$body = Get-Content -Path $PolicyFile -Raw
+Invoke-WebRequest -Uri "$ElasticUrl/_ilm/policy/mobile-money-logs-policy" -Method Put -ContentType 'application/json' -Body $body -UseBasicParsing
+Write-Host "ILM policy applied successfully."

--- a/elk/scripts/apply-ilm-policy.sh
+++ b/elk/scripts/apply-ilm-policy.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+ELASTICSEARCH_URL="${ELASTICSEARCH_URL:-http://localhost:9200}"
+POLICY_FILE="${POLICY_FILE:-$(cd "$(dirname "$0")/../ilm" && pwd)/mobile-money-logs-policy.json}"
+
+echo "Applying ILM policy from ${POLICY_FILE} to ${ELASTICSEARCH_URL}"
+
+until curl -fsS "${ELASTICSEARCH_URL}" >/dev/null 2>&1; do
+  echo "Waiting for Elasticsearch at ${ELASTICSEARCH_URL}..."
+  sleep 5
+done
+
+curl -fsS -X PUT "${ELASTICSEARCH_URL}/_ilm/policy/mobile-money-logs-policy" \
+  -H 'Content-Type: application/json' \
+  -d @"${POLICY_FILE}"
+
+echo "ILM policy applied successfully."


### PR DESCRIPTION

## Description

Enable Index Lifecycle Management (ILM) for application logs: rollover after 30 days, delete after 90 days. Added ILM policy and deployment scripts; updated Logstash template and docs.

## Related Issue

Fixes #902 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Added [mobile-money-logs-policy.json]
- Updated [logstash.conf]
- Updated [mobile-money-logs-template.json]
- Added deployment scripts: [apply-ilm-policy.sh]
- Updated [ELK_STACK.md]


- [ ] Code follows project style
- [x] Self-reviewed my code
- [ ] Commented complex code
- [x] Updated documentation
- [ ] No new warnings

## Additional Notes
Enables ILM so logs are written to a rollover alias (mobile-money-logs), automatically rolling to a new index after 30 days (or 50GB) and deleting after 90 days.

Close #902 