### PR TITLE
feat: add Airtel Money region-aware currency handling for East Africa

### DIFF
--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1,4 +1,5 @@
 import { getConfigValue } from './appConfig';
+import { resolveAirtelRegion, AIRTEL_REGION_MAP } from '../services/mobilemoney/providers/airtel-regions';
 
 export enum MobileMoneyProvider {
   MTN = "mtn",
@@ -64,21 +65,43 @@ export function validateProviderLimits(
 ): { valid: boolean; error?: string } {
   const limits = getProviderLimits(provider);
 
+  // Use region-aware currency label for Airtel
+  const currencyLabel = provider === MobileMoneyProvider.AIRTEL
+    ? getAirtelCurrencyLabel()
+    : "XAF";
+
   if (amount < limits.minAmount) {
     return {
       valid: false,
-      error: `Amount ${amount} XAF is below the minimum of ${limits.minAmount} XAF for ${provider.toUpperCase()}. Allowed range: ${limits.minAmount} - ${limits.maxAmount} XAF`,
+      error: `Amount ${amount} ${currencyLabel} is below the minimum of ${limits.minAmount} ${currencyLabel} for ${provider.toUpperCase()}. Allowed range: ${limits.minAmount} - ${limits.maxAmount} ${currencyLabel}`,
     };
   }
 
   if (amount > limits.maxAmount) {
     return {
       valid: false,
-      error: `Amount ${amount} XAF exceeds the maximum of ${limits.maxAmount} XAF for ${provider.toUpperCase()}. Allowed range: ${limits.minAmount} - ${limits.maxAmount} XAF`,
+      error: `Amount ${amount} ${currencyLabel} exceeds the maximum of ${limits.maxAmount} ${currencyLabel} for ${provider.toUpperCase()}. Allowed range: ${limits.minAmount} - ${limits.maxAmount} ${currencyLabel}`,
     };
   }
 
   return { valid: true };
+}
+
+/**
+ * Resolve the currency label for Airtel based on configured country.
+ * Falls back to XAF for backwards compatibility.
+ */
+function getAirtelCurrencyLabel(): string {
+  try {
+    const country = process.env.AIRTEL_COUNTRY ?? "CM";
+    const region = resolveAirtelRegion(country);
+    if (region) {
+      return AIRTEL_REGION_MAP[region].currencies[0];
+    }
+  } catch {
+    /* ignore — fallback to XAF */
+  }
+  return "XAF";
 }
 
 function validateLimitsConfig(): void {

--- a/src/services/mobilemoney/providers/airtel-regions.ts
+++ b/src/services/mobilemoney/providers/airtel-regions.ts
@@ -1,0 +1,66 @@
+/**
+ * Airtel Money region configuration.
+ *
+ * Maps African regions to their supported country codes and currencies.
+ * Used to auto-resolve the correct currency from a country code and to
+ * validate country↔currency pairs before sending API requests.
+ */
+
+export type AirtelRegion = "central" | "east" | "west";
+
+export interface AirtelRegionConfig {
+  countries: string[];
+  currencies: string[];
+}
+
+export const AIRTEL_REGION_MAP: Record<AirtelRegion, AirtelRegionConfig> = {
+  central: {
+    countries: ["CM", "GA", "CG", "TD", "CF", "GQ"],
+    currencies: ["XAF"],
+  },
+  east: {
+    countries: ["TZ", "KE", "UG", "RW", "MW", "MG", "ZM"],
+    currencies: ["TZS", "KES", "UGX", "RWF", "MWK", "MGA", "ZMW"],
+  },
+  west: {
+    countries: ["NG", "GH", "SN", "CI", "BF", "ML", "NE", "TG", "BJ", "GN"],
+    currencies: ["NGN", "GHS", "XOF"],
+  },
+};
+
+/**
+ * Resolve the region for a given country code.
+ * Returns undefined if the country is not in any known region.
+ */
+export function resolveAirtelRegion(country: string): AirtelRegion | undefined {
+  const upper = country.toUpperCase();
+  for (const [region, cfg] of Object.entries(AIRTEL_REGION_MAP)) {
+    if (cfg.countries.includes(upper)) {
+      return region as AirtelRegion;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Validate that a currency is expected for a given country.
+ * Returns an error message string if invalid, or undefined if valid.
+ */
+export function validateCountryCurrency(
+  country: string,
+  currency: string,
+): string | undefined {
+  const region = resolveAirtelRegion(country);
+  if (!region) {
+    return undefined; // Unknown country — skip validation
+  }
+
+  const expected = AIRTEL_REGION_MAP[region].currencies;
+  if (!expected.includes(currency.toUpperCase())) {
+    return (
+      `Currency "${currency}" is not valid for Airtel country "${country}" (region: ${region}). ` +
+      `Expected one of: ${expected.join(", ")}`
+    );
+  }
+  return undefined;
+}

--- a/src/services/mobilemoney/providers/airtel.ts
+++ b/src/services/mobilemoney/providers/airtel.ts
@@ -7,6 +7,8 @@ import axios, {
 
 import logger from "../../../utils/logger";
 import { maskPII } from "../../../utils/masking";
+import { resolveAirtelRegion, validateCountryCurrency, AIRTEL_REGION_MAP } from "./airtel-regions";
+import type { AirtelRegion } from "./airtel-regions";
 
 // ============================================================================
 // TYPES & INTERFACES
@@ -148,6 +150,34 @@ export class AirtelService {
   // =========================================================================
 
   private buildConfig(options: AirtelProviderOptions): AirtelProviderConfig {
+    const country = (
+      options.country ??
+      process.env.AIRTEL_COUNTRY ??
+      "NG"
+    ).toUpperCase();
+
+    // Auto-resolve currency from country if not explicitly provided,
+    // or use the provided value.  This makes East-Africa configs simpler:
+    // just set AIRTEL_COUNTRY=TZ and the currency defaults to TZS.
+    const explicitCurrency =
+      options.currency ?? process.env.AIRTEL_CURRENCY;
+    let currency: string;
+
+    if (explicitCurrency) {
+      currency = explicitCurrency.toUpperCase();
+    } else {
+      const region = resolveAirtelRegion(country);
+      currency =
+        region ? AIRTEL_REGION_MAP[region].currencies[0] : "NGN";
+    }
+
+    // Warn on mismatched country/currency pairs (non-fatal for backwards
+    // compat, but surfaces misconfiguration early).
+    const mismatch = validateCountryCurrency(country, currency);
+    if (mismatch) {
+      logger.warn({ country, currency }, `Airtel config: ${mismatch}`);
+    }
+
     return {
       mode: options.mode ?? (process.env.AIRTEL_MODE as AirtelMode | undefined),
       webBaseUrl:
@@ -191,8 +221,8 @@ export class AirtelService {
       csrfField: options.csrfField ?? process.env.AIRTEL_CSRF_FIELD ?? "_csrf",
       apiKey: options.apiKey ?? process.env.AIRTEL_API_KEY ?? "",
       apiSecret: options.apiSecret ?? process.env.AIRTEL_API_SECRET ?? "",
-      country: options.country ?? process.env.AIRTEL_COUNTRY ?? "NG",
-      currency: options.currency ?? process.env.AIRTEL_CURRENCY ?? "NGN",
+      country,
+      currency,
       sessionStorePath:
         options.sessionStorePath ?? process.env.AIRTEL_SESSION_STORE_PATH,
       sessionTtlMs: Number(
@@ -1212,3 +1242,7 @@ export class AirtelService {
     await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
   }
 }
+
+// Re-export region utilities from dedicated module
+export { resolveAirtelRegion, validateCountryCurrency, AIRTEL_REGION_MAP };
+export type { AirtelRegion };

--- a/tests/services/mobilemoney/providers/airtel-region.test.ts
+++ b/tests/services/mobilemoney/providers/airtel-region.test.ts
@@ -1,0 +1,97 @@
+import {
+  resolveAirtelRegion,
+  validateCountryCurrency,
+  AIRTEL_REGION_MAP,
+} from "../../../../src/services/mobilemoney/providers/airtel-regions";
+
+// ============================================================================
+// Region Resolution Tests
+// ============================================================================
+
+describe("resolveAirtelRegion", () => {
+  it("resolves Central Africa countries to 'central'", () => {
+    expect(resolveAirtelRegion("CM")).toBe("central");
+    expect(resolveAirtelRegion("GA")).toBe("central");
+    expect(resolveAirtelRegion("TD")).toBe("central");
+  });
+
+  it("resolves East Africa countries to 'east'", () => {
+    expect(resolveAirtelRegion("TZ")).toBe("east");
+    expect(resolveAirtelRegion("KE")).toBe("east");
+    expect(resolveAirtelRegion("UG")).toBe("east");
+    expect(resolveAirtelRegion("RW")).toBe("east");
+  });
+
+  it("resolves West Africa countries to 'west'", () => {
+    expect(resolveAirtelRegion("NG")).toBe("west");
+    expect(resolveAirtelRegion("GH")).toBe("west");
+  });
+
+  it("is case-insensitive", () => {
+    expect(resolveAirtelRegion("tz")).toBe("east");
+    expect(resolveAirtelRegion("cm")).toBe("central");
+  });
+
+  it("returns undefined for unknown countries", () => {
+    expect(resolveAirtelRegion("US")).toBeUndefined();
+    expect(resolveAirtelRegion("ZZ")).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Currency Validation Tests
+// ============================================================================
+
+describe("validateCountryCurrency", () => {
+  it("accepts valid Central Africa pair (CM/XAF)", () => {
+    expect(validateCountryCurrency("CM", "XAF")).toBeUndefined();
+  });
+
+  it("accepts valid East Africa pair (TZ/TZS)", () => {
+    expect(validateCountryCurrency("TZ", "TZS")).toBeUndefined();
+  });
+
+  it("accepts valid East Africa pair (KE/KES)", () => {
+    expect(validateCountryCurrency("KE", "KES")).toBeUndefined();
+  });
+
+  it("rejects mismatched pair (TZ/XAF)", () => {
+    const error = validateCountryCurrency("TZ", "XAF");
+    expect(error).toBeDefined();
+    expect(error).toContain("TZS");
+  });
+
+  it("rejects mismatched pair (CM/TZS)", () => {
+    const error = validateCountryCurrency("CM", "TZS");
+    expect(error).toBeDefined();
+    expect(error).toContain("XAF");
+  });
+
+  it("returns undefined for unknown country (skips validation)", () => {
+    expect(validateCountryCurrency("US", "USD")).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Region Map Tests
+// ============================================================================
+
+describe("AIRTEL_REGION_MAP", () => {
+  it("contains all expected regions", () => {
+    expect(Object.keys(AIRTEL_REGION_MAP)).toEqual(
+      expect.arrayContaining(["central", "east", "west"]),
+    );
+  });
+
+  it("East Africa region includes TZS and KES", () => {
+    expect(AIRTEL_REGION_MAP.east.currencies).toContain("TZS");
+    expect(AIRTEL_REGION_MAP.east.currencies).toContain("KES");
+    expect(AIRTEL_REGION_MAP.east.countries).toContain("TZ");
+    expect(AIRTEL_REGION_MAP.east.countries).toContain("KE");
+  });
+
+  it("Central Africa region includes XAF", () => {
+    expect(AIRTEL_REGION_MAP.central.currencies).toContain("XAF");
+    expect(AIRTEL_REGION_MAP.central.countries).toContain("CM");
+  });
+});


### PR DESCRIPTION
## Summary

Adds region-aware currency handling to the Airtel Money provider to properly support both Central Africa (XAF) and East Africa (TZS/KES) API interfaces.

Fixes #1041

## Changes

- **New `airtel-regions.ts` module** — defines a region map with three regions:
  - **Central Africa**: CM, GA, CG, TD, CF, GQ → XAF
  - **East Africa**: TZ, KE, UG, RW, MW, MG, ZM → TZS, KES, UGX, RWF, MWK, MGA, ZMW
  - **West Africa**: NG, GH, SN, CI, BF, ML, NE, TG, BJ, GN → NGN, GHS, XOF

- **`resolveAirtelRegion(country)`** — maps a country code to its region (case-insensitive)
- **`validateCountryCurrency(country, currency)`** — validates a country↔currency pair and returns a descriptive error message if mismatched

- **AirtelService `buildConfig()` updated** — auto-resolves currency from country when not explicitly provided. Example: `{ country: "TZ" }` now automatically sets currency to `"TZS"`.

- **Provider validation messages** — `validateProviderLimits()` now uses the region map to show the expected currency(s) for the configured country instead of hardcoding "XAF".

## Testing

- 14 unit tests covering region resolution, currency validation, and region map structure
- All tests pass (`PASS tests/services/mobilemoney/providers/airtel-region.test.ts`)

## Design Decisions

- **Explicit currency overrides auto-resolution**: If a caller provides `{ country: "TZ", currency: "USD" }`, the explicit currency is used. No error is thrown — the caller is trusted to know what they're doing.
- **Case-insensitive country codes**: `tz`, `TZ`, and `Tz` all resolve to the same region.
- **Unknown countries are skipped**: If a country isn't in the region map, no validation error is returned (backward-compatible with custom/experimental setups).
- **Dedicated module**: Region logic lives in `airtel-regions.ts` (no heavy dependencies) to avoid circular imports between the Airtel service and the provider config.