### PR TITLE
feat: add Tigo and Vodacom provider mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,14 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 ## 🚀 Key Features
 
 ### Core Platform
-
 - **Mobile Money Integration** — MTN MoMo, Airtel Money, Orange Money with circuit breaker, failover, and batch payouts
 - **Stellar Blockchain** — XLM, USDC, and custom asset support via Stellar SDK + Horizon API
 - **Dual API** — REST (40+ endpoints) and GraphQL (queries, mutations, and real-time subscriptions)
 - **Real-time Processing** — BullMQ job queues with Redis, admin dashboard at `/admin/queues`
 - **WebSocket** — Live transaction updates with JWT auth, per-user rooms, and Redis pub/sub for horizontal scaling
-- **Provider Mock Server** — Full mock for MTN, Airtel, Tigo, and Vodacom APIs for local development without real credentials
+- **Provider Mock Server** — Full mock for MTN + Airtel APIs for local development without real credentials
 
 ### Security & Compliance
-
 - **Multi-tier KYC** — Tiered identity verification with document upload (S3) and third-party verification (Entrust)
 - **AML Monitoring** — Auto-flagging of suspicious patterns (large transactions, rapid structuring, daily totals)
 - **Travel Rule Compliance** — FATF travel rule data collection for qualifying transactions
@@ -64,7 +62,6 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 - **PII Encryption** — AES-256-GCM encryption for sensitive data at rest
 
 ### Financial Engine
-
 - **Dynamic Fee Engine** — Configurable fee strategies with VIP tiers (25KB+ fee strategy engine)
 - **Transaction Limits** — Provider-specific and KYC-tiered daily limits
 - **Vault System** — Secure fund storage with distributed locking
@@ -74,7 +71,6 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 - **Reconciliation** — Provider reconciliation workflows
 
 ### Stellar Protocol (SEP) Support
-
 - **SEP-06** — Deposit and Withdrawal API
 - **SEP-10** — Web Authentication (challenge-response)
 - **SEP-12** — KYC API (customer CRUD with document upload)
@@ -82,12 +78,10 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 - **SEP-31** — Cross-Border Payments (send-side anchor)
 
 ### Smart Contracts
-
 - **Escrow Contract** — Soroban smart contract for escrowed payments (Rust)
 - **HTLC Contract** — Hash Time-Locked Contract for atomic cross-chain swaps (Rust)
 
 ### Notifications
-
 - **Email** — SendGrid integration
 - **SMS** — Twilio integration
 - **Push Notifications** — Firebase Cloud Messaging
@@ -95,7 +89,6 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 - **PagerDuty** — Operational alerting
 
 ### Developer Tools
-
 - **CLI** (`momo-cli`) — Admin tool for auth, status checks, and transaction retries
 - **Kotlin SDK** — Auto-generated from OpenAPI spec
 - **Postman Collections** — Pre-built API collections for testing
@@ -163,19 +156,16 @@ npm run seed  # Optional: development data
 ### 4. Run
 
 **Development (with provider mocks):**
-
 ```bash
 npm run docker:dev   # Starts app + Postgres + Redis + provider mock server
 ```
 
 **Development (standalone):**
-
 ```bash
 npm run dev
 ```
 
 **Production:**
-
 ```bash
 npm run build
 npm start
@@ -195,7 +185,6 @@ npm run test:mutation       # Mutation testing (Stryker)
 ```
 
 **Test infrastructure includes:**
-
 - Unit & integration tests across controllers, services, middleware, routes
 - Pact consumer-driven contract tests for provider APIs
 - Playwright end-to-end tests
@@ -210,7 +199,6 @@ npm run test:mutation       # Mutation testing (Stryker)
 ### Interactive Docs (Development Only)
 
 Start the dev server and visit:
-
 - **Swagger UI**: `http://localhost:3000/docs`
 - **OpenAPI JSON**: `http://localhost:3000/docs/openapi.json`
 
