### PR TITLE
feat: add Tanzania Tigo/Vodacom phone number validation (Fixes #1039)

### DIFF
--- a/src/utils/phoneUtils.ts
+++ b/src/utils/phoneUtils.ts
@@ -1,6 +1,6 @@
 import { parsePhoneNumberFromString, type CountryCode } from "libphonenumber-js";
 
-export type MobileProvider = "mtn" | "airtel" | "orange";
+export type MobileProvider = "mtn" | "airtel" | "orange" | "tigo" | "vodacom";
 type PhoneOutputFormat = "e164" | "national";
 
 interface ProviderPhoneFormatConfig {
@@ -16,6 +16,8 @@ const PROVIDER_PREFIXES: Record<MobileProvider, string[]> = {
   mtn: ["23767", "23768", "25677", "25678", "23324", "23354", "23355", "23359"],
   airtel: ["23766", "25670", "25675", "23326", "23356", "23357"],
   orange: ["23765", "23769", "22507", "22177"],
+  tigo: ["25565", "25566", "25567", "25571"],
+  vodacom: ["25575", "25576", "25561", "25562", "25574"],
 };
 
 const PROVIDER_PHONE_FORMATS: Record<MobileProvider, ProviderPhoneFormatConfig> = {
@@ -29,6 +31,14 @@ const PROVIDER_PHONE_FORMATS: Record<MobileProvider, ProviderPhoneFormatConfig> 
   },
   orange: {
     defaultRegion: "CM",
+    output: "e164",
+  },
+  tigo: {
+    defaultRegion: "TZ",
+    output: "e164",
+  },
+  vodacom: {
+    defaultRegion: "TZ",
     output: "e164",
   },
 };

--- a/tests/utils/phoneUtils.test.ts
+++ b/tests/utils/phoneUtils.test.ts
@@ -34,9 +34,51 @@ describe("phoneUtils", () => {
     });
 
     it("should return invalid for a phone number that does not match the provider", () => {
-      const result = validatePhoneProviderMatch("+256701234567", "mtn");
+      const result = validatePhoneProviderMatch("+256****4567", "mtn");
       expect(result.valid).toBe(false);
       expect(result.error).toContain("does not belong to the MTN network");
+    });
+
+    it("should return valid for a matching tigo number (Tanzania)", () => {
+      const result = validatePhoneProviderMatch("+25565123456", "tigo");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching tigo number with 71 prefix", () => {
+      const result = validatePhoneProviderMatch("+255711234567", "tigo");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching vodacom number (Tanzania)", () => {
+      const result = validatePhoneProviderMatch("+255751234567", "vodacom");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching vodacom number with 61 prefix", () => {
+      const result = validatePhoneProviderMatch("+255611234567", "vodacom");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return invalid when tanzania number does not match tigo", () => {
+      const result = validatePhoneProviderMatch("+255751234567", "tigo");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("does not belong to the TIGO network");
+    });
+
+    it("should return invalid when tanzania number does not match vodacom", () => {
+      const result = validatePhoneProviderMatch("+255651234567", "vodacom");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("does not belong to the VODACOM network");
+    });
+
+    it("should handle case-insensitive tigo provider", () => {
+      const result = validatePhoneProviderMatch("+25565123456", "TIGO");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should handle case-insensitive vodacom provider", () => {
+      const result = validatePhoneProviderMatch("+255751234567", "Vodacom");
+      expect(result.valid).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds phone number prefix validation for Tanzania's Tigo and Vodacom mobile money providers.

## Changes
- Extended `MobileProvider` type to include `tigo` and `vodacom`
- Added Tanzania phone prefixes (country code +255):
  - **Tigo:** 25565, 25566, 25567, 25571
  - **Vodacom:** 25575, 25576, 25561, 25562, 25574
- Added TZ default region for phone format configs
- Added 8 comprehensive tests covering:
  - Valid matching numbers for both providers
  - Cross-provider rejection (Tigo number rejected for Vodacom and vice versa)
  - Case-insensitive provider names

## Testing
- All existing tests continue to pass
- New tests validate Tanzania prefix matching and cross-provider rejection

Fixes #1039