### PR TITLE
chore: tune provider chaos testing simulation latency thresholds

### DIFF
--- a/docs/CENTRALIZED_CONFIG.md
+++ b/docs/CENTRALIZED_CONFIG.md
@@ -20,6 +20,7 @@ The application uses **Convict** for centralized configuration management. This 
 The main schema is defined in `src/config/appConfig.ts`. It includes:
 
 ### Provider Limits
+
 ```
 providers:
   - mtn: { minAmount, maxAmount }
@@ -28,6 +29,7 @@ providers:
 ```
 
 ### Transaction Limits (by KYC Level)
+
 ```
 transactionLimits:
   - unverified: daily limit
@@ -36,6 +38,7 @@ transactionLimits:
 ```
 
 ### General Transaction Settings
+
 ```
 transactions:
   - minAmount: global minimum
@@ -48,6 +51,7 @@ transactions:
 ```
 
 ### Authentication Settings
+
 ```
 auth:
   - maxLoginAttempts: failed login limit
@@ -56,6 +60,7 @@ auth:
 ```
 
 ### Cache Settings
+
 ```
 cache:
   - geolocationTtlSeconds
@@ -82,16 +87,20 @@ Configuration files are stored in `src/config/configurations/`:
 ### Import the config module
 
 ```typescript
-import { getConfigValue, getConfig } from 'src/config';
+import { getConfigValue, getConfig } from "src/config";
 
 // Get a single value
-const maxAmount = getConfigValue('providers.mtn.maxAmount');
+const maxAmount = getConfigValue("providers.mtn.maxAmount");
 
 // Get all configuration
 const config = getConfig();
 
 // Use helper functions
-import { getTransactionConfig, getCacheConfig, getAuthConfig } from 'src/config';
+import {
+  getTransactionConfig,
+  getCacheConfig,
+  getAuthConfig,
+} from "src/config";
 
 const txConfig = getTransactionConfig();
 console.log(txConfig.timeoutMinutes);
@@ -100,7 +109,7 @@ console.log(txConfig.timeoutMinutes);
 ### In Service Classes
 
 ```typescript
-import { getConfigValue } from 'src/config';
+import { getConfigValue } from "src/config";
 
 class TransactionService {
   validateAmount(provider: string, amount: number) {
@@ -139,11 +148,53 @@ export MAX_LOGIN_ATTEMPTS=10
 export SLOW_QUERY_THRESHOLD_MS=2000
 ```
 
+### Chaos Provider Controls
+
+The staging chaos provider reads its simulation settings directly from `process.env`
+when `ChaosMiddleware` is constructed without an explicit config. Tests may also
+pass an explicit `ChaosConfig` object to override these values for a single run.
+
+| Variable               | Default | Description                                                                          |
+| ---------------------- | ------: | ------------------------------------------------------------------------------------ |
+| `CHAOS_ENABLED`        | `false` | Enables latency and failure injection when set to `true`, `1`, `yes`, or `on`.       |
+| `CHAOS_LATENCY_CHANCE` |     `0` | Ratio from `0` to `1` for adding latency to an operation.                            |
+| `CHAOS_LATENCY_MIN_MS` |     `0` | Lower latency bound in milliseconds.                                                 |
+| `CHAOS_LATENCY_MAX_MS` |     `0` | Upper latency bound in milliseconds.                                                 |
+| `CHAOS_LATENCY_MS`     |     `0` | Backward-compatible alias for `CHAOS_LATENCY_MAX_MS` when the max variable is unset. |
+| `CHAOS_ERROR_CHANCE`   |     `0` | Ratio from `0` to `1` for returning a simulated provider 500 response.               |
+| `CHAOS_DROP_CHANCE`    |     `0` | Ratio from `0` to `1` for throwing a simulated connection reset.                     |
+
+Examples:
+
+```bash
+# Disable chaos entirely
+CHAOS_ENABLED=false pnpm test tests/services/mobilemoney/chaos.test.ts
+
+# Add 100-750ms latency to every provider call, without injected failures
+CHAOS_ENABLED=true \
+CHAOS_LATENCY_CHANCE=1 \
+CHAOS_LATENCY_MIN_MS=100 \
+CHAOS_LATENCY_MAX_MS=750 \
+CHAOS_ERROR_CHANCE=0 \
+CHAOS_DROP_CHANCE=0 \
+pnpm test tests/services/mobilemoney/chaos.test.ts
+
+# Run a mixed staging scenario with latency, provider 500s, and drops
+CHAOS_ENABLED=true \
+CHAOS_LATENCY_CHANCE=0.4 \
+CHAOS_LATENCY_MIN_MS=50 \
+CHAOS_LATENCY_MAX_MS=500 \
+CHAOS_ERROR_CHANCE=0.05 \
+CHAOS_DROP_CHANCE=0.02 \
+pnpm test
+```
+
 ## Migration Guide
 
 ### For Existing Code
 
 Old approach (hardcoded):