@@ -292,9 +280,11 @@ query {
 
 # Create a deposit
 mutation {
-  createDeposit(
-    input: { amount: "10000", phoneNumber: "+237670000000", provider: MTN }
-  ) {
+  createDeposit(input: {
+    amount: "10000"
+    phoneNumber: "+237670000000"
+    provider: MTN
+  }) {
     id
     status
   }
@@ -313,13 +303,11 @@ subscription {
 ### Authentication
 
 Most endpoints require JWT:
-
 ```bash
 Authorization: Bearer <token>
 ```
 
 Admin operations use API key:
-
 ```bash
 X-API-Key: <key>
 ```
@@ -328,31 +316,30 @@ X-API-Key: <key>
 
 ### Transaction Limits
 
-| Type    | Limit         | Purpose          |
-| ------- | ------------- | ---------------- |
-| Minimum | 100 XAF       | Prevent spam     |
+| Type | Limit | Purpose |
+|------|-------|---------|
+| Minimum | 100 XAF | Prevent spam |
 | Maximum | 1,000,000 XAF | Fraud prevention |
 
 ### KYC-Based Daily Limits
 
-| Level      | Daily Limit   | Requirements             |
-| ---------- | ------------- | ------------------------ |
-| Unverified | 10,000 XAF    | Email only               |
-| Basic      | 100,000 XAF   | ID + selfie              |
-| Full       | 1,000,000 XAF | Proof of address + video |
+| Level | Daily Limit | Requirements |
+|-------|-------------|--------------|
+| Unverified | 10,000 XAF | Email only |
+| Basic | 100,000 XAF | ID + selfie |
+| Full | 1,000,000 XAF | Proof of address + video |
 
 ### Provider Limits
 
-| Provider | Min     | Max           |
-| -------- | ------- | ------------- |
-| MTN      | 100 XAF | 500,000 XAF   |
-| Airtel   | 100 XAF | 1,000,000 XAF |
-| Orange   | 500 XAF | 750,000 XAF   |
+| Provider | Min | Max |
+|----------|-----|-----|
+| MTN | 100 XAF | 500,000 XAF |
+| Airtel | 100 XAF | 1,000,000 XAF |
+| Orange | 500 XAF | 750,000 XAF |
 
 ### AML Monitoring
 
 Auto-flagging of suspicious transactions:
-
 - Single transaction > 1,000,000 XAF
 - 24h total > 5,000,000 XAF
 - Rapid structuring (3+ mixed in 15 min)
@@ -362,19 +349,19 @@ Auto-flagging of suspicious transactions:
 
 ### Tech Stack
 
-| Layer                        | Technology                                                                       |
-| ---------------------------- | -------------------------------------------------------------------------------- |
-| **API Server**               | Node.js, TypeScript, Express, Apollo Server (GraphQL)                            |
-| **Database**                 | PostgreSQL 16 (primary + read replicas), Redis 7 (cache, sessions, pub/sub)      |
-| **Blockchain**               | Stellar SDK, Horizon API, Soroban smart contracts (Rust)                         |
-| **Job Processing**           | BullMQ workers, node-cron scheduled jobs                                         |
+| Layer | Technology |
+|-------|------------|
+| **API Server** | Node.js, TypeScript, Express, Apollo Server (GraphQL) |
+| **Database** | PostgreSQL 16 (primary + read replicas), Redis 7 (cache, sessions, pub/sub) |
+| **Blockchain** | Stellar SDK, Horizon API, Soroban smart contracts (Rust) |
+| **Job Processing** | BullMQ workers, node-cron scheduled jobs |
 | **Ingest (High-throughput)** | Go service (fasthttp) + Node.js service (Fastify), Redis Streams, NATS JetStream |
-| **Security**                 | Helmet, bcrypt, JWT, Speakeasy (TOTP), Casbin (RBAC), AES-256-GCM (PII)          |
-| **Monitoring**               | Prometheus, Datadog (dd-trace), Sentry, PagerDuty                                |
-| **Logging**                  | Structured JSON → Loki/Grafana (primary), ELK stack (secondary)                  |
-| **Edge**                     | Cloudflare Workers (`.well-known` caching)                                       |
-| **Infrastructure**           | Docker, Kubernetes (+ Helm, KEDA), Terraform (AWS)                               |
-| **CI/CD**                    | GitHub Actions (lint, test, build, deploy, rollback)                             |
+| **Security** | Helmet, bcrypt, JWT, Speakeasy (TOTP), Casbin (RBAC), AES-256-GCM (PII) |
+| **Monitoring** | Prometheus, Datadog (dd-trace), Sentry, PagerDuty |
+| **Logging** | Structured JSON → Loki/Grafana (primary), ELK stack (secondary) |
+| **Edge** | Cloudflare Workers (`.well-known` caching) |
+| **Infrastructure** | Docker, Kubernetes (+ Helm, KEDA), Terraform (AWS) |
+| **CI/CD** | GitHub Actions (lint, test, build, deploy, rollback) |
 
 ### Project Structure
 
@@ -446,7 +433,6 @@ HTTP method-based routing: `GET`/`HEAD`/`OPTIONS` → read replicas (round-robin
 ### Metrics
 
 Prometheus metrics at `/metrics`:
-
 - Transaction counts by status and provider
 - API response times (histograms)
 - Queue depths and job latencies
@@ -464,7 +450,6 @@ curl http://localhost:3000/health/lb  # Load balancer
 ### Logging
 
 Dual logging stack:
-
 - **Primary**: Structured JSON → Loki → Grafana (included in docker-compose)
 - **Secondary**: Filebeat → Logstash → Elasticsearch → Kibana (ELK stack configs in `elk/`)
 
@@ -492,7 +477,6 @@ The production Dockerfile uses a multi-stage build targeting < 200MB image size 
 ### Kubernetes
 
 Pre-built manifests in `k8s/` include:
-
 - **Deployment** — 3 replicas, rolling updates, startup/liveness/readiness probes, resource limits
 - **Worker Deployment** — Separate BullMQ worker pods
 - **KEDA Autoscaling** — Scale workers based on queue depth (threshold: 20 jobs, 1–20 replicas)
@@ -507,7 +491,6 @@ kubectl apply -f k8s/
 ### Terraform (AWS)
 
 Full AWS infrastructure in `terraform/`:
-
 - VPC with public/private subnets across multiple AZs
 - ECS Fargate for containerized deployment
 - RDS PostgreSQL with Multi-AZ (production)
@@ -525,7 +508,6 @@ terraform apply
 ### CI/CD
 
 GitHub Actions pipeline (`.github/workflows/ci.yml`):
-
 1. **Security** — npm audit, Snyk vulnerability scanning
 2. **Test** — Lint, Jest (with Postgres + Redis services), Playwright E2E, Codecov upload
 3. **Build** — TypeScript compilation
@@ -539,27 +521,23 @@ See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for detailed error codes and soluti
 ### Common Issues
 
 **Database connection fails:**
-
 ```bash
 pg_isready -h localhost -p 5432
 # Verify DATABASE_URL format
 ```
 
 **Redis connection fails:**
-
 ```bash
 redis-cli ping  # Should return PONG
 ```
 
 **Stellar transactions fail:**
-
 ```bash
 echo $STELLAR_NETWORK  # Should be 'testnet' or 'mainnet'
 curl https://horizon-testnet.stellar.org
 ```
 
 **Provider mock not working:**
-
 ```bash
 # Use docker-compose.dev.yml which includes the mock server
 docker compose -f docker-compose.dev.yml up
@@ -568,7 +546,6 @@ docker compose -f docker-compose.dev.yml up
 ## 🚨 Error Handling
 
 Standardized error codes organized by category:
-
 - **4000-4099**: Validation (HTTP 400)
 - **4010-4019**: Authentication (HTTP 401)
 - **4030-4039**: Authorization (HTTP 403)

--- a/README.md
+++ b/README.md
@@ -43,14 +43,16 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 ## 🚀 Key Features
 
 ### Core Platform
+
 - **Mobile Money Integration** — MTN MoMo, Airtel Money, Orange Money with circuit breaker, failover, and batch payouts
 - **Stellar Blockchain** — XLM, USDC, and custom asset support via Stellar SDK + Horizon API
 - **Dual API** — REST (40+ endpoints) and GraphQL (queries, mutations, and real-time subscriptions)
 - **Real-time Processing** — BullMQ job queues with Redis, admin dashboard at `/admin/queues`
 - **WebSocket** — Live transaction updates with JWT auth, per-user rooms, and Redis pub/sub for horizontal scaling
-- **Provider Mock Server** — Full mock for MTN + Airtel APIs for local development without real credentials
+- **Provider Mock Server** — Full mock for MTN, Airtel, Tigo, and Vodacom APIs for local development without real credentials
 
 ### Security & Compliance
+
 - **Multi-tier KYC** — Tiered identity verification with document upload (S3) and third-party verification (Entrust)
 - **AML Monitoring** — Auto-flagging of suspicious patterns (large transactions, rapid structuring, daily totals)
 - **Travel Rule Compliance** — FATF travel rule data collection for qualifying transactions
@@ -62,6 +64,7 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 - **PII Encryption** — AES-256-GCM encryption for sensitive data at rest
 
 ### Financial Engine
+
 - **Dynamic Fee Engine** — Configurable fee strategies with VIP tiers (25KB+ fee strategy engine)
 - **Transaction Limits** — Provider-specific and KYC-tiered daily limits
 - **Vault System** — Secure fund storage with distributed locking
@@ -71,6 +74,7 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 - **Reconciliation** — Provider reconciliation workflows
 
 ### Stellar Protocol (SEP) Support
+
 - **SEP-06** — Deposit and Withdrawal API
 - **SEP-10** — Web Authentication (challenge-response)
 - **SEP-12** — KYC API (customer CRUD with document upload)
@@ -78,10 +82,12 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 - **SEP-31** — Cross-Border Payments (send-side anchor)
 
 ### Smart Contracts
+
 - **Escrow Contract** — Soroban smart contract for escrowed payments (Rust)
 - **HTLC Contract** — Hash Time-Locked Contract for atomic cross-chain swaps (Rust)
 
 ### Notifications
+
 - **Email** — SendGrid integration
 - **SMS** — Twilio integration
 - **Push Notifications** — Firebase Cloud Messaging
@@ -89,6 +95,7 @@ The sender and recipient interact with their familiar mobile money apps. Stellar
 - **PagerDuty** — Operational alerting
 
 ### Developer Tools
+
 - **CLI** (`momo-cli`) — Admin tool for auth, status checks, and transaction retries
 - **Kotlin SDK** — Auto-generated from OpenAPI spec
 - **Postman Collections** — Pre-built API collections for testing
@@ -156,16 +163,19 @@ npm run seed  # Optional: development data
 ### 4. Run
 
 **Development (with provider mocks):**
+
 ```bash
 npm run docker:dev   # Starts app + Postgres + Redis + provider mock server
 ```
 
 **Development (standalone):**
+
 ```bash
 npm run dev
 ```
 
 **Production:**
+
 ```bash
 npm run build
 npm start
@@ -185,6 +195,7 @@ npm run test:mutation       # Mutation testing (Stryker)
 ```
 
 **Test infrastructure includes:**
+
 - Unit & integration tests across controllers, services, middleware, routes
 - Pact consumer-driven contract tests for provider APIs
 - Playwright end-to-end tests
@@ -199,6 +210,7 @@ npm run test:mutation       # Mutation testing (Stryker)
 ### Interactive Docs (Development Only)
 
 Start the dev server and visit:
+
 - **Swagger UI**: `http://localhost:3000/docs`
 - **OpenAPI JSON**: `http://localhost:3000/docs/openapi.json`
 
@@ -280,11 +292,9 @@ query {
 
 # Create a deposit
 mutation {
-  createDeposit(input: {
-    amount: "10000"
-    phoneNumber: "+237670000000"
-    provider: MTN
-  }) {
+  createDeposit(
+    input: { amount: "10000", phoneNumber: "+237670000000", provider: MTN }
+  ) {
     id
     status
   }
@@ -303,11 +313,13 @@ subscription {
 ### Authentication
 
 Most endpoints require JWT:
+
 ```bash
 Authorization: Bearer <token>
 ```
 
 Admin operations use API key:
+
 ```bash
 X-API-Key: <key>
 ```
@@ -316,30 +328,31 @@ X-API-Key: <key>
 
 ### Transaction Limits
 
-| Type | Limit | Purpose |
-|------|-------|---------|
-| Minimum | 100 XAF | Prevent spam |
+| Type    | Limit         | Purpose          |
+| ------- | ------------- | ---------------- |
+| Minimum | 100 XAF       | Prevent spam     |
 | Maximum | 1,000,000 XAF | Fraud prevention |
 
 ### KYC-Based Daily Limits
 
-| Level | Daily Limit | Requirements |
-|-------|-------------|--------------|
-| Unverified | 10,000 XAF | Email only |
-| Basic | 100,000 XAF | ID + selfie |
-| Full | 1,000,000 XAF | Proof of address + video |
+| Level      | Daily Limit   | Requirements             |
+| ---------- | ------------- | ------------------------ |
+| Unverified | 10,000 XAF    | Email only               |
+| Basic      | 100,000 XAF   | ID + selfie              |
+| Full       | 1,000,000 XAF | Proof of address + video |
 
 ### Provider Limits
 
-| Provider | Min | Max |
-|----------|-----|-----|
-| MTN | 100 XAF | 500,000 XAF |
-| Airtel | 100 XAF | 1,000,000 XAF |
-| Orange | 500 XAF | 750,000 XAF |
+| Provider | Min     | Max           |
+| -------- | ------- | ------------- |
+| MTN      | 100 XAF | 500,000 XAF   |
+| Airtel   | 100 XAF | 1,000,000 XAF |
+| Orange   | 500 XAF | 750,000 XAF   |
 
 ### AML Monitoring
 
 Auto-flagging of suspicious transactions:
+
 - Single transaction > 1,000,000 XAF
 - 24h total > 5,000,000 XAF
 - Rapid structuring (3+ mixed in 15 min)
@@ -349,19 +362,19 @@ Auto-flagging of suspicious transactions:
 
 ### Tech Stack
 
-| Layer | Technology |
-|-------|------------|
-| **API Server** | Node.js, TypeScript, Express, Apollo Server (GraphQL) |
-| **Database** | PostgreSQL 16 (primary + read replicas), Redis 7 (cache, sessions, pub/sub) |
-| **Blockchain** | Stellar SDK, Horizon API, Soroban smart contracts (Rust) |
-| **Job Processing** | BullMQ workers, node-cron scheduled jobs |
+| Layer                        | Technology                                                                       |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| **API Server**               | Node.js, TypeScript, Express, Apollo Server (GraphQL)                            |
+| **Database**                 | PostgreSQL 16 (primary + read replicas), Redis 7 (cache, sessions, pub/sub)      |
+| **Blockchain**               | Stellar SDK, Horizon API, Soroban smart contracts (Rust)                         |
+| **Job Processing**           | BullMQ workers, node-cron scheduled jobs                                         |
 | **Ingest (High-throughput)** | Go service (fasthttp) + Node.js service (Fastify), Redis Streams, NATS JetStream |
-| **Security** | Helmet, bcrypt, JWT, Speakeasy (TOTP), Casbin (RBAC), AES-256-GCM (PII) |
-| **Monitoring** | Prometheus, Datadog (dd-trace), Sentry, PagerDuty |
-| **Logging** | Structured JSON → Loki/Grafana (primary), ELK stack (secondary) |
-| **Edge** | Cloudflare Workers (`.well-known` caching) |
-| **Infrastructure** | Docker, Kubernetes (+ Helm, KEDA), Terraform (AWS) |
-| **CI/CD** | GitHub Actions (lint, test, build, deploy, rollback) |
+| **Security**                 | Helmet, bcrypt, JWT, Speakeasy (TOTP), Casbin (RBAC), AES-256-GCM (PII)          |
+| **Monitoring**               | Prometheus, Datadog (dd-trace), Sentry, PagerDuty                                |
+| **Logging**                  | Structured JSON → Loki/Grafana (primary), ELK stack (secondary)                  |
+| **Edge**                     | Cloudflare Workers (`.well-known` caching)                                       |
+| **Infrastructure**           | Docker, Kubernetes (+ Helm, KEDA), Terraform (AWS)                               |
+| **CI/CD**                    | GitHub Actions (lint, test, build, deploy, rollback)                             |
 
 ### Project Structure
 
@@ -433,6 +446,7 @@ HTTP method-based routing: `GET`/`HEAD`/`OPTIONS` → read replicas (round-robin
 ### Metrics
 
 Prometheus metrics at `/metrics`:
+
 - Transaction counts by status and provider
 - API response times (histograms)
 - Queue depths and job latencies
@@ -450,6 +464,7 @@ curl http://localhost:3000/health/lb  # Load balancer
 ### Logging
 
 Dual logging stack:
+
 - **Primary**: Structured JSON → Loki → Grafana (included in docker-compose)
 - **Secondary**: Filebeat → Logstash → Elasticsearch → Kibana (ELK stack configs in `elk/`)
 
@@ -477,6 +492,7 @@ The production Dockerfile uses a multi-stage build targeting < 200MB image size 
 ### Kubernetes
 
 Pre-built manifests in `k8s/` include:
+
 - **Deployment** — 3 replicas, rolling updates, startup/liveness/readiness probes, resource limits
 - **Worker Deployment** — Separate BullMQ worker pods
 - **KEDA Autoscaling** — Scale workers based on queue depth (threshold: 20 jobs, 1–20 replicas)
@@ -491,6 +507,7 @@ kubectl apply -f k8s/
 ### Terraform (AWS)
 
 Full AWS infrastructure in `terraform/`:
+
 - VPC with public/private subnets across multiple AZs
 - ECS Fargate for containerized deployment
 - RDS PostgreSQL with Multi-AZ (production)
@@ -508,6 +525,7 @@ terraform apply
 ### CI/CD
 
 GitHub Actions pipeline (`.github/workflows/ci.yml`):
+
 1. **Security** — npm audit, Snyk vulnerability scanning
 2. **Test** — Lint, Jest (with Postgres + Redis services), Playwright E2E, Codecov upload
 3. **Build** — TypeScript compilation
@@ -521,23 +539,27 @@ See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for detailed error codes and soluti
 ### Common Issues
 
 **Database connection fails:**
+
 ```bash
 pg_isready -h localhost -p 5432
 # Verify DATABASE_URL format
 ```
 
 **Redis connection fails:**
+
 ```bash
 redis-cli ping  # Should return PONG
 ```
 
 **Stellar transactions fail:**
+
 ```bash
 echo $STELLAR_NETWORK  # Should be 'testnet' or 'mainnet'
 curl https://horizon-testnet.stellar.org
 ```
 
 **Provider mock not working:**
+
 ```bash
 # Use docker-compose.dev.yml which includes the mock server
 docker compose -f docker-compose.dev.yml up
@@ -546,6 +568,7 @@ docker compose -f docker-compose.dev.yml up
 ## 🚨 Error Handling
 
 Standardized error codes organized by category:
+
 - **4000-4099**: Validation (HTTP 400)
 - **4010-4019**: Authentication (HTTP 401)
 - **4030-4039**: Authorization (HTTP 403)

--- a/scripts/provider-mock-server.ts
+++ b/scripts/provider-mock-server.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from "crypto";
 import { Server } from "http";
 import { Request, Response } from "express";
-import express = require("express");
+import express from "express";
 import mockServerConfig from "../src/config/mockServer";
 
 type MockScenario = "success" | "failed" | "pending";
 
 interface StoredTransaction {
-  provider: "mtn" | "airtel";
+  provider: "mtn" | "airtel" | "tigo" | "vodacom";
   scenario: MockScenario;
   createdAt: string;
 }
@@ -96,6 +96,26 @@ function getAirtelStatus(scenario: MockScenario): "TS" | "TF" | "TP" {
   return "TS";
 }
 
+function getTigoStatus(
+  scenario: MockScenario,
+): "SUCCESSFUL" | "FAILED" | "PENDING" {
+  if (scenario === "failed") return "FAILED";
+  if (scenario === "pending") return "PENDING";
+  return "SUCCESSFUL";
+}
+
+function getVodacomStatus(
+  scenario: MockScenario,
+): "COMPLETED" | "FAILED" | "PENDING" {
+  if (scenario === "failed") return "FAILED";
+  if (scenario === "pending") return "PENDING";
+  return "COMPLETED";
+}
+
+function getVodacomResponseCode(scenario: MockScenario): "INS-0" | "INS-1" {
+  return scenario === "failed" ? "INS-1" : "INS-0";
+}
+
 async function applyDelay(
   req: Request<unknown, unknown, MockRequestBody>,
 ): Promise<void> {
@@ -109,7 +129,7 @@ async function applyDelay(
 /**
  * Helper function to delay execution by a specified number of milliseconds.
  * Used to simulate webhook callback latency.
- * 
+ *
  * @param ms - The number of milliseconds to delay
  * @returns A Promise that resolves after the specified delay
  */
@@ -121,7 +141,7 @@ async function delay(ms: number): Promise<void> {
  * Fires a webhook callback to a configured webhook URL if available.
  * Respects the webhook latency configuration to simulate realistic delays
  * before webhook delivery.
- * 
+ *
  * @param referenceId - The transaction reference ID to include in the webhook payload
  * @param provider - The payment provider (mtn or airtel)
  * @param status - The transaction status
@@ -134,7 +154,10 @@ async function fireWebhookCallback(
   webhookUrl?: string,
 ): Promise<void> {
   // Apply webhook latency if enabled
-  if (mockServerConfig.webhookLatencyEnabled && mockServerConfig.webhookLatencyMs > 0) {
+  if (
+    mockServerConfig.webhookLatencyEnabled &&
+    mockServerConfig.webhookLatencyMs > 0
+  ) {
     await delay(mockServerConfig.webhookLatencyMs);
   }
 
@@ -149,14 +172,20 @@ async function fireWebhookCallback(
     try {
       // Fire webhook asynchronously without blocking the response
       // In a real scenario, this would be sent via HTTP request
-      console.log(`[webhook] Firing ${provider} webhook to ${webhookUrl}:`, payload);
+      console.log(
+        `[webhook] Firing ${provider} webhook to ${webhookUrl}:`,
+        payload,
+      );
       // Actual HTTP request would go here (e.g., fetch or axios)
       // await fetch(webhookUrl, { method: 'POST', body: JSON.stringify(payload) });
     } catch (error) {
       console.error(`[webhook] Error firing ${provider} webhook:`, error);
     }
   } else {
-    console.log(`[webhook] Webhook callback for ${provider} (no URL configured):`, payload);
+    console.log(
+      `[webhook] Webhook callback for ${provider} (no URL configured):`,
+      payload,
+    );
   }
 }
 
@@ -182,7 +211,7 @@ export function createProviderMockApp() {
   app.get("/health", (_req: Request, res: Response) => {
     res.json({
       status: "ok",
-      providers: ["mtn", "airtel"],
+      providers: ["mtn", "airtel", "tigo", "vodacom"],
     });
   });
 
@@ -333,9 +362,11 @@ export function createProviderMockApp() {
       });
 
       // Fire webhook callback asynchronously after response is sent
-      fireWebhookCallback(referenceId, "airtel", getAirtelStatus(scenario)).catch(
-        console.error,
-      );
+      fireWebhookCallback(
+        referenceId,
+        "airtel",
+        getAirtelStatus(scenario),
+      ).catch(console.error);
     },
   );
 
@@ -439,9 +470,228 @@ export function createProviderMockApp() {
       });
 
       // Fire webhook callback asynchronously after response is sent
-      fireWebhookCallback(referenceId, "airtel", getAirtelStatus(scenario)).catch(
-        console.error,
+      fireWebhookCallback(
+        referenceId,
+        "airtel",
+        getAirtelStatus(scenario),
+      ).catch(console.error);
+    },
+  );
+
+  app.post(
+    "/tigo/oauth/token",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      res.json({
+        access_token: "mock-tigo-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    },
+  );
+
+  app.post(
+    "/tigo/payments/collect",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      const referenceId = getReferenceId(req, "tigo-pay");
+
+      transactions.set(referenceId, {
+        provider: "tigo",
+        scenario,
+        createdAt: new Date().toISOString(),
+      });
+
+      if (scenario === "failed") {
+        return res.status(400).json({
+          status: "FAILED",
+          referenceId,
+          message: "Mock Tigo payment collection failure",
+        });
+      }
+
+      return res.status(202).json({
+        status: getTigoStatus(scenario),
+        referenceId,
+        message: "Mock Tigo payment collection accepted",
+      });
+    },
+  );
+
+  app.post(
+    "/tigo/payments/disburse",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      const referenceId = getReferenceId(req, "tigo-payout");
+
+      transactions.set(referenceId, {
+        provider: "tigo",
+        scenario,
+        createdAt: new Date().toISOString(),
+      });
+
+      if (scenario === "failed") {
+        return res.status(400).json({
+          status: "FAILED",
+          referenceId,
+          message: "Mock Tigo payout failure",
+        });
+      }
+
+      return res.status(202).json({
+        status: getTigoStatus(scenario),
+        referenceId,
+        message: "Mock Tigo payout accepted",
+      });
+    },
+  );
+
+  app.get(
+    "/tigo/payments/status/:referenceId",
+    async (
+      req: Request<{ referenceId: string }, unknown, MockRequestBody>,
+      res: Response,
+    ) => {
+      await applyDelay(req);
+
+      const stored = transactions.get(req.params.referenceId);
+      const scenario = stored?.scenario || getScenario(req);
+
+      return res.json({
+        referenceId: req.params.referenceId,
+        status: getTigoStatus(scenario),
+      });
+    },
+  );
+
+  app.get(
+    "/tigo/account/balance",
+    async (req: Request<unknown, unknown, MockRequestBody>, res: Response) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      if (scenario === "failed") {
+        return res.status(503).json({
+          message: "Mock Tigo balance service unavailable",
+        });
+      }
+
+      return res.json({
+        availableBalance: DEFAULT_BALANCE,
+        currency: process.env.TIGO_CURRENCY || "TZS",
+      });
+    },
+  );
+
+  app.get(
+    "/vodacom/:market/getSession/",
+    async (
+      req: Request<{ market: string }, unknown, MockRequestBody>,
+      res: Response,
+    ) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      if (scenario === "failed") {
+        return res.status(401).json({
+          output_ResponseCode: "INS-1",
+          output_ResponseDesc: "Mock Vodacom session failure",
+        });
+      }
+
+      return res.json({
+        output_ResponseCode: "INS-0",
+        output_ResponseDesc: "Success",
+        output_SessionID: `mock-${req.params.market}-session-token`,
+      });
+    },
+  );
+
+  app.post(
+    "/vodacom/:market/c2bPayment/singleStage/",
+    async (
+      req: Request<{ market: string }, unknown, MockRequestBody>,
+      res: Response,
+    ) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      const referenceId = getReferenceId(req, "vodacom-c2b");
+      const responseCode = getVodacomResponseCode(scenario);
+
+      transactions.set(referenceId, {
+        provider: "vodacom",
+        scenario,
+        createdAt: new Date().toISOString(),
+      });
+
+      return res.status(responseCode === "INS-0" ? 200 : 400).json({
+        output_ResponseCode: responseCode,
+        output_ResponseDesc:
+          responseCode === "INS-0"
+            ? "Success"
+            : "Mock Vodacom payment request failure",
+        output_TransactionID: referenceId,
+        output_TransactionStatus: getVodacomStatus(scenario),
+      });
+    },
+  );
+
+  app.post(
+    "/vodacom/:market/b2cPayment/singleStage/",
+    async (
+      req: Request<{ market: string }, unknown, MockRequestBody>,
+      res: Response,
+    ) => {
+      await applyDelay(req);
+
+      const scenario = getScenario(req);
+      const referenceId = getReferenceId(req, "vodacom-b2c");
+      const responseCode = getVodacomResponseCode(scenario);
+
+      transactions.set(referenceId, {
+        provider: "vodacom",
+        scenario,
+        createdAt: new Date().toISOString(),
+      });
+
+      return res.status(responseCode === "INS-0" ? 200 : 400).json({
+        output_ResponseCode: responseCode,
+        output_ResponseDesc:
+          responseCode === "INS-0" ? "Success" : "Mock Vodacom payout failure",
+        output_TransactionID: referenceId,
+        output_TransactionStatus: getVodacomStatus(scenario),
+      });
+    },
+  );
+
+  app.get(
+    "/vodacom/:market/queryTransactionStatus/",
+    async (
+      req: Request<{ market: string }, unknown, MockRequestBody>,
+      res: Response,
+    ) => {
+      await applyDelay(req);
+
+      const referenceId = String(
+        req.query.input_QueryReference || req.query.referenceId || "",
       );
+      const stored = transactions.get(referenceId);
+      const scenario = stored?.scenario || getScenario(req);
+      const responseCode = getVodacomResponseCode(scenario);
+
+      return res.status(responseCode === "INS-0" ? 200 : 400).json({
+        output_ResponseCode: responseCode,
+        output_ResponseDesc:
+          responseCode === "INS-0" ? "Success" : "Mock Vodacom status failure",
+        output_TransactionID: referenceId,
+        output_TransactionStatus: getVodacomStatus(scenario),
+      });
     },
   );
 

--- a/tests/scripts/providerMockServer.test.ts
+++ b/tests/scripts/providerMockServer.test.ts
@@ -1,5 +1,8 @@
 import { createProviderMockApp } from "../../scripts/provider-mock-server";
-import request = require("supertest");
+import mockServerConfig from "../../src/config/mockServer";
+import request from "supertest";
+
+mockServerConfig.webhookLatencyEnabled = false;
 
 describe("provider mock server", () => {
   const app = createProviderMockApp();
@@ -10,7 +13,7 @@ describe("provider mock server", () => {
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
       status: "ok",
-      providers: ["mtn", "airtel"],
+      providers: ["mtn", "airtel", "tigo", "vodacom"],
     });
   });
 
@@ -74,6 +77,90 @@ describe("provider mock server", () => {
     expect(response.body.status).toEqual({
       success: false,
       code: "BALANCE_UNAVAILABLE",
+    });
+  });
+
+  it("supports Tigo collection, status, payout, and balance mock routes", async () => {
+    const collectionResponse = await request(app)
+      .post("/tigo/payments/collect?scenario=pending")
+      .send({ externalId: "tigo-ref-123" });
+
+    expect(collectionResponse.status).toBe(202);
+    expect(collectionResponse.body).toMatchObject({
+      referenceId: "tigo-ref-123",
+      status: "PENDING",
+    });
+
+    const statusResponse = await request(app).get(
+      "/tigo/payments/status/tigo-ref-123",
+    );
+
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body).toMatchObject({
+      referenceId: "tigo-ref-123",
+      status: "PENDING",
+    });
+
+    const payoutResponse = await request(app)
+      .post("/tigo/payments/disburse")
+      .send({ reference: "tigo-payout-123" });
+
+    expect(payoutResponse.status).toBe(202);
+    expect(payoutResponse.body).toMatchObject({
+      referenceId: "tigo-payout-123",
+      status: "SUCCESSFUL",
+    });
+
+    const balanceResponse = await request(app).get("/tigo/account/balance");
+
+    expect(balanceResponse.status).toBe(200);
+    expect(balanceResponse.body).toMatchObject({
+      availableBalance: "100000",
+      currency: "TZS",
+    });
+  });
+
+  it("supports Vodacom session, c2b, b2c, and status mock routes", async () => {
+    const sessionResponse = await request(app).get(
+      "/vodacom/vodacomTZN/getSession/",
+    );
+
+    expect(sessionResponse.status).toBe(200);
+    expect(sessionResponse.body).toMatchObject({
+      output_ResponseCode: "INS-0",
+      output_SessionID: "mock-vodacomTZN-session-token",
+    });
+
+    const c2bResponse = await request(app)
+      .post("/vodacom/vodacomTZN/c2bPayment/singleStage/?scenario=pending")
+      .send({ reference: "vodacom-c2b-123" });
+
+    expect(c2bResponse.status).toBe(200);
+    expect(c2bResponse.body).toMatchObject({
+      output_ResponseCode: "INS-0",
+      output_TransactionID: "vodacom-c2b-123",
+      output_TransactionStatus: "PENDING",
+    });
+
+    const statusResponse = await request(app)
+      .get("/vodacom/vodacomTZN/queryTransactionStatus/")
+      .query({ input_QueryReference: "vodacom-c2b-123" });
+
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body).toMatchObject({
+      output_TransactionID: "vodacom-c2b-123",
+      output_TransactionStatus: "PENDING",
+    });
+
+    const b2cResponse = await request(app)
+      .post("/vodacom/vodacomTZN/b2cPayment/singleStage/")
+      .send({ reference: "vodacom-b2c-123" });
+
+    expect(b2cResponse.status).toBe(200);
+    expect(b2cResponse.body).toMatchObject({
+      output_ResponseCode: "INS-0",
+      output_TransactionID: "vodacom-b2c-123",
+      output_TransactionStatus: "COMPLETED",
     });
   });
 });


### PR DESCRIPTION
## Summary
Add local mock API support for the existing Tigo and Vodacom mobile money provider integrations.

## Changes
- add Tigo token, collection, disbursement, status, and balance mock routes
- add Vodacom session, C2B, B2C, and transaction status mock routes
- expose Tigo and Vodacom in the provider mock health endpoint
- add route-level Jest coverage for both providers

## Testing
- `npx lint-staged`
- `npx jest tests/scripts/providerMockServer.test.ts --runInBand --forceExit`
- `npx eslint scripts/provider-mock-server.ts tests/scripts/providerMockServer.test.ts`
- `npx prettier --check scripts/provider-mock-server.ts tests/scripts/providerMockServer.test.ts`
- `git diff --check`

## Pre-existing repository failures
- `npm run type-check` and `npm run build` currently fail on untouched `src/index.ts` lines 602 and 604 due to a syntax error already present on `upstream/main`.
- `npm run lint` currently reports pre-existing repository-wide lint errors. The changed TypeScript files pass ESLint directly.

## Related Issue
Closes #1036
