### PR TITLE
feat: implement dynamic CORS headers injection in Edge Workers (Fixes #1049)

### DIFF
--- a/workers/well-known-cache/src/__tests__/cors.test.ts
+++ b/workers/well-known-cache/src/__tests__/cors.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { buildCorsHeaders } from "../index";
+
+describe("buildCorsHeaders", () => {
+  const BASE_HEADERS = {
+    "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+
+  describe("when ALLOWED_ORIGINS is empty (wildcard mode)", () => {
+    const emptyOrigins = new Set<string>();
+
+    it("returns wildcard origin when no allowlist configured", () => {
+      const headers = buildCorsHeaders("https://example.com", emptyOrigins);
+      expect(headers).toEqual({
+        ...BASE_HEADERS,
+        "Access-Control-Allow-Origin": "*",
+      });
+    });
+
+    it("returns wildcard origin when request has no Origin header", () => {
+      const headers = buildCorsHeaders(null, emptyOrigins);
+      expect(headers).toEqual({
+        ...BASE_HEADERS,
+        "Access-Control-Allow-Origin": "*",
+      });
+    });
+  });
+
+  describe("when ALLOWED_ORIGINS has entries (allowlist mode)", () => {
+    const allowedOrigins = new Set([
+      "https://app.example.com",
+      "https://admin.example.com",
+    ]);
+
+    it("reflects the origin when it matches the allowlist", () => {
+      const headers = buildCorsHeaders(
+        "https://app.example.com",
+        allowedOrigins
+      );
+      expect(headers).toEqual({
+        ...BASE_HEADERS,
+        "Access-Control-Allow-Origin": "https://app.example.com",
+        Vary: "Origin",
+      });
+    });
+
+    it("reflects the second allowed origin", () => {
+      const headers = buildCorsHeaders(
+        "https://admin.example.com",
+        allowedOrigins
+      );
+      expect(headers).toEqual({
+        ...BASE_HEADERS,
+        "Access-Control-Allow-Origin": "https://admin.example.com",
+        Vary: "Origin",
+      });
+    });
+
+    it("omits Access-Control-Allow-Origin when origin is not in allowlist", () => {
+      const headers = buildCorsHeaders(
+        "https://evil.com",
+        allowedOrigins
+      );
+      expect(headers).toEqual(BASE_HEADERS);
+      expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+    });
+
+    it("omits Access-Control-Allow-Origin when no Origin header present", () => {
+      const headers = buildCorsHeaders(null, allowedOrigins);
+      expect(headers).toEqual(BASE_HEADERS);
+      expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+    });
+
+    it("handles origins with trailing spaces in env var", () => {
+      const origins = new Set(["https://app.example.com"]);
+      const headers = buildCorsHeaders(
+        "https://app.example.com",
+        origins
+      );
+      expect(headers["Access-Control-Allow-Origin"]).toBe(
+        "https://app.example.com"
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("treats http and https origins as distinct", () => {
+      const origins = new Set(["https://example.com"]);
+      const headers = buildCorsHeaders("http://example.com", origins);
+      expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+    });
+
+    it("treats origins with different ports as distinct", () => {
+      const origins = new Set(["https://example.com:3000"]);
+      const headers = buildCorsHeaders("https://example.com", origins);
+      expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+    });
+
+    it("handles empty string origin header", () => {
+      const origins = new Set(["https://example.com"]);
+      const headers = buildCorsHeaders("", origins);
+      expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+    });
+
+    it("always includes base headers regardless of origin match", () => {
+      const origins = new Set(["https://example.com"]);
+      const headers = buildCorsHeaders("https://nope.com", origins);
+      expect(headers["Access-Control-Allow-Methods"]).toBe("GET, HEAD, OPTIONS");
+      expect(headers["Access-Control-Allow-Headers"]).toBe("Content-Type");
+    });
+  });
+});

--- a/workers/well-known-cache/src/index.ts
+++ b/workers/well-known-cache/src/index.ts
@@ -5,41 +5,19 @@ interface Env {
   STELLAR_TOML_STALE_WHILE_REVALIDATE: string;
   DEFAULT_MAX_AGE: string;
   DEFAULT_STALE_WHILE_REVALIDATE: string;
+  /**
+   * Comma-separated list of allowed origins for CORS.
+   * Example: "https://app.example.com,https://admin.example.com"
+   * When empty or unset, falls back to wildcard "*" for backward compatibility.
+   */
+  ALLOWED_ORIGINS: string;
 }
-
-const CORS_HEADERS: Record<string, string> = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
-};
 
 interface ErrorResponse {
   status: number;
   error: string;
   message: string;
   timestamp: string;
-}
-
-function errorResponse(status: number, error: string, message: string): Response {
-  const body: ErrorResponse = {
-    status,
-    error,
-    message,
-    timestamp: new Date().toISOString(),
-  };
-  return new Response(JSON.stringify(body, null, 2), {
-    status,
-    headers: {
-      "Content-Type": "application/json",
-      ...CORS_HEADERS,
-    },
-  });
-}
-
-function cacheControlFor(pathname: string): string {
-  return pathname.endsWith("/stellar.toml")
-    ? "public, max-age=3600, stale-while-revalidate=86400"
-    : "public, max-age=300, stale-while-revalidate=3600";
 }
 
 interface RequestMetrics {
@@ -51,6 +29,84 @@ interface RequestMetrics {
   responseBytes: number;
   timestamp: string;
   userAgent: string;
+}
+
+/**
+ * Parse the ALLOWED_ORIGINS environment variable into a Set of exact origin
+ * strings. Returns an empty set when the variable is unset or empty.
+ */
+function parseAllowedOrigins(raw: string | undefined): Set<string> {
+  if (!raw || raw.trim() === "") return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((o) => o.trim())
+      .filter(Boolean)
+  );
+}
+
+/**
+ * Build CORS headers for the given request origin.
+ *
+ * - When ALLOWED_ORIGINS is configured and the request Origin is in the
+ *   allowlist, the specific origin is reflected back (credential-safe).
+ * - When ALLOWED_ORIGINS is configured but the Origin is NOT in the list,
+ *   no Access-Control-Allow-Origin header is emitted (browser blocks the
+ *   response).
+ * - When ALLOWED_ORIGINS is empty/unset, wildcard "*" is used for backward
+ *   compatibility with the original behaviour.
+ */
+export function buildCorsHeaders(
+  requestOrigin: string | null,
+  allowedOrigins: Set<string>
+): Record<string, string> {
+  const base: Record<string, string> = {
+    "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+
+  if (allowedOrigins.size === 0) {
+    // No allowlist configured — wildcard (original behaviour)
+    return { ...base, "Access-Control-Allow-Origin": "*" };
+  }
+
+  if (requestOrigin && allowedOrigins.has(requestOrigin)) {
+    return {
+      ...base,
+      "Access-Control-Allow-Origin": requestOrigin,
+      Vary: "Origin",
+    };
+  }
+
+  // Origin not allowed — omit Access-Control-Allow-Origin
+  return base;
+}
+
+function errorResponse(
+  status: number,
+  error: string,
+  message: string,
+  corsHeaders: Record<string, string>
+): Response {
+  const body: ErrorResponse = {
+    status,
+    error,
+    message,
+    timestamp: new Date().toISOString(),
+  };
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...corsHeaders,
+    },
+  });
+}
+
+function cacheControlFor(pathname: string): string {
+  return pathname.endsWith("/stellar.toml")
+    ? "public, max-age=3600, stale-while-revalidate=86400"
+    : "public, max-age=300, stale-while-revalidate=3600";
 }
 
 function logMetrics(metrics: RequestMetrics): void {
@@ -65,15 +121,20 @@ function logMetrics(metrics: RequestMetrics): void {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    const allowedOrigins = parseAllowedOrigins(env.ALLOWED_ORIGINS);
+    const requestOrigin = request.headers.get("Origin");
+    const corsHeaders = buildCorsHeaders(requestOrigin, allowedOrigins);
+
     if (request.method === "OPTIONS") {
-      return new Response(null, { status: 204, headers: CORS_HEADERS });
+      return new Response(null, { status: 204, headers: corsHeaders });
     }
 
     if (!["GET", "HEAD"].includes(request.method)) {
       return errorResponse(
         405,
         "Method Not Allowed",
-        `HTTP method ${request.method} is not supported. Use GET or HEAD.`
+        `HTTP method ${request.method} is not supported. Use GET or HEAD.`,
+        corsHeaders
       );
     }
 
@@ -81,7 +142,7 @@ export default {
     try {
       url = new URL(request.url);
     } catch {
-      return errorResponse(400, "Bad Request", "Invalid request URL.");
+      return errorResponse(400, "Bad Request", "Invalid request URL.", corsHeaders);
     }
 
     try {
@@ -91,7 +152,7 @@ export default {
       if (cached) {
         const res = new Response(cached.body, cached);
         res.headers.set("cf-cache-status", "HIT");
-        for (const [k, v] of Object.entries(CORS_HEADERS)) res.headers.set(k, v);
+        for (const [k, v] of Object.entries(corsHeaders)) res.headers.set(k, v);
         return res;
       }
 
@@ -100,20 +161,27 @@ export default {
         return errorResponse(
           origin.status,
           origin.statusText || "Upstream Error",
-          `Origin server returned ${origin.status} for ${url.pathname}.`
+          `Origin server returned ${origin.status} for ${url.pathname}.`,
+          corsHeaders
         );
       }
 
       const res = new Response(origin.body, origin);
       res.headers.set("Cache-Control", cacheControlFor(url.pathname));
       res.headers.set("cf-cache-status", "MISS");
-      for (const [k, v] of Object.entries(CORS_HEADERS)) res.headers.set(k, v);
+      for (const [k, v] of Object.entries(corsHeaders)) res.headers.set(k, v);
 
       await cache.put(request, res.clone());
       return res;
     } catch (err) {
-      const message = err instanceof Error ? err.message : "An unexpected error occurred.";
-      return errorResponse(502, "Bad Gateway", `Failed to fetch origin: ${message}`);
+      const message =
+        err instanceof Error ? err.message : "An unexpected error occurred.";
+      return errorResponse(
+        502,
+        "Bad Gateway",
+        `Failed to fetch origin: ${message}`,
+        corsHeaders
+      );
     }
   },
 } satisfies ExportedHandler<Env>;

--- a/workers/well-known-cache/vitest.config.ts
+++ b/workers/well-known-cache/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "miniflare",
+    environmentOptions: {
+      modules: true,
+      scriptPath: "src/index.ts",
+    },
+  },
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,3 +14,5 @@ STELLAR_TOML_STALE_WHILE_REVALIDATE = "86400"
 # Cache TTL for other .well-known paths (seconds)
 DEFAULT_MAX_AGE = "300"
 DEFAULT_STALE_WHILE_REVALIDATE = "3600"
+# Comma-separated list of allowed CORS origins (empty = wildcard "*" for backward compat)
+ALLOWED_ORIGINS = ""


### PR DESCRIPTION
## Summary
Implements dynamic CORS headers injection in the well-known-cache Edge Worker based on an origin allowlist, replacing the previous static wildcard `Access-Control-Allow-Origin: *` with configurable, origin-aware CORS policy.

## Changes
- **Dynamic origin validation**: New `buildCorsHeaders()` function validates the request `Origin` header against a configurable allowlist
- **`ALLOWED_ORIGINS` env var**: Comma-separated list of allowed origins (e.g., `https://app.example.com,https://admin.example.com`)
- **Backward compatibility**: Empty/unset `ALLOWED_ORIGINS` falls back to wildcard `*` (original behaviour)
- **`Vary: Origin` header**: Set when reflecting a specific origin, ensuring correct CDN caching behaviour
- **Comprehensive tests**: 11 unit tests covering wildcard mode, allowlist mode, edge cases (ports, schemes, empty origins)
- **wrangler.toml updated**: Added `ALLOWED_ORIGINS` variable with documentation

## Testing
- All 11 unit tests pass (buildCorsHeaders function verified with node)
- Wildcard mode: returns `*` when no allowlist configured
- Allowlist mode: reflects allowed origins, blocks disallowed ones
- Edge cases: port/scheme differences, null origin, empty strings

## Related Issues
Fixes #1049