### PR TITLE
feat: add image optimization pipeline with WebP conversion and lazy loading (Fixes #1029)

### DIFF
--- a/docs-portal/docusaurus.config.ts
+++ b/docs-portal/docusaurus.config.ts
@@ -38,6 +38,19 @@ const config: Config = {
     ],
   ],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-ideal-image',
+      {
+        quality: 80,
+        max: 1200,
+        min: 320,
+        steps: 4,
+        disableInDev: false,
+      },
+    ],
+  ],
+
   themeConfig: {
     navbar: {
       title: 'Mobile Money API',

--- a/docs-portal/package.json
+++ b/docs-portal/package.json
@@ -4,6 +4,8 @@
   "version": "1.0.0",
   "scripts": {
     "sync:openapi": "cp ../openapi.yaml ./static/openapi.yaml",
+    "optimize:images": "bash scripts/optimize-images.sh",
+    "prebuild": "npm run optimize:images",
     "start": "npm run sync:openapi && docusaurus start --port 3001",
     "build": "npm run sync:openapi && docusaurus build",
     "serve": "docusaurus serve",
@@ -11,6 +13,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
+    "@docusaurus/plugin-ideal-image": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
@@ -18,5 +21,9 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "redoc": "^2.5.1"
+  },
+  "devDependencies": {
+    "sharp": "^0.33.0",
+    "sharp-cli": "^5.0.0"
   }
 }

--- a/docs-portal/scripts/optimize-images.sh
+++ b/docs-portal/scripts/optimize-images.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# optimize-images.sh — Build-time image optimization for Docusaurus docs portal
+#
+# Compresses PNG/JPEG/GIF images in static/ to WebP format using sharp-cli.
+# Original files are preserved; optimized copies are placed alongside with .webp extension.
+#
+# Usage:
+#   bash scripts/optimize-images.sh          # optimize all images
+#   bash scripts/optimize-images.sh --dry-run # preview without writing
+#
+# Requirements: sharp-cli (installed as devDependency)
+
+set -euo pipefail
+
+STATIC_DIR="$(cd "$(dirname "$0")/../static" && pwd)"
+DRY_RUN=false
+QUALITY=80
+MAX_WIDTH=1200
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+  echo "🔍 DRY RUN — no files will be written"
+fi
+
+if ! command -v sharp &>/dev/null; then
+  echo "❌ sharp-cli not found. Install with: npm install --save-dev sharp-cli sharp"
+  exit 1
+fi
+
+total_original=0
+total_optimized=0
+count=0
+
+echo "🖼️  Scanning ${STATIC_DIR} for images..."
+
+while IFS= read -r -d '' img; do
+  ext="${img##*.}"
+  ext_lower="$(echo "$ext" | tr '[:upper:]' '[:lower:]')"
+  
+  # Skip SVGs (vector format, no rasterization benefit) and already-optimized WebP
+  if [[ "$ext_lower" == "svg" || "$ext_lower" == "webp" || "$ext_lower" == "avif" ]]; then
+    continue
+  fi
+  
+  original_size=$(stat -f%z "$img" 2>/dev/null || stat -c%s "$img" 2>/dev/null)
+  webp_target="${img%.*}.webp"
+  
+  # Skip if WebP already exists and is smaller
+  if [[ -f "$webp_target" ]]; then
+    existing_size=$(stat -f%z "$webp_target" 2>/dev/null || stat -c%s "$webp_target" 2>/dev/null)
+    if [[ "$existing_size" -lt "$original_size" ]]; then
+      echo "  ⏭️  $(basename "$img") — WebP already smaller ($(numfmt --to=iec "$existing_size" 2>/dev/null || echo "${existing_size}B"))"
+      continue
+    fi
+  fi
+  
+  if $DRY_RUN; then
+    echo "  📋 Would optimize: $(basename "$img") ($(numfmt --to=iec "$original_size" 2>/dev/null || echo "${original_size}B"))"
+  else
+    # Convert to WebP with quality and max-width constraints
+    sharp -i "$img" -o "$webp_target" \
+      --format webp \
+      --quality "$QUALITY" \
+      --resize "$MAX_WIDTH" \
+      --fit inside \
+      2>/dev/null || {
+        echo "  ⚠️  Failed to optimize: $(basename "$img")"
+        continue
+      }
+    
+    if [[ -f "$webp_target" ]]; then
+      new_size=$(stat -f%z "$webp_target" 2>/dev/null || stat -c%s "$webp_target" 2>/dev/null)
+      if [[ "$new_size" -lt "$original_size" ]]; then
+        saved=$((original_size - new_size))
+        pct=$((saved * 100 / original_size))
+        echo "  ✅ $(basename "$img") → $(basename "$webp_target") — saved ${pct}% ($(numfmt --to=iec "$saved" 2>/dev/null || echo "${saved}B"))"
+        total_original=$((total_original + original_size))
+        total_optimized=$((total_optimized + new_size))
+        count=$((count + 1))
+      else
+        echo "  ⏭️  $(basename "$img") — WebP not smaller, keeping original"
+        rm -f "$webp_target"
+      fi
+    fi
+  fi
+done < <(find "$STATIC_DIR" -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' \) -print0)
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ "$count" -gt 0 ]]; then
+  total_saved=$((total_original - total_optimized))
+  echo "📊 Optimized $count images"
+  echo "   Original:  $(numfmt --to=iec "$total_original" 2>/dev/null || echo "${total_original}B")"
+  echo "   WebP:      $(numfmt --to=iec "$total_optimized" 2>/dev/null || echo "${total_optimized}B")"
+  echo "   Saved:     $(numfmt --to=iec "$total_saved" 2>/dev/null || echo "${total_saved}B")"
+else
+  echo "📊 No images needed optimization"
+fi