+
 ```typescript
 const MIN_AMOUNT = 100;
 const MAX_AMOUNT = 500000;
@@ -154,11 +205,12 @@ if (amount < MIN_AMOUNT) {
 ```
 
 New approach (config):
-```typescript
-import { getConfigValue } from 'src/config';
 
-const minAmount = getConfigValue('transactions.minAmount');
-const maxAmount = getConfigValue('transactions.maxAmount');
+```typescript
+import { getConfigValue } from "src/config";
+
+const minAmount = getConfigValue("transactions.minAmount");
+const maxAmount = getConfigValue("transactions.maxAmount");
 
 if (amount < minAmount) {
   // error
@@ -168,20 +220,22 @@ if (amount < minAmount) {
 ### Fetching Provider Limits
 
 Old approach:
+
 ```typescript
-import { PROVIDER_LIMITS } from 'src/config/providers';
-const limits = PROVIDER_LIMITS['mtn'];
+import { PROVIDER_LIMITS } from "src/config/providers";
+const limits = PROVIDER_LIMITS["mtn"];
 ```
 
 New approach (still works!):
+
 ```typescript
 // Direct import still works due to migration
-import { PROVIDER_LIMITS } from 'src/config/providers';
-const limits = PROVIDER_LIMITS['mtn'];
+import { PROVIDER_LIMITS } from "src/config/providers";
+const limits = PROVIDER_LIMITS["mtn"];
 
 // Or use helper
-import { getProviderLimit } from 'src/config';
-const limits = getProviderLimit('mtn');
+import { getProviderLimit } from "src/config";
+const limits = getProviderLimit("mtn");
 ```
 
 ## Configuration Precedence
@@ -194,7 +248,7 @@ const limits = getProviderLimit('mtn');
    - Development-only overrides
    - Gitignored for security
 
-3. **Environment-Specific Configuration** 
+3. **Environment-Specific Configuration**
    - `development.json`, `staging.json`, `production.json`
    - Based on `NODE_ENV` value
 
@@ -204,18 +258,20 @@ const limits = getProviderLimit('mtn');
 ## Adding New Configuration
 
 1. **Add to Schema** in `src/config/appConfig.ts`:
+
 ```typescript
 export const configSchema = convict({
   myNewSetting: {
-    doc: 'Description of the setting',
-    format: String,  // or 'nat', Number, Boolean, etc.
-    default: 'default-value',
-    env: 'MY_NEW_SETTING',  // optional env var name
+    doc: "Description of the setting",
+    format: String, // or 'nat', Number, Boolean, etc.
+    default: "default-value",
+    env: "MY_NEW_SETTING", // optional env var name
   },
 });
 ```
 
 2. **Add to Environment Files**:
+
 ```json
 // src/config/configurations/development.json
 {
@@ -224,14 +280,16 @@ export const configSchema = convict({
 ```
 
 3. **Use in Code**:
+
 ```typescript
-import { getConfigValue } from 'src/config';
-const setting = getConfigValue('myNewSetting');
+import { getConfigValue } from "src/config";
+const setting = getConfigValue("myNewSetting");
 ```
 
 ## Best Practices
 
 ✅ **DO:**
+
 - Use config for all limits, TTLs, and thresholds
 - Document all configuration options
 - Use environment variables in production
@@ -239,6 +297,7 @@ const setting = getConfigValue('myNewSetting');
 - Use typed helper functions
 
 ❌ **DON'T:**
+
 - Hardcode magic numbers
 - Use `process.env.MY_VAR` directly (use `getConfigValue` instead)
 - Store sensitive data in JSON files (use env vars instead)
@@ -247,11 +306,13 @@ const setting = getConfigValue('myNewSetting');
 ## Testing
 
 Run configuration tests:
+
 ```bash
 npm test -- src/config/__tests__/appConfig.test.ts
 ```
 
 Validate configuration at startup:
+
 ```bash
 npm run build && npm start
 ```
@@ -259,16 +320,19 @@ npm run build && npm start
 ## Troubleshooting
 
 ### Configuration not loading
+
 - Check that `NODE_ENV` is set correctly
 - Verify JSON files are in `src/config/configurations/`
 - Check for JSON syntax errors
 
 ### Environment variable not working
+
 - Ensure variable name matches the schema
 - Check that convict's env property is set
 - Note: Changes require app restart
 
 ### Circular dependency issues
+
 - Import config init early: `import 'src/config/init'`
 - Use lazy imports if needed: `const { getConfigValue } = require('src/config')`
 

--- a/src/services/mobilemoney/providers/chaos.ts
+++ b/src/services/mobilemoney/providers/chaos.ts
@@ -4,16 +4,87 @@ import logger from "../../../utils/logger";
 export interface ChaosConfig {
   enabled: boolean;
   latencyChance: number; // 0 to 1
-  latencyMs: number;
+  latencyMinMs?: number;
+  latencyMaxMs?: number;
+  latencyMs?: number;
   errorChance: number; // 0 to 1
   dropChance: number; // 0 to 1
 }
 
+type NormalizedChaosConfig = ChaosConfig & {
+  latencyMinMs: number;
+  latencyMaxMs: number;
+};
+
+const DEFAULT_CHAOS_CONFIG: NormalizedChaosConfig = {
+  enabled: false,
+  latencyChance: 0,
+  latencyMinMs: 0,
+  latencyMaxMs: 0,
+  errorChance: 0,
+  dropChance: 0,
+};
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+function parseNumber(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === "") return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function clampRatio(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function normalizeLatencyBounds(minMs: number, maxMs: number): Pick<NormalizedChaosConfig, "latencyMinMs" | "latencyMaxMs"> {
+  const lower = Math.max(0, Math.floor(minMs));
+  const upper = Math.max(0, Math.floor(maxMs));
+
+  return lower <= upper
+    ? { latencyMinMs: lower, latencyMaxMs: upper }
+    : { latencyMinMs: upper, latencyMaxMs: lower };
+}
+
+export function getChaosConfigFromEnv(env: NodeJS.ProcessEnv = process.env): NormalizedChaosConfig {
+  const latencyMaxFallback = parseNumber(env.CHAOS_LATENCY_MS, DEFAULT_CHAOS_CONFIG.latencyMaxMs);
+  const latencyMinMs = parseNumber(env.CHAOS_LATENCY_MIN_MS, DEFAULT_CHAOS_CONFIG.latencyMinMs);
+  const latencyMaxMs = parseNumber(env.CHAOS_LATENCY_MAX_MS, latencyMaxFallback);
+
+  return {
+    enabled: parseBoolean(env.CHAOS_ENABLED, DEFAULT_CHAOS_CONFIG.enabled),
+    latencyChance: clampRatio(parseNumber(env.CHAOS_LATENCY_CHANCE, DEFAULT_CHAOS_CONFIG.latencyChance)),
+    ...normalizeLatencyBounds(latencyMinMs, latencyMaxMs),
+    errorChance: clampRatio(parseNumber(env.CHAOS_ERROR_CHANCE, DEFAULT_CHAOS_CONFIG.errorChance)),
+    dropChance: clampRatio(parseNumber(env.CHAOS_DROP_CHANCE, DEFAULT_CHAOS_CONFIG.dropChance)),
+  };
+}
+
+function normalizeConfig(config: ChaosConfig): NormalizedChaosConfig {
+  const latencyMaxMs = config.latencyMaxMs ?? config.latencyMs ?? DEFAULT_CHAOS_CONFIG.latencyMaxMs;
+
+  return {
+    enabled: config.enabled,
+    latencyChance: clampRatio(config.latencyChance),
+    ...normalizeLatencyBounds(config.latencyMinMs ?? 0, latencyMaxMs),
+    latencyMs: config.latencyMs,
+    errorChance: clampRatio(config.errorChance),
+    dropChance: clampRatio(config.dropChance),
+  };
+}
+
 export class ChaosMiddleware implements MobileMoneyProvider {
+  private config: NormalizedChaosConfig;
+
   constructor(
     private inner: MobileMoneyProvider,
-    private config: ChaosConfig,
-  ) {}
+    config: ChaosConfig = getChaosConfigFromEnv(),
+  ) {
+    this.config = normalizeConfig(config);
+  }
 
   private shouldInject(chance: number): boolean {
     return this.config.enabled && Math.random() < chance;
@@ -32,7 +103,8 @@ export class ChaosMiddleware implements MobileMoneyProvider {
 
     // 1. Latency injection
     if (this.shouldInject(this.config.latencyChance)) {
-      const delay = Math.floor(Math.random() * this.config.latencyMs);
+      const { latencyMinMs, latencyMaxMs } = this.config;
+      const delay = latencyMinMs + Math.floor(Math.random() * (latencyMaxMs - latencyMinMs + 1));
       log.info({ delay }, "Chaos: Injecting latency");
       await this.sleep(delay);
     }

--- a/tests/services/mobilemoney/chaos.test.ts
+++ b/tests/services/mobilemoney/chaos.test.ts
@@ -1,24 +1,27 @@
-import { MobileMoneyService } from "../../../src/services/mobilemoney/mobileMoneyService";
 import { MockProvider } from "../../../src/services/mobilemoney/providers/mock";
-import { ChaosMiddleware } from "../../../src/services/mobilemoney/providers/chaos";
+import { ChaosMiddleware, getChaosConfigFromEnv } from "../../../src/services/mobilemoney/providers/chaos";
 
 describe("ChaosMiddleware", () => {
   let mockProvider: MockProvider;
+  const originalEnv = process.env;
 
   beforeEach(() => {
+    process.env = { ...originalEnv };
     mockProvider = new MockProvider();
     jest.spyOn(console, "log").mockImplementation(() => {});
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    process.env = originalEnv;
   });
 
   it("should inject latency when enabled", async () => {
     const config = {
       enabled: true,
       latencyChance: 1.0, // Always inject
-      latencyMs: 100,
+      latencyMinMs: 100,
+      latencyMaxMs: 100,
       errorChance: 0,
       dropChance: 0,
     };
@@ -38,7 +41,8 @@ describe("ChaosMiddleware", () => {
     const config = {
       enabled: true,
       latencyChance: 0,
-      latencyMs: 0,
+      latencyMinMs: 0,
+      latencyMaxMs: 0,
       errorChance: 1.0, // Always fail
       dropChance: 0,
     };
@@ -53,7 +57,8 @@ describe("ChaosMiddleware", () => {
     const config = {
       enabled: true,
       latencyChance: 0,
-      latencyMs: 0,
+      latencyMinMs: 0,
+      latencyMaxMs: 0,
       errorChance: 0,
       dropChance: 1.0, // Always drop
     };
@@ -66,7 +71,8 @@ describe("ChaosMiddleware", () => {
     const config = {
       enabled: false,
       latencyChance: 1.0,
-      latencyMs: 1000,
+      latencyMinMs: 1000,
+      latencyMaxMs: 1000,
       errorChance: 1.0,
       dropChance: 1.0,
     };
@@ -74,5 +80,36 @@ describe("ChaosMiddleware", () => {
     
     const result = await chaos.requestPayment("123456789", "1000");
     expect(result.success).toBe(true);
+  });
+
+  it("should build chaos config from environment variables", () => {
+    const config = getChaosConfigFromEnv({
+      CHAOS_ENABLED: "true",
+      CHAOS_LATENCY_CHANCE: "0.25",
+      CHAOS_LATENCY_MIN_MS: "50",
+      CHAOS_LATENCY_MAX_MS: "250",
+      CHAOS_ERROR_CHANCE: "0.1",
+      CHAOS_DROP_CHANCE: "0.05",
+    });
+
+    expect(config).toEqual({
+      enabled: true,
+      latencyChance: 0.25,
+      latencyMinMs: 50,
+      latencyMaxMs: 250,
+      errorChance: 0.1,
+      dropChance: 0.05,
+    });
+  });
+
+  it("should use environment configuration when no explicit config is provided", async () => {
+    process.env.CHAOS_ENABLED = "true";
+    process.env.CHAOS_ERROR_CHANCE = "1";
+
+    const chaos = new ChaosMiddleware(mockProvider);
+
+    const result = await chaos.requestPayment("123456789", "1000");
+    expect(result.success).toBe(false);
+    expect((result as any).error.status).toBe(500);
   });
 });


### PR DESCRIPTION
## Description

- Added environment-driven chaos configuration for latency, provider 500s, and connection drops.
- Added latency min/max bounds with safe defaults, ratio clamping, and legacy CHAOS_LATENCY_MS support.
- Documented chaos controls and sample test/staging scenarios in developer config docs.

## Testing
- pnpm exec jest --runTestsByPath tests/services/mobilemoney/chaos.test.ts --testPathIgnorePatterns=tests/pact --forceExit

## Notes
- pnpm test tests/services/mobilemoney/chaos.test.ts currently expands into the broader Jest suite in this repo; the focused chaos test path above passes.

## Related Issue

closes #858

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [s] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

- pnpm exec jest --runTestsByPath tests/services/mobilemoney/chaos.test.ts --testPathIgnorePatterns=tests/pact --forceExit

## Checklist

- [s] Code follows project style
- [s] Self-reviewed my code
- [s] Commented complex code
- [s] Updated documentation
- [s] No new warnings
- [s] Added tests (if applicable)