### PR TITLE
test: add Wrangler local environment testing mocks for well-known-cache worker (Fixes #1047)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "test:load:ingestion-10k": "k6 run --vus-max 12000 -e SCENARIO=ingestion_10k tests/load/api.js",
     "test:load:spike-10k": "k6 run --vus-max 12000 -e SCENARIO=spike_10k tests/load/api.js",
     "test:load:traffic-spike": "k6 run --vus-max 6000 -e SCENARIO=traffic_spike tests/load/api.js",
-    "test:load:spike-5k": "k6 run --vus-max 6000 -e SCENARIO=spike_5k tests/load/api.js"
+    "test:load:spike-5k": "k6 run --vus-max 6000 -e SCENARIO=spike_5k tests/load/api.js",
+    "test:worker": "npm --prefix workers/well-known-cache run test",
+    "worker:dev": "npm --prefix workers/well-known-cache run dev"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/workers/well-known-cache/package.json
+++ b/workers/well-known-cache/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "well-known-cache-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.8.0",
+    "@cloudflare/workers-types": "^4.20250422.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.1.0",
+    "wrangler": "^4.15.0"
+  }
+}

--- a/workers/well-known-cache/src/__tests__/index.test.ts
+++ b/workers/well-known-cache/src/__tests__/index.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import worker from "../index";
+
+/**
+ * Local testing mocks for the well-known-cache Cloudflare Worker.
+ *
+ * Uses vitest-pool-workers to provide a simulated Cloudflare Workers runtime
+ * with in-memory cache, allowing developers to test worker logic locally
+ * without publishing to Cloudflare networks.
+ */
+
+// Mock environment bindings
+const env = {
+  STELLAR_TOML_MAX_AGE: "3600",
+  STELLAR_TOML_STALE_WHILE_REVALIDATE: "86400",
+  DEFAULT_MAX_AGE: "300",
+  DEFAULT_STALE_WHILE_REVALIDATE: "3600",
+};
+
+// Helper to create mock fetch responses for the origin server
+function mockOriginFetch(responseBody: string, status = 200, contentType = "text/plain") {
+  return async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+    return new Response(responseBody, {
+      status,
+      headers: { "Content-Type": contentType },
+    });
+  };
+}
+
+describe("well-known-cache worker", () => {
+  describe("CORS preflight (OPTIONS)", () => {
+    it("returns 204 with CORS headers for OPTIONS requests", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "OPTIONS",
+      });
+      const res = await worker.fetch(req, env);
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(res.headers.get("Access-Control-Allow-Methods")).toBe("GET, HEAD, OPTIONS");
+      expect(res.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type");
+    });
+  });
+
+  describe("method validation", () => {
+    it("returns 405 for POST requests", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "POST",
+        body: JSON.stringify({ test: true }),
+      });
+      const res = await worker.fetch(req, env);
+      const body = await res.json() as { status: number; error: string };
+
+      expect(res.status).toBe(405);
+      expect(body.status).toBe(405);
+      expect(body.error).toBe("Method Not Allowed");
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    });
+
+    it("returns 405 for PUT requests", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "PUT",
+      });
+      const res = await worker.fetch(req, env);
+      const body = await res.json() as { status: number; error: string };
+
+      expect(res.status).toBe(405);
+      expect(body.error).toBe("Method Not Allowed");
+    });
+
+    it("returns 405 for DELETE requests", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "DELETE",
+      });
+      const res = await worker.fetch(req, env);
+      const body = await res.json() as { status: number; error: string };
+
+      expect(res.status).toBe(405);
+      expect(body.error).toBe("Method Not Allowed");
+    });
+
+    it("allows GET requests", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "GET",
+      });
+      // fetch will succeed via the pool-workers runtime
+      const res = await worker.fetch(req, env);
+
+      // Should not be 405
+      expect(res.status).not.toBe(405);
+    });
+
+    it("allows HEAD requests", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "HEAD",
+      });
+      const res = await worker.fetch(req, env);
+
+      expect(res.status).not.toBe(405);
+    });
+  });
+
+  describe("cache behavior", () => {
+    it("returns MISS on first request and HIT on subsequent request", async () => {
+      const url = "https://example.com/.well-known/stellar.toml";
+
+      // First request — cache MISS
+      const req1 = new Request(url, { method: "GET" });
+      const res1 = await worker.fetch(req1, env);
+      expect(res1.headers.get("cf-cache-status")).toBe("MISS");
+
+      // Second request — cache HIT (from Cloudflare edge cache)
+      const req2 = new Request(url, { method: "GET" });
+      const res2 = await worker.fetch(req2, env);
+      expect(res2.headers.get("cf-cache-status")).toBe("HIT");
+    });
+
+    it("sets correct Cache-Control for stellar.toml", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "GET",
+      });
+      const res = await worker.fetch(req, env);
+
+      expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+      expect(res.headers.get("Cache-Control")).toContain("stale-while-revalidate=86400");
+    });
+
+    it("sets correct Cache-Control for non-stellar.toml paths", async () => {
+      const req = new Request("https://example.com/.well-known/openid-configuration", {
+        method: "GET",
+      });
+      const res = await worker.fetch(req, env);
+
+      expect(res.headers.get("Cache-Control")).toContain("max-age=300");
+      expect(res.headers.get("Cache-Control")).toContain("stale-while-revalidate=3600");
+    });
+  });
+
+  describe("CORS headers on responses", () => {
+    it("includes CORS headers on GET responses", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "GET",
+      });
+      const res = await worker.fetch(req, env);
+
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(res.headers.get("Access-Control-Allow-Methods")).toBe("GET, HEAD, OPTIONS");
+    });
+
+    it("includes CORS headers on error responses", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "POST",
+      });
+      const res = await worker.fetch(req, env);
+
+      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(res.headers.get("Content-Type")).toBe("application/json");
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns JSON error body with timestamp for 405 errors", async () => {
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "PATCH",
+      });
+      const res = await worker.fetch(req, env);
+      const body = await res.json() as {
+        status: number;
+        error: string;
+        message: string;
+        timestamp: string;
+      };
+
+      expect(body.status).toBe(405);
+      expect(body.error).toBe("Method Not Allowed");
+      expect(body.message).toContain("PATCH");
+      expect(body.timestamp).toBeDefined();
+      // Verify timestamp is a valid ISO date
+      expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+    });
+  });
+
+  describe("metrics logging", () => {
+    it("logs request metrics on successful fetch", async () => {
+      // This test verifies the worker doesn't throw during metrics logging
+      const req = new Request("https://example.com/.well-known/stellar.toml", {
+        method: "GET",
+        headers: { "User-Agent": "test-agent/1.0" },
+      });
+      const res = await worker.fetch(req, env);
+
+      // If we get here without throwing, metrics logging succeeded
+      expect(res.status).toBeLessThan(500);
+    });
+  });
+});

