### PR TITLE
ci: add automated docs linting workflow with markdownlint (Fixes #1028)

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,40 @@
+name: Docs Lint
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "docs-portal/**"
+      - "*.md"
+      - ".markdownlint-cli2.jsonc"
+      - ".markdownlint.json"
+      - ".github/workflows/docs-lint.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "docs-portal/**"
+      - "*.md"
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: Markdownlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2
+
+      - name: Lint documentation markdown files
+        run: markdownlint-cli2 "docs/**/*.md" "docs-portal/**/*.md" "docs-portal/**/*.mdx" "*.md"

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,91 @@
+{
+  // markdownlint-cli2 configuration for mobile-money documentation
+  // See https://github.com/DavidAnson/markdownlint-cli2 for details
+
+  "config": {
+    // Default state for all rules
+    "default": true,
+
+    // Line length — relaxed for docs with long URLs and tables
+    "MD013": {
+      "line_length": 150,
+      "heading_line_length": 120,
+      "code_block_line_length": 120,
+      "strict": false,
+      "stern": false
+    },
+
+    // Allow inline HTML (needed for Mermaid diagrams, badges, tables)
+    "MD033": {
+      "allowed_elements": [
+        "br", "details", "summary", "sub", "sup",
+        "img", "a", "table", "thead", "tbody", "tr", "th", "td",
+        "div", "span", "p", "mermaid"
+      ]
+    },
+
+    // First heading should be h1 (allow for frontmatter)
+    "MD041": false,
+
+    // Allow duplicate headings in different sections
+    "MD024": {
+      "siblings_only": true
+    },
+
+    // Code block style — allow fenced (```) and indented
+    "MD046": {
+      "style": "fenced"
+    },
+
+    // Code fence style — consistent backtick fences
+    "MD048": {
+      "style": "backtick"
+    },
+
+    // Allow bare URLs (common in API docs)
+    "MD034": false,
+
+    // Emphasis style — allow both **bold** and __bold__
+    "MD049": {
+      "style": "consistent"
+    },
+
+    // Unordered list style — consistent dash
+    "MD004": {
+      "style": "dash"
+    },
+
+    // Ordered list style — consistent one-ordered (1. 2. 3.)
+    "MD029": {
+      "style": "one"
+    },
+
+    // Allow trailing punctuation in headings (e.g., "## What is this?")
+    "MD026": {
+      "punctuation": ".,;:!"
+    },
+
+    // Link fragments — don't require anchors for auto-generated headings
+    "MD051": false
+  },
+
+  // Globs of files to lint
+  "globs": [
+    "docs/**/*.md",
+    "docs-portal/**/*.md",
+    "docs-portal/**/*.mdx",
+    "*.md"
+  ],
+
+  // Ignore node_modules, build artifacts, and generated files
+  "ignores": [
+    "**/node_modules/**",
+    "**/build/**",
+    "**/.docusaurus/**",
+    "**/dist/**",
+    "**/coverage/**",
+    "**/CHANGELOG.md",
+    "pnpm-lock.yaml",
+    "package-lock.json"
+  ]
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,37 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 150,
+    "heading_line_length": 120,
+    "code_block_line_length": 120,
+    "strict": false
+  },
+  "MD033": {
+    "allowed_elements": [
+      "br", "details", "summary", "sub", "sup",
+      "img", "a", "table", "thead", "tbody", "tr", "th", "td",
+      "div", "span", "p"
+    ]
+  },
+  "MD041": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD046": {
+    "style": "fenced"
+  },
+  "MD048": {
+    "style": "backtick"
+  },
+  "MD034": false,
+  "MD004": {
+    "style": "dash"
+  },
+  "MD029": {
+    "style": "one"
+  },
+  "MD026": {
+    "punctuation": ".,;:!"
+  },
+  "MD051": false
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "sdk:build:ts": "cd sdk-ts && npm install && npm run build",
     "docs:dev": "npm --prefix docs-portal run start",
     "docs:build": "npm --prefix docs-portal run build",
+    "lint:docs": "markdownlint-cli2 \"docs/**/*.md\" \"docs-portal/**/*.md\" \"docs-portal/**/*.mdx\" \"*.md\"",
+    "lint:docs:fix": "markdownlint-cli2 --fix \"docs/**/*.md\" \"docs-portal/**/*.md\" \"docs-portal/**/*.mdx\" \"*.md\"",
     "test:load:ingestion-10k": "k6 run --vus-max 12000 -e SCENARIO=ingestion_10k tests/load/api.js",
     "test:load:spike-10k": "k6 run --vus-max 12000 -e SCENARIO=spike_10k tests/load/api.js",
     "test:load:traffic-spike": "k6 run --vus-max 6000 -e SCENARIO=traffic_spike tests/load/api.js",
@@ -65,7 +67,11 @@
       "eslint --fix",
       "jest --bail --findRelatedTests"
     ],
-    "*.{js,cjs,mjs,json,md,yml,yaml}": "prettier --write"
+    "*.{js,cjs,mjs,json,yml,yaml}": "prettier --write",
+    "*.md": [
+      "prettier --write",
+      "markdownlint-cli2 --fix"
+    ]
   },
   "keywords": [],
   "author": "",
@@ -204,6 +210,7 @@
     "jest": "^29.7.0",
     "js-yaml": "^4.1.1",
     "lint-staged": "^16.4.0",
+    "markdownlint-cli2": "^0.17.2",
     "playwright": "^1.60.0",
     "prettier": "^3.8.3",
     "supertest": "^7.2.2",


### PR DESCRIPTION
## Summary

Adds an automated markdown linting workflow using [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) to prevent broken links, badly formatted syntax, and inconsistent documentation across all markdown files in `docs/` and `docs-portal/`.

Fixes #1028

## Changes

- **`.markdownlint-cli2.jsonc`** — CLI2 configuration with sensible defaults for a large documentation project
- **`.markdownlint.json`** — Rule overrides compatible with markdownlint CLI and editors
- **`.github/workflows/docs-lint.yml`** — GitHub Actions workflow that runs on PRs touching docs and on pushes to `main`
- **`package.json`** — Added `markdownlint-cli2` devDependency, `lint:docs` / `lint:docs:fix` scripts, and lint-staged integration for pre-commit checks

## Rule Configuration

| Rule | Setting | Rationale |
|------|---------|-----------|
| MD013 | 150 chars | Accommodates long URLs and markdown tables |
| MD033 | Allow list | Permits HTML needed for Mermaid diagrams, badges, tables |
| MD041 | Disabled | Allows frontmatter before first heading |
| MD024 | Siblings only | Permits duplicate headings across sections |
| MD034 | Disabled | Bare URLs common in API documentation |
| MD051 | Disabled | Auto-generated anchor fragments |

## Testing

- Verified `package.json` is valid JSON
- The workflow installs `markdownlint-cli2` globally via npm and lints `docs/**/*.md`, `docs-portal/**/*.md`, `docs-portal/**/*.mdx`, and `*.md`
- Lint-staged integration ensures markdown is linted (with auto-fix) on every commit

## Usage

```bash
# Lint all docs
npm run lint:docs

# Lint and auto-fix
npm run lint:docs:fix
```