### PR TITLE
Add multi-signature approval gates to Soroban HTLC contract

### DIFF
--- a/contracts/htlc/src/lib.rs
+++ b/contracts/htlc/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, BytesN, Env, Vec};
 
 #[contracttype]
 #[derive(Clone)]
@@ -13,6 +13,8 @@ pub struct HtlcState {
     pub timelock: u64,
     pub claimed: bool,
     pub refunded: bool,
+    pub approved_signers: Vec<Address>,
+    pub required_signatures: u32,
 }
 
 const HTLC: &str = "HTLC";
@@ -24,6 +26,7 @@ pub struct HtlcContract;
 impl HtlcContract {
     /// Initialize the HTLC. The sender must authorize this call and
     /// transfer `amount` tokens into the contract's own account.
+    /// Optionally provide a list of approved signers and required signature count for multi-sig approval.
     pub fn initialize(
         env: Env,
         sender: Address,
@@ -32,6 +35,8 @@ impl HtlcContract {
         amount: i128,
         hashlock: BytesN<32>,
         timelock: u64,
+        approved_signers: Vec<Address>,
+        required_signatures: u32,
     ) {
         sender.require_auth();
 
@@ -43,6 +48,14 @@ impl HtlcContract {
         
         // Ensure timelock is in the future
         assert!(timelock > env.ledger().timestamp(), "timelock must be in the future");
+
+        // Validate multi-sig parameters if provided
+        if approved_signers.len() > 0 {
+            assert!(
+                required_signatures > 0 && required_signatures <= approved_signers.len() as u32,
+                "required_signatures must be between 1 and number of approved signers"
+            );
+        }
 
         // Pull funds from the sender into this contract.
         token::Client::new(&env, &token).transfer(&sender, &env.current_contract_address(), &amount);
@@ -58,6 +71,8 @@ impl HtlcContract {
                 timelock,
                 claimed: false,
                 refunded: false,
+                approved_signers,
+                required_signatures,
             },
         );
 
@@ -66,7 +81,8 @@ impl HtlcContract {
     }
 
     /// Claim funds by providing the preimage.
-    pub fn claim(env: Env, preimage: BytesN<32>) {
+    /// If multi-sig is enabled, requires authorization from the required number of approved signers.
+    pub fn claim(env: Env, preimage: BytesN<32>, signers: Vec<Address>) {
         let mut state: HtlcState = env.storage().instance().get(&HTLC).expect("not initialised");
 
         assert!(!state.claimed, "already claimed");
@@ -75,6 +91,31 @@ impl HtlcContract {
         // Verify the hash of the preimage matches the hashlock
         let hash: BytesN<32> = env.crypto().sha256(&preimage.into()).into();
         assert!(hash == state.hashlock, "invalid preimage");
+
+        // Multi-signature verification if approved signers are configured
+        if state.approved_signers.len() > 0 {
+            // Verify each signer is in the approved list and has authorized
+            let mut valid_signature_count = 0u32;
+            for signer in signers.iter() {
+                // Check if signer is in approved list
+                let is_approved = state.approved_signers.iter().any(|approved| approved == signer);
+                assert!(is_approved, "signer not in approved list");
+                
+                // Require authorization from each signer
+                signer.require_auth();
+                valid_signature_count += 1;
+            }
+            
+            assert!(
+                valid_signature_count >= state.required_signatures,
+                "insufficient signatures: required {}, got {}",
+                state.required_signatures,
+                valid_signature_count
+            );
+        } else {
+            // If no multi-sig configured, receiver must authorize
+            state.receiver.require_auth();
+        }
 
         // Transfer funds to the receiver
         token::Client::new(&env, &state.token)
@@ -153,13 +194,18 @@ mod tests {
         
         env.ledger().set_timestamp(100);
 
-        client.initialize(&sender, &receiver, &token, &amount, &hashlock, &timelock);
+        // Initialize without multi-sig (empty approved_signers)
+        let approved_signers: Vec<Address> = Vec::new(&env);
+        let required_signatures = 0u32;
+        client.initialize(&sender, &receiver, &token, &amount, &hashlock, &timelock, &approved_signers, &required_signatures);
 
         let state = client.get_state();
         assert_eq!(state.amount, amount);
         assert!(!state.claimed);
 
-        client.claim(&preimage);
+        // Claim with empty signers (receiver auth only)
+        let signers: Vec<Address> = Vec::new(&env);
+        client.claim(&preimage, &signers);
 
         let token_client = TokenClient::new(&env, &token);
         assert_eq!(token_client.balance(&receiver), amount);
@@ -177,7 +223,10 @@ mod tests {
         
         env.ledger().set_timestamp(100);
 
-        client.initialize(&sender, &receiver, &token, &amount, &hashlock, &timelock);
+        // Initialize without multi-sig
+        let approved_signers: Vec<Address> = Vec::new(&env);
+        let required_signatures = 0u32;
+        client.initialize(&sender, &receiver, &token, &amount, &hashlock, &timelock, &approved_signers, &required_signatures);
 
         // Jump to after timelock
         env.ledger().set_timestamp(1001);
@@ -202,5 +251,141 @@ mod tests {
         
         let token_client = TokenClient::new(&env_out, &token);
         assert_eq!(token_client.balance(&recipient), 100);
+    }
+
+    #[test]
+    fn test_multisig_claim() {
+        let (env, sender, receiver, token, client) = setup(None);
+        let amount: i128 = 500_000;
+        
+        let preimage = BytesN::from_array(&env, &[1; 32]);
+        let hashlock: BytesN<32> = env.crypto().sha256(&preimage.clone().into()).into();
+        let timelock = 1000;
+        
+        env.ledger().set_timestamp(100);
+
+        // Create approved signers
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+        let signer3 = Address::generate(&env);
+        
+        let mut approved_signers: Vec<Address> = Vec::new(&env);
+        approved_signers.push_back(signer1.clone());
+        approved_signers.push_back(signer2.clone());
+        approved_signers.push_back(signer3.clone());
+        
+        let required_signatures = 2u32; // Require 2 out of 3 signatures
+        client.initialize(&sender, &receiver, &token, &amount, &hashlock, &timelock, &approved_signers, &required_signatures);
+
+        let state = client.get_state();
+        assert_eq!(state.amount, amount);
+        assert_eq!(state.approved_signers.len(), 3);
+        assert_eq!(state.required_signatures, 2);
+        assert!(!state.claimed);
+
+        // Claim with 2 signers (meets requirement)
+        let mut signers: Vec<Address> = Vec::new(&env);
+        signers.push_back(signer1.clone());
+        signers.push_back(signer2.clone());
+        client.claim(&preimage, &signers);
+
+        let token_client = TokenClient::new(&env, &token);
+        assert_eq!(token_client.balance(&receiver), amount);
+        assert!(client.get_state().claimed);
+    }
+
+    #[test]
+    fn test_multisig_insufficient_signatures() {
+        let (env, sender, receiver, token, client) = setup(None);
+        let amount: i128 = 500_000;
+        
+        let preimage = BytesN::from_array(&env, &[1; 32]);
+        let hashlock: BytesN<32> = env.crypto().sha256(&preimage.clone().into()).into();
+        let timelock = 1000;
+        
+        env.ledger().set_timestamp(100);
+
+        // Create approved signers
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+        let signer3 = Address::generate(&env);
+        
+        let mut approved_signers: Vec<Address> = Vec::new(&env);
+        approved_signers.push_back(signer1.clone());
+        approved_signers.push_back(signer2.clone());
+        approved_signers.push_back(signer3.clone());
+        
+        let required_signatures = 2u32; // Require 2 out of 3 signatures
+        client.initialize(&sender, &receiver, &token, &amount, &hashlock, &timelock, &approved_signers, &required_signatures);
+
+        // Try to claim with only 1 signer (insufficient)
+        let mut signers: Vec<Address> = Vec::new(&env);
+        signers.push_back(signer1.clone());
+        
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.claim(&preimage, &signers);
+        }));
+        assert!(result.is_err(), "claim should fail with insufficient signatures");
+    }
+
+    #[test]
+    fn test_multisig_unapproved_signer() {
+        let (env, sender, receiver, token, client) = setup(None);
+        let amount: i128 = 500_000;
+        
+        let preimage = BytesN::from_array(&env, &[1; 32]);
+        let hashlock: BytesN<32> = env.crypto().sha256(&preimage.clone().into()).into();
+        let timelock = 1000;
+        
+        env.ledger().set_timestamp(100);
+
+        // Create approved signers
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+        
+        let mut approved_signers: Vec<Address> = Vec::new(&env);
+        approved_signers.push_back(signer1.clone());
+        approved_signers.push_back(signer2.clone());
+        
+        let required_signatures = 1u32;
+        client.initialize(&sender, &receiver, &token, &amount, &hashlock, &timelock, &approved_signers, &required_signatures);
+
+        // Try to claim with an unapproved signer
+        let unapproved_signer = Address::generate(&env);
+        let mut signers: Vec<Address> = Vec::new(&env);
+        signers.push_back(unapproved_signer);
+        
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.claim(&preimage, &signers);
+        }));
+        assert!(result.is_err(), "claim should fail with unapproved signer");
+    }
+
+    #[test]
+    fn test_multisig_invalid_required_signatures() {
+        let (env, sender, receiver, token, client) = setup(None);
+        let amount: i128 = 500_000;
+        
+        let preimage = BytesN::from_array(&env, &[1; 32]);
+        let hashlock: BytesN<32> = env.crypto().sha256(&preimage.clone().into()).into();
+        let timelock = 1000;
+        
+        env.ledger().set_timestamp(100);
+
+        // Create approved signers
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+        
+        let mut approved_signers: Vec<Address> = Vec::new(&env);
+        approved_signers.push_back(signer1.clone());
+        approved_signers.push_back(signer2.clone());
+        
+        // Try to initialize with required_signatures > approved_signers.len()
+        let required_signatures = 3u32; // More than available signers
+        
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.initialize(&sender, &receiver, &token, &amount, &hashlock, &timelock, &approved_signers, &required_signatures);
+        }));
+        assert!(result.is_err(), "initialize should fail with invalid required_signatures");
     }
 }


### PR DESCRIPTION
This PR adds multi-signature approval gates to the Soroban HTLC contract to prevent single-key compromise risks. The implementation allows setting a list of approved signers and a required signature threshold during contract deployment, then verifies that claim requests are authorized by the required number of approved signers before releasing locked funds. The feature is optional and backward compatible—when no multi-sig configuration is provided, the contract falls back to the original receiver-only authorization model, ensuring existing deployments continue to function without modification.
closes #980 