--- a/workers/well-known-cache/vitest.config.ts
+++ b/workers/well-known-cache/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: {
+        wrangler: {
+          configPath: "../../wrangler.toml",
+        },
+        miniflare: {
+          // Use in-memory cache for local testing (no real Cloudflare cache)
+          cachePersist: false,
+          // Bindings for local testing
+          vars: {
+            STELLAR_TOML_MAX_AGE: "3600",
+            STELLAR_TOML_STALE_WHILE_REVALIDATE: "86400",
+            DEFAULT_MAX_AGE: "300",
+            DEFAULT_STALE_WHILE_REVALIDATE: "3600",
+          },
+        },
+      },
+    },
+  },
+});

--- a/workers/well-known-cache/worker-configuration.d.ts
+++ b/workers/well-known-cache/worker-configuration.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for the well-known-cache worker environment bindings.
+// Auto-generated for local development — update when wrangler.toml changes.
+
+interface Env {
+  /** Cache TTL for stellar.toml (seconds) */
+  STELLAR_TOML_MAX_AGE: string;
+  /** Stale-while-revalidate TTL for stellar.toml (seconds) */
+  STELLAR_TOML_STALE_WHILE_REVALIDATE: string;
+  /** Cache TTL for other .well-known paths (seconds) */
+  DEFAULT_MAX_AGE: string;
+  /** Stale-while-revalidate TTL for other .well-known paths (seconds) */
+  DEFAULT_STALE_WHILE_REVALIDATE: string;
+}


### PR DESCRIPTION
## Summary

Adds local development testing infrastructure for the `well-known-cache` Cloudflare Worker using [vitest-pool-workers](https://developers.cloudflare.com/workers/testing/vitest-integration/) and Miniflare, allowing developers to test worker logic locally without publishing to Cloudflare networks.

Fixes #1047

## Changes

- **`workers/well-known-cache/package.json`** — Worker package with vitest, wrangler, and @cloudflare/vitest-pool-workers devDependencies
- **`workers/well-known-cache/vitest.config.ts`** — Vitest configuration with Miniflare in-memory cache and environment bindings
- **`workers/well-known-cache/src/__tests__/index.test.ts`** — Comprehensive test suite (11 test cases)
- **`workers/well-known-cache/worker-configuration.d.ts`** — TypeScript type definitions for Env bindings
- **`package.json`** — Added `test:worker` and `worker:dev` convenience scripts

## Test Coverage

| Category | Tests | What's Verified |
|----------|-------|-----------------|
| CORS preflight | 1 | OPTIONS returns 204 with correct headers |
| Method validation | 5 | POST/PUT/DELETE → 405, GET/HEAD → allowed |
| Cache behavior | 3 | MISS→HIT lifecycle, Cache-Control TTLs |
| CORS on responses | 2 | Headers present on success and error |
| Error handling | 1 | JSON error body with timestamp |
| Metrics logging | 1 | No-throw verification on fetch |

## Usage

```bash
# Run worker tests locally (no Cloudflare deployment needed)
npm run test:worker

# Start local dev server with hot reload
npm run worker:dev

# Run from worker directory
cd workers/well-known-cache
npm test
npm run dev
```

## Testing

- All tests use the `@cloudflare/vitest-pool-workers` pool which provides a simulated Workers runtime
- Cache is configured as in-memory (`cachePersist: false`) for test isolation
- Environment variables are injected via Miniflare `vars` config, matching `wrangler.toml` defaults