### PR TITLE
Add Sentry release tracking and deployment registration integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ env:
   IMAGE: ${{ github.repository }}
   DEPLOY_TIMEOUT: "120s"
   HEALTHCHECK_RETRIES: "10"
+  SENTRY_RELEASE: ${{ github.sha }}
 
 jobs:
   deploy:
@@ -53,6 +54,32 @@ jobs:
             ${{ env.IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+        - name: Install Sentry CLI
+          if: steps.check_deploy.outputs.deploy_available == 'true'
+          run: |
+            curl -sL https://sentry.io/get-cli/ | bash
+        - name: Create Sentry release
+          if: steps.check_deploy.outputs.deploy_available == 'true'
+          env:
+            SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+            SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          run: |
+            sentry-cli releases new -p ${{ secrets.SENTRY_PROJECT }} ${{ env.SENTRY_RELEASE }}
+        - name: Associate commits with release
+          if: steps.check_deploy.outputs.deploy_available == 'true'
+          env:
+            SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          run: |
+            sentry-cli releases set-commits --auto ${{ env.SENTRY_RELEASE }}
+        - name: Finalize Sentry release
+          if: steps.check_deploy.outputs.deploy_available == 'true'
+          env:
+            SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          run: |
+            sentry-cli releases finalize ${{ env.SENTRY_RELEASE }}
 
       # ── Kubernetes deploy ──────────────────────────────────────────────────
       - name: Configure kubectl
@@ -98,6 +125,14 @@ jobs:
           done
           echo "Healthcheck failed after ${{ env.HEALTHCHECK_RETRIES }} attempts"
           exit 1
+        - name: Register Sentry deployment
+          if: steps.check_deploy.outputs.deploy_available == 'true' && steps.healthcheck.outcome == 'success'
+          env:
+            SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+            SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          run: |
+            sentry-cli releases deploys ${{ env.SENTRY_RELEASE }} new -e production
 
       # ── Automated rollback ─────────────────────────────────────────────────
       - name: Rollback on failure

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ import { layeredCache } from "./services/layeredCache";
 dotenv.config();
 
 if (process.env.SENTRY_DSN) {
-  initSentry(process.env.SENTRY_DSN);
+  initSentry(process.env.SENTRY_DSN, process.env.SENTRY_RELEASE);
 }
 
 validateStellarNetwork();

--- a/src/middleware/sentry.ts
+++ b/src/middleware/sentry.ts
@@ -74,10 +74,11 @@ export const sentryBreadcrumbMiddleware = (
 /**
  * Global Sentry configuration with PII scrubbing in beforeSend
  */
-export const initSentry = (dsn: string) => {
+export const initSentry = (dsn: string, release?: string) => {
   Sentry.init({
     dsn,
     environment: process.env.NODE_ENV || "development",
+    release: release || process.env.SENTRY_RELEASE,
     beforeSend(event) {
       if (event.request?.data) {
         event.request.data = scrubSensitiveData(event.request.data);


### PR DESCRIPTION
This pr closes #1020 
Implemented Sentry release tracking and deployment registration.

- Added `release` support to Sentry initialization (`src/middleware/sentry.ts`) and passed the release ID from the environment in `src/index.ts`.
- Set `SENTRY_RELEASE` (Git SHA) in the GitHub Actions workflow.
- Integrated Sentry CLI steps:
  * Install CLI
  * Create a new release
  * Auto‑associate commits
  * Finalize the release
  * Register a production deployment after a successful health‑check
- No functional changes to the API; only adds observability and links errors to exact commits.

Requires the repository secrets `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` to be configured.