--- a/docs-portal/src/components/OptimizedImage.tsx
+++ b/docs-portal/src/components/OptimizedImage.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+interface OptimizedImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src: string;
+  alt: string;
+  width?: number | string;
+  height?: number | string;
+  /** Enable lazy loading (default: true) */
+  lazy?: boolean;
+  /** Placeholder shown while image loads */
+  placeholder?: 'blur' | 'empty';
+  /** Low-quality placeholder src for blur effect */
+  blurSrc?: string;
+}
+
+/**
+ * OptimizedImage — lazy-loading image component with WebP source and
+ * automatic fallback to the original format.
+ *
+ * Usage:
+ *   <OptimizedImage src="/img/screenshot.png" alt="API overview" />
+ *
+ * The browser will prefer screenshot.webp (if it exists in the same dir)
+ * and fall back to screenshot.png if WebP is unsupported.
+ */
+export default function OptimizedImage({
+  src,
+  alt,
+  width,
+  height,
+  lazy = true,
+  placeholder = 'empty',
+  blurSrc,
+  style,
+  ...rest
+}: OptimizedImageProps): React.JSX.Element {
+  const [loaded, setLoaded] = useState(false);
+  const [inView, setInView] = useState(!lazy);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  // Intersection Observer for lazy loading
+  useEffect(() => {
+    if (!lazy || !imgRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '200px' } // Start loading 200px before visible
+    );
+
+    observer.observe(imgRef.current);
+    return () => observer.disconnect();
+  }, [lazy]);
+
+  // Derive WebP source path from original
+  const webpSrc = src.replace(/\.(png|jpe?g|gif)$/i, '.webp');
+  const showBlur = placeholder === 'blur' && !loaded && blurSrc;
+
+  const imgStyle: React.CSSProperties = {
+    transition: 'opacity 0.3s ease-in-out',
+    opacity: loaded ? 1 : showBlur ? 0.5 : 1,
+    ...style,
+  };
+
+  return (
+    <picture ref={imgRef}>
+      {/* WebP source — browsers that support it will prefer this */}
+      {inView && (
+        <source srcSet={webpSrc} type="image/webp" />
+      )}
+      {/* Fallback to original format */}
+      {inView ? (
+        <img
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          loading={lazy ? 'lazy' : 'eager'}
+          decoding="async"
+          style={imgStyle}
+          onLoad={() => setLoaded(true)}
+          {...rest}
+        />
+      ) : (
+        // Placeholder while not in view
+        <div
+          style={{
+            width: width || '100%',
+            height: height || 200,
+            backgroundColor: 'var(--ifm-background-surface-color)',
+            borderRadius: 4,
+            ...style,
+          }}
+          aria-label={alt}
+          role="img"
+        />
+      )}
+    </picture>
+  );
+}

--- a/docs-portal/src/css/custom.css
+++ b/docs-portal/src/css/custom.css
@@ -26,3 +26,36 @@ button.copyButton_node_modules-\@docusaurus-theme-classic-src-theme-CodeBlock-st
 pre code {
   position: relative;
 }
+
+/* ── Responsive image defaults ────────────────────────────── */
+/* All images inside docs/markdown are capped at container width */
+.markdown img,
+article img,
+[class*='markdown'] img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: var(--ifm-global-radius);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+}
+
+/* Ideal-image placeholder (while lazy-loading) */
+[class*='idealImagePlaceholder'] {
+  background-color: var(--ifm-background-surface-color, #f5f5f5);
+  border-radius: var(--ifm-global-radius);
+}
+
+/* Prevent layout shift by reserving space for images with known dimensions */
+img[width][height] {
+  aspect-ratio: attr(width) / attr(height);
+}
+
+/* Dark mode image adjustments */
+html[data-theme='dark'] article img {
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.4);
+  opacity: 0.92;
+  transition: opacity 0.2s ease-in-out;
+}
+html[data-theme='dark'] article img:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary

Adds a complete image optimization pipeline to the Docusaurus docs portal, reducing image load times through automatic WebP conversion, responsive srcsets, and lazy loading.

## Changes

### Build Pipeline
- **`@docusaurus/plugin-ideal-image`** — Docusaurus-native plugin that generates responsive `srcset` attributes (320/560/800/1200px widths) and lazy-loads images below the fold
- **`sharp` + `sharp-cli`** — Build-time image compression as devDependencies
- **`scripts/optimize-images.sh`** — Prebuild script that scans `static/` for PNG/JPEG/GIF images and creates optimized WebP copies (quality 80%, max-width 1200px)
- **`prebuild` npm script** — Automatically runs image optimization before every build

### Components
- **`OptimizedImage.tsx`** — Lazy-loading image component with:
  - `<picture>` element with WebP `<source>` and original format fallback
  - Intersection Observer for viewport-based loading (200px rootMargin)
  - Placeholder div while off-screen to prevent layout shift
  - Fade-in animation on load

### Styling
- **Responsive image CSS** — `max-width: 100%`, `height: auto`, rounded corners, subtle shadow
- **CLS prevention** — `aspect-ratio` on images with known dimensions
- **Dark mode** — Adjusted shadows and slight opacity for better contrast
- **Ideal-image placeholder** — Surface-color background while loading

## Testing

```bash
cd docs-portal
npm install
npm run optimize:images          # Should report "No images needed optimization" (only SVG present)
npm run build                     # Should build successfully with ideal-image plugin
```

The optimization pipeline is forward-looking: any future PNG/JPEG/GIF images added to `static/` will be automatically compressed to WebP during build. The `OptimizedImage` component can be used in MDX pages for full control over lazy loading and format selection.

## Related Issues
Fixes #1029