### PR TITLE
feat(ci): integrate Pact contract tests into CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,21 @@ jobs:
           NODE_ENV: test
           CI: true
 
+      - name: Run Pact Contract Tests
+        run: npm run test:pact
+        continue-on-error: false
+        env:
+          CI: true
+
+      - name: Upload Pact files as artifacts
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: pact-contracts
+          path: pacts/
+          retention-days: 30
+          if-no-files-found: ignore
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 

--- a/pacts/MobileMoneyService-AirtelMoneyAPI.json
+++ b/pacts/MobileMoneyService-AirtelMoneyAPI.json
@@ -1,0 +1,696 @@
+{
+  "consumer": {
+    "name": "MobileMoneyService"
+  },
+  "interactions": [
+    {
+      "description": "a request for an Airtel access token",
+      "providerStates": [
+        {
+          "name": "valid Airtel API credentials"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Basic dGVzdC1rZXk6dGVzdC1zZWNyZXQ=",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Basic [A-Za-z0-9+/=]+$"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/auth/oauth2/token"
+      },
+      "response": {
+        "body": {
+          "access_token": "eyJhbGciOiJSUzI1NiJ9.airtel",
+          "expires_in": 3600,
+          "token_type": "Bearer"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.access_token": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.expires_in": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.token_type": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request for the Airtel operational balance",
+      "providerStates": [
+        {
+          "name": "Airtel account has funds"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer test-airtel-bearer-token",
+          "X-Country": "NG",
+          "X-Currency": "NGN"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            },
+            "X-Country": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "X-Currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "GET",
+        "path": "/standard/v1/users/balance"
+      },
+      "response": {
+        "body": {
+          "data": {
+            "availableBalance": "5000.00",
+            "currency": "NGN"
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data.availableBalance": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to check a failed transaction status",
+      "providerStates": [
+        {
+          "name": "Airtel transaction has failed"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer test-airtel-bearer-token",
+          "X-Country": "NG",
+          "X-Currency": "NGN"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            },
+            "X-Country": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "X-Currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "GET",
+        "path": "/standard/v1/payments/AIRTEL-1700000000000"
+      },
+      "response": {
+        "body": {
+          "data": {
+            "transaction": {
+              "id": "AIRTEL-1700000000000",
+              "message": "Insufficient funds",
+              "status": "TF"
+            }
+          },
+          "status": {
+            "code": "200",
+            "success": false
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data.transaction.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data.transaction.message": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status.code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status.success": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to check a successful transaction status",
+      "providerStates": [
+        {
+          "name": "Airtel transaction is successful"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer test-airtel-bearer-token",
+          "X-Country": "NG",
+          "X-Currency": "NGN"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            },
+            "X-Country": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "X-Currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "GET",
+        "path": "/standard/v1/payments/AIRTEL-1700000000000"
+      },
+      "response": {
+        "body": {
+          "data": {
+            "transaction": {
+              "id": "AIRTEL-1700000000000",
+              "message": "Paid",
+              "status": "TS"
+            }
+          },
+          "status": {
+            "code": "200",
+            "success": true
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data.transaction.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data.transaction.message": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status.code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status.success": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to collect payment from a subscriber",
+      "providerStates": [
+        {
+          "name": "Airtel collection service is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "reference": "AIRTEL-1700000000000",
+          "subscriber": {
+            "country": "NG",
+            "currency": "NGN",
+            "msisdn": "2348012345678"
+          },
+          "transaction": {
+            "amount": 100,
+            "country": "NG",
+            "currency": "NGN",
+            "id": "AIRTEL-1700000000000"
+          }
+        },
+        "headers": {
+          "Authorization": "Bearer test-airtel-bearer-token",
+          "Content-Type": "application/json",
+          "X-Country": "NG",
+          "X-Currency": "NGN"
+        },
+        "matchingRules": {
+          "body": {
+            "$.reference": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.subscriber.country": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.subscriber.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.subscriber.msisdn": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.amount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.country": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            },
+            "X-Country": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "X-Currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/merchant/v1/payments/"
+      },
+      "response": {
+        "body": {
+          "data": {
+            "transaction": {
+              "id": "AIRTEL-1700000000000",
+              "status": "TP"
+            }
+          },
+          "status": {
+            "code": "200",
+            "success": true
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data.transaction.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data.transaction.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status.code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status.success": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to disburse funds to a subscriber",
+      "providerStates": [
+        {
+          "name": "Airtel disbursement service is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "payee": {
+            "msisdn": "2348012345678"
+          },
+          "reference": "AIRTEL-PAYOUT-1700000000000",
+          "transaction": {
+            "amount": 50,
+            "id": "AIRTEL-PAYOUT-1700000000000"
+          }
+        },
+        "headers": {
+          "Authorization": "Bearer test-airtel-bearer-token",
+          "Content-Type": "application/json",
+          "X-Country": "NG",
+          "X-Currency": "NGN"
+        },
+        "matchingRules": {
+          "body": {
+            "$.payee.msisdn": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.reference": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.amount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            },
+            "X-Country": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "X-Currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/standard/v1/disbursements/"
+      },
+      "response": {
+        "body": {
+          "data": {
+            "transaction": {
+              "id": "AIRTEL-PAYOUT-1700000000000",
+              "status": "TS"
+            }
+          },
+          "status": {
+            "code": "200",
+            "success": true
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data.transaction.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data.transaction.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status.code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status.success": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-js": {
+      "version": "16.3.0"
+    },
+    "pactRust": {
+      "ffi": "0.5.3",
+      "models": "1.3.9"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "AirtelMoneyAPI"
+  }
+}

--- a/pacts/MobileMoneyService-MTNMoMoAPI.json
+++ b/pacts/MobileMoneyService-MTNMoMoAPI.json
@@ -1,0 +1,470 @@
+{
+  "consumer": {
+    "name": "MobileMoneyService"
+  },
+  "interactions": [
+    {
+      "description": "a request for an access token",
+      "providerStates": [
+        {
+          "name": "valid MTN API credentials"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Basic dGVzdC1hcGkta2V5OnRlc3QtYXBpLXNlY3JldA==",
+          "Ocp-Apim-Subscription-Key": "test-subscription-key"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Basic [A-Za-z0-9+/=]+$"
+                }
+              ]
+            },
+            "Ocp-Apim-Subscription-Key": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/collection/token/"
+      },
+      "response": {
+        "body": {
+          "access_token": "eyJhbGciOiJSUzI1NiJ9.test",
+          "expires_in": 3600,
+          "token_type": "access_token"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.access_token": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.expires_in": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.token_type": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request for the operational balance",
+      "providerStates": [
+        {
+          "name": "MTN disbursement account has funds"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer test-bearer-token",
+          "Ocp-Apim-Subscription-Key": "test-subscription-key",
+          "X-Target-Environment": "sandbox"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            },
+            "Ocp-Apim-Subscription-Key": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "X-Target-Environment": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "GET",
+        "path": "/disbursement/v1_0/account/balance"
+      },
+      "response": {
+        "body": {
+          "availableBalance": "1000.00",
+          "currency": "EUR"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.availableBalance": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to collect payment from a subscriber",
+      "providerStates": [
+        {
+          "name": "MTN collection service is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "amount": "100",
+          "currency": "EUR",
+          "externalId": "ext-001",
+          "payeeNote": "Deposit",
+          "payer": {
+            "partyId": "46733123450",
+            "partyIdType": "MSISDN"
+          },
+          "payerMessage": "Payment for Stellar deposit"
+        },
+        "headers": {
+          "Authorization": "Bearer test-bearer-token",
+          "Content-Type": "application/json",
+          "Ocp-Apim-Subscription-Key": "test-subscription-key",
+          "X-Reference-Id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+          "X-Target-Environment": "sandbox"
+        },
+        "matchingRules": {
+          "body": {
+            "$.amount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.externalId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.payeeNote": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.payer.partyId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.payerMessage": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            },
+            "Ocp-Apim-Subscription-Key": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "X-Reference-Id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+                }
+              ]
+            },
+            "X-Target-Environment": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/collection/v1_0/requesttopay"
+      },
+      "response": {
+        "status": 202
+      }
+    },
+    {
+      "description": "a request to get a failed transaction status",
+      "providerStates": [
+        {
+          "name": "MTN transaction exists and has failed"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer test-bearer-token",
+          "Ocp-Apim-Subscription-Key": "test-subscription-key",
+          "X-Target-Environment": "sandbox"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            },
+            "Ocp-Apim-Subscription-Key": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "X-Target-Environment": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "GET",
+        "path": "/collection/v1_0/requesttopay/f47ac10b-58cc-4372-a567-0e02b2c3d479"
+      },
+      "response": {
+        "body": {
+          "reason": "PAYER_NOT_FOUND",
+          "status": "FAILED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.reason": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to get transaction status",
+      "providerStates": [
+        {
+          "name": "MTN transaction exists and is successful"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer test-bearer-token",
+          "Ocp-Apim-Subscription-Key": "test-subscription-key",
+          "X-Target-Environment": "sandbox"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            },
+            "Ocp-Apim-Subscription-Key": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "X-Target-Environment": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "GET",
+        "path": "/collection/v1_0/requesttopay/f47ac10b-58cc-4372-a567-0e02b2c3d479"
+      },
+      "response": {
+        "body": {
+          "amount": "100",
+          "currency": "EUR",
+          "externalId": "ext-001",
+          "financialTransactionId": "363440463",
+          "payer": {
+            "partyId": "46733123450",
+            "partyIdType": "MSISDN"
+          },
+          "status": "SUCCESSFUL"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.amount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.externalId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.financialTransactionId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.payer.partyId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-js": {
+      "version": "16.3.0"
+    },
+    "pactRust": {
+      "ffi": "0.5.3",
+      "models": "1.3.9"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "MTNMoMoAPI"
+  }
+}

--- a/pacts/MobileMoneyService-OrangeMoneyAPI.json
+++ b/pacts/MobileMoneyService-OrangeMoneyAPI.json
@@ -1,0 +1,551 @@
+{
+  "consumer": {
+    "name": "MobileMoneyService"
+  },
+  "interactions": [
+    {
+      "description": "a client credentials token request",
+      "providerStates": [
+        {
+          "name": "valid Orange API credentials"
+        }
+      ],
+      "request": {
+        "body": "grant_type=client_credentials",
+        "headers": {
+          "Authorization": "Basic dGVzdC1rZXk6dGVzdC1zZWNyZXQ=",
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Basic [A-Za-z0-9+/=]+$"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/oauth/token"
+      },
+      "response": {
+        "body": {
+          "access_token": "eyJhbGciOiJSUzI1NiJ9.orange",
+          "expires_in": 3600,
+          "token_type": "Bearer"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.access_token": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.expires_in": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.token_type": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a collection request with an invalid bearer token",
+      "providerStates": [
+        {
+          "name": "Orange API rejects invalid token"
+        }
+      ],
+      "request": {
+        "body": {
+          "reference": "ORANGE-PAYMENT-1700000000000",
+          "subscriber": {
+            "msisdn": "+237600000000"
+          },
+          "transaction": {
+            "amount": 1000,
+            "currency": "XAF",
+            "id": "ORANGE-PAYMENT-1700000000000"
+          }
+        },
+        "headers": {
+          "Authorization": "Bearer invalid-token",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/v1/payments/collect"
+      },
+      "response": {
+        "body": {
+          "message": "Unauthorized"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.message": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 401
+      }
+    },
+    {
+      "description": "a request to check a completed transaction status",
+      "providerStates": [
+        {
+          "name": "Orange transaction is completed"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer test-orange-bearer-token"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            }
+          }
+        },
+        "method": "GET",
+        "path": "/v1/payments/ORANGE-PAYMENT-1700000000000"
+      },
+      "response": {
+        "body": {
+          "amount": 1000,
+          "currency": "XAF",
+          "id": "ORANGE-PAYMENT-1700000000000",
+          "status": "COMPLETED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.amount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to check a failed transaction status",
+      "providerStates": [
+        {
+          "name": "Orange transaction has failed"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer test-orange-bearer-token"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            }
+          }
+        },
+        "method": "GET",
+        "path": "/v1/payments/ORANGE-PAYMENT-1700000000000"
+      },
+      "response": {
+        "body": {
+          "id": "ORANGE-PAYMENT-1700000000000",
+          "reason": "INSUFFICIENT_FUNDS",
+          "status": "FAILED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.reason": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to check a non-existent transaction",
+      "providerStates": [
+        {
+          "name": "Orange transaction does not exist"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer test-orange-bearer-token"
+        },
+        "matchingRules": {
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            }
+          }
+        },
+        "method": "GET",
+        "path": "/v1/payments/ORANGE-PAYMENT-UNKNOWN"
+      },
+      "response": {
+        "body": {
+          "message": "Transaction not found"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.message": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 404
+      }
+    },
+    {
+      "description": "a request to collect payment from a subscriber",
+      "providerStates": [
+        {
+          "name": "Orange collection service is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "reference": "ORANGE-PAYMENT-1700000000000",
+          "subscriber": {
+            "msisdn": "+237600000000"
+          },
+          "transaction": {
+            "amount": 1000,
+            "currency": "XAF",
+            "id": "ORANGE-PAYMENT-1700000000000"
+          }
+        },
+        "headers": {
+          "Authorization": "Bearer test-orange-bearer-token",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.reference": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.subscriber.msisdn": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.amount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/v1/payments/collect"
+      },
+      "response": {
+        "body": {
+          "id": "ORANGE-PAYMENT-1700000000000",
+          "status": "PENDING"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to disburse funds to a subscriber",
+      "providerStates": [
+        {
+          "name": "Orange disbursement service is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "payee": {
+            "msisdn": "+237600000001"
+          },
+          "reference": "ORANGE-PAYOUT-1700000000000",
+          "transaction": {
+            "amount": 500,
+            "currency": "XAF",
+            "id": "ORANGE-PAYOUT-1700000000000"
+          }
+        },
+        "headers": {
+          "Authorization": "Bearer test-orange-bearer-token",
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.payee.msisdn": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.reference": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.amount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transaction.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {
+            "Authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^Bearer .+$"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/v1/payments/disburse"
+      },
+      "response": {
+        "body": {
+          "id": "ORANGE-PAYOUT-1700000000000",
+          "status": "SUCCESS"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-js": {
+      "version": "16.3.0"
+    },
+    "pactRust": {
+      "ffi": "0.5.3",
+      "models": "1.3.9"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "OrangeMoneyAPI"
+  }
+}

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -13,7 +13,7 @@ jest.mock("axios", () => {
   const originalAxios = jest.requireActual("axios") as any;
   return {
     ...originalAxios,
-    get: jest.fn((url: string) => {
+    get: jest.fn((url: string, config?: any) => {
       if (url === "https://scsanctions.un.org/resources/xml/en/consolidated.xml") {
         return Promise.resolve({
           data: `
@@ -45,10 +45,10 @@ jest.mock("axios", () => {
         });
       }
       // Fallback to original or error for unhandled external URLs in tests
-      if (url.startsWith("http")) {
+      if (url.startsWith("http") && !url.includes("127.0.0.1") && !url.includes("localhost")) {
         return Promise.reject(new Error(`Unmocked external request to ${url}`));
       }
-      return originalAxios.get(url);
+      return originalAxios.get(url, config);
     }),
   };
 });


### PR DESCRIPTION
# Close #910 

- Resolve global Axios mock overriding local Pact mock server connections

- Add Pact tests runner step and pact JSON contracts artifact upload step to main GitHub Actions CI/CD workflow

- Include generated JSON contracts in the repository for reference

## Description

Integrates Pact contract testing into the GitHub Actions CI/CD pipeline and resolves local Axios interception issues blocking the Pact mock servers.

## Related Issue

Fixes #910

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Bypassed the global Axios mock in [jest.setup.ts](file:///c:/Users/USER/Downloads/mobile-money/tests/jest.setup.ts) for `localhost`/`127.0.0.1` addresses to enable connections to the Pact mock servers.
- Modified the global Axios GET mock signature to forward the request configuration/headers parameter.
- Integrated the execution step `npm run test:pact` into the `test` job in [ci.yml](file:///c:/Users/USER/Downloads/mobile-money/.github/workflows/ci.yml).
- Configured the workflow to upload generated contracts under the `pacts/` directory using `actions/upload-artifact@v4`.
- Checked in the generated Pact JSON contract files to the repository under `pacts/` for tracking.

## Testing

- Verified execution locally by running `npm run test:pact`. All 18 tests passed across Airtel, Orange, and MTN contract suites.
- Confirmed output files are correctly written to `pacts/`.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed my code
- [x] Commented complex code
- [x] Updated documentation
- [x] No new warnings
- [x] Added tests (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

N/A