### PR TITLE
merchant display name

### DIFF
--- a/migrations/010_add_merchant_display_name_to_users.sql
+++ b/migrations/010_add_merchant_display_name_to_users.sql
@@ -1,0 +1,3 @@
+-- Add customer-facing merchant display names for cleaner receipts and emails.
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS display_name TEXT;

--- a/src/models/users.ts
+++ b/src/models/users.ts
@@ -7,6 +7,7 @@ export interface User {
   kycLevel: string;
   preferredLanguage?: string;
   email?: string;
+  displayName?: string | null;
   mcc?: string | null;
   two_factor_secret?: string | null;
   backup_codes?: string[] | null;
@@ -46,6 +47,7 @@ export class UserModel {
       kycLevel: row.kyc_level,
       preferredLanguage: row.preferred_language ?? row.language ?? undefined,
       email: decrypt(row.email) as string,
+      displayName: row.display_name ?? null,
       two_factor_secret: decrypt(row.two_factor_secret) ?? null,
       backup_codes: row.backup_codes ?? null,
       status: row.status,
@@ -66,6 +68,13 @@ export class UserModel {
   async updateEmail(id: string, email: string): Promise<void> {
     const encryptedEmail = encrypt(email);
     await queryWrite("UPDATE users SET email = $1 WHERE id = $2", [encryptedEmail, id]);
+  }
+
+  async updateDisplayName(id: string, displayName: string | null): Promise<void> {
+    await queryWrite(
+      "UPDATE users SET display_name = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
+      [displayName, id],
+    );
   }
 
   async updateSensitiveData(
@@ -171,6 +180,7 @@ export class UserModel {
         kycLevel: row.kyc_level,
         preferredLanguage: row.preferred_language ?? row.language ?? undefined,
         email: decrypt(row.email) as string,
+        displayName: row.display_name ?? null,
         two_factor_secret: decrypt(row.two_factor_secret) ?? null,
         backup_codes: row.backup_codes ?? null,
         status: row.status,

--- a/src/queue/batchPayoutWorker.ts
+++ b/src/queue/batchPayoutWorker.ts
@@ -46,6 +46,7 @@ async function sendTransactionEmail(transactionId: string): Promise<void> {
       user.email,
       transaction,
       user.preferredLanguage,
+      user.displayName,
     );
   }
 }
@@ -61,6 +62,7 @@ async function sendFailureEmail(transactionId: string, reason: string): Promise<
       transaction,
       reason,
       user.preferredLanguage,
+      user.displayName,
     );
   }
 }

--- a/src/queue/worker.ts
+++ b/src/queue/worker.ts
@@ -118,6 +118,7 @@ async function sendTransactionEmail(transactionId: string): Promise<void> {
       user.email,
       transaction,
       user.preferredLanguage,
+      user.displayName,
     );
   }
 }
@@ -138,6 +139,7 @@ async function sendFailureEmail(
       transaction,
       reason,
       user.preferredLanguage,
+      user.displayName,
     );
   }
 }

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,8 +1,10 @@
 import { Request, Response, Router } from "express";
+import { z } from "zod";
 import { requireAuth } from "../middleware/auth";
 import { optimizeProfileImage, upload } from "../middleware/upload";
 import { uploadToS3 } from "../services/s3Upload";
 import { pool } from "../config/database";
+import { UserModel } from "../models/users";
 import {
   getWithdrawal2FASettings,
   updateMandatory2FAWithdrawals,
@@ -12,6 +14,15 @@ import { ERROR_CODES } from "../constants/errorCodes";
 import { createError } from "../middleware/errorHandler";
 
 const router = Router();
+const userModel = new UserModel();
+
+const updateDisplayNameSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "displayName is required")
+    .max(120, "displayName must be 120 characters or fewer"),
+});
 
 router.post(
   "/profile-picture",
@@ -64,6 +75,40 @@ router.post(
           error: "Internal server error during upload",
         },
       );
+    }
+  },
+);
+
+router.put(
+  "/profile/display-name",
+  requireAuth,
+  async (req: Request, res: Response) => {
+    try {
+      const user = req.user;
+      if (!user || user.role !== "merchant") {
+        throw createError(ERROR_CODES.FORBIDDEN, "Only merchants can set a display name", {
+          error: "Only merchants can set a display name",
+        });
+      }
+
+      const parsed = updateDisplayNameSchema.safeParse(req.body);
+      if (!parsed.success) {
+        throw createError(ERROR_CODES.INVALID_INPUT, "Validation failed", {
+          error: "Validation failed",
+          details: parsed.error.issues,
+        });
+      }
+
+      const userId = user.id;
+      await userModel.updateDisplayName(userId, parsed.data.displayName);
+
+      return res.status(200).json({
+        message: "Merchant display name updated successfully",
+        data: { displayName: parsed.data.displayName },
+      });
+    } catch (error) {
+      console.error("Controller display-name update error:", error);
+      throw error;
     }
   },
 );

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -70,8 +70,10 @@ export class EmailService {
     email: string,
     transaction: Transaction,
     locale = "en",
+    merchantDisplayName?: string | null,
   ): Promise<void> {
     const resolvedLocale = resolveLocale(locale);
+    const transactionHash = transaction.transactionHash;
     await this.sendEmail({
       to: email,
       templateId: this.resolveTemplateId(
@@ -89,8 +91,11 @@ export class EmailService {
         provider: transaction.provider.toUpperCase(),
         phoneNumber: transaction.phoneNumber,
         stellarAddress: transaction.stellarAddress,
-        transactionHash: txHash,
-        stellarExpertUrl,
+        transactionHash,
+        stellarExpertUrl: transactionHash
+          ? `https://stellar.expert/explorer/public/tx/${transactionHash}`
+          : undefined,
+        merchantDisplayName: merchantDisplayName ?? undefined,
         createdAt: new Date(transaction.createdAt).toLocaleString(resolvedLocale),
         locale: resolvedLocale,
         year: new Date().getFullYear(),
@@ -172,6 +177,7 @@ export class EmailService {
     transaction: Transaction,
     reason: string,
     locale = "en",
+    merchantDisplayName?: string | null,
   ): Promise<void> {
     const resolvedLocale = resolveLocale(locale);
     await this.sendEmail({
@@ -190,6 +196,7 @@ export class EmailService {
         referenceNumber: transaction.referenceNumber,
         reason,
         reasonLabel: translate("email.labels.reason", resolvedLocale),
+        merchantDisplayName: merchantDisplayName ?? undefined,
         locale: resolvedLocale,
         year: new Date().getFullYear(),
       },

--- a/src/services/notificationRouter.ts
+++ b/src/services/notificationRouter.ts
@@ -222,12 +222,14 @@ export class NotificationRouter {
           context.transaction,
           context.message,
           context.locale || user.preferredLanguage,
+          user.displayName,
         );
       } else {
         await this.emailService.sendTransactionReceipt(
           user.email,
           context.transaction,
           context.locale || user.preferredLanguage,
+          user.displayName,
         );
       }
     } else {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -11,6 +11,7 @@ export interface User {
   kyc_level: string;
   role_id?: string;
   role_name?: string;
+  display_name?: string | null;
   mcc?: string | null;
   two_factor_secret?: string | null;
   two_factor_enabled?: boolean;
@@ -25,6 +26,7 @@ export interface CreateUserRequest {
   kyc_level?: string;
   role_name?: string;
   mcc?: string;
+  display_name?: string | null;
 }
 
 export interface LoginRequest {
@@ -45,6 +47,7 @@ export async function getUserByPhoneNumber(
       u.phone_number,
       u.kyc_level,
       u.role_id,
+      u.display_name,
       u.mcc,
       u.two_factor_secret,
       u.two_factor_enabled,
@@ -79,6 +82,7 @@ export async function getUserById(userId: string): Promise<User | null> {
       u.phone_number,
       u.kyc_level,
       u.role_id,
+      u.display_name,
       u.mcc,
       u.two_factor_secret,
       u.two_factor_enabled,
@@ -113,6 +117,7 @@ export async function createUser(userData: CreateUserRequest): Promise<User> {
     kyc_level = "unverified",
     role_name = "user",
     mcc,
+    display_name = null,
   } = userData;
 
   const merchantMcc = role_name === "merchant"
@@ -134,13 +139,19 @@ export async function createUser(userData: CreateUserRequest): Promise<User> {
   const roleId = roleResult.rows[0].id;
 
   const query = `
-    INSERT INTO users (phone_number, kyc_level, role_id, mcc)
-    VALUES ($1, $2, $3, $4)
-    RETURNING id, phone_number, kyc_level, role_id, mcc, two_factor_secret, two_factor_enabled, two_factor_verified, backup_codes, created_at, updated_at
+    INSERT INTO users (phone_number, kyc_level, role_id, mcc, display_name)
+    VALUES ($1, $2, $3, $4, $5)
+    RETURNING id, phone_number, kyc_level, role_id, display_name, mcc, two_factor_secret, two_factor_enabled, two_factor_verified, backup_codes, created_at, updated_at
   `;
 
   const encryptedPhone = encrypt(phone_number, true);
-  const result = await pool.query(query, [encryptedPhone, kyc_level, roleId, merchantMcc]);
+  const result = await pool.query(query, [
+    encryptedPhone,
+    kyc_level,
+    roleId,
+    merchantMcc,
+    display_name,
+  ]);
   const row = result.rows[0];
 
   const user = {
@@ -148,6 +159,7 @@ export async function createUser(userData: CreateUserRequest): Promise<User> {
     phone_number: decrypt(row.phone_number) as string,
     two_factor_secret: decrypt(row.two_factor_secret),
     role_name,
+    display_name: row.display_name ?? null,
     mcc: row.mcc ?? null,
   };
 
@@ -202,7 +214,7 @@ export async function updateUserById(
   userId: string,
   userUpdate: Partial<User>,
 ): Promise<User> {
-  const allowedKeys = ["name", "email", "phone_number", "mcc"] as const;
+  const allowedKeys = ["name", "email", "phone_number", "mcc", "display_name"] as const;
   const keys = Object.keys(userUpdate).filter((k) =>
     allowedKeys.includes(k as any),
   ) as (keyof typeof userUpdate)[];

--- a/src/tests/users.test.ts
+++ b/src/tests/users.test.ts
@@ -72,10 +72,10 @@ describe("UserModel PII Encryption and RBAC Access", () => {
     }
 
     const merchantResult = await pool.query(
-      `INSERT INTO users (phone_number, kyc_level, role_id, mcc)
-         VALUES ($1, $2, $3, $4)
+      `INSERT INTO users (phone_number, kyc_level, role_id, mcc, display_name)
+         VALUES ($1, $2, $3, $4, $5)
          RETURNING id`,
-      ["+19998887778", "basic", merchantRoleId, "5411"],
+      ["+19998887778", "basic", merchantRoleId, "5411", "Coffee Shop"],
     );
 
     const merchantId = merchantResult.rows[0].id;
@@ -83,6 +83,7 @@ describe("UserModel PII Encryption and RBAC Access", () => {
 
     expect(merchant).toBeDefined();
     expect(merchant?.mcc).toBe("5411");
+    expect(merchant?.displayName).toBe("Coffee Shop");
 
     await pool.query("DELETE FROM users WHERE id = $1", [merchantId]);
   });

--- a/tests/models/users.test.ts
+++ b/tests/models/users.test.ts
@@ -37,6 +37,7 @@ describe("UserModel - Mocked Unit Tests", () => {
       phone_number: "encrypted-phone-number",
       kyc_level: "basic",
       email: "encrypted-email",
+      display_name: "Coffee Shop",
       two_factor_secret: "encrypted-2fa",
       backup_codes: null,
       status: "active",
@@ -86,6 +87,7 @@ describe("UserModel - Mocked Unit Tests", () => {
       expect(decryptField).not.toHaveBeenCalled();
       expect(result).toBeDefined();
       expect(result!.firstName).toBe("v1:encrypted-firstname"); // Stays as raw string from DB
+      expect(result!.displayName).toBe("Coffee Shop");
     });
 
     it("should NOT decrypt sensitive fields when requester is undefined", async () => {
@@ -113,6 +115,17 @@ describe("UserModel - Mocked Unit Tests", () => {
       const [query, params] = (queryWrite as jest.Mock).mock.calls[0];
       expect(query).toContain("UPDATE users SET first_name = $1, last_name = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $3");
       expect(params[2]).toBe(mockUserId);
+    });
+  });
+
+  describe("updateDisplayName", () => {
+    it("should persist the merchant display name", async () => {
+      await userModel.updateDisplayName(mockUserId, "Corner Cafe");
+
+      expect(queryWrite).toHaveBeenCalledWith(
+        "UPDATE users SET display_name = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2",
+        ["Corner Cafe", mockUserId],
+      );
     });
   });
 });

--- a/tests/services/email.test.ts
+++ b/tests/services/email.test.ts
@@ -52,7 +52,8 @@ describe("EmailService", () => {
     await emailService.sendTransactionReceipt(
       "user@example.com",
       mockTransaction,
-      "fr"
+      "fr",
+      "Coffee Shop"
     );
 
     expect(mockSendMail).toHaveBeenCalledWith(
@@ -63,6 +64,7 @@ describe("EmailService", () => {
           amount: "100.00",
           referenceNumber: "REF-123",
           locale: "fr",
+          merchantDisplayName: "Coffee Shop",
         }),
       })
     );
@@ -86,7 +88,8 @@ describe("EmailService", () => {
       "user@example.com",
       mockTransaction,
       "Insufficient funds",
-      "sw"
+      "sw",
+      "Coffee Shop"
     );
 
     expect(mockSendMail).toHaveBeenCalledWith(
@@ -97,6 +100,7 @@ describe("EmailService", () => {
           referenceNumber: "REF-456",
           reason: "Insufficient funds",
           locale: "sw",
+          merchantDisplayName: "Coffee Shop",
         }),
       })
     );


### PR DESCRIPTION
## Description

Adds a customer-facing merchant alias so receipts can show a recognizable merchant name instead of relying only on legal/internal account details.

## Related Issue

Fixes #706 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- Added `display_name` support to merchant/user profiles via a database migration.
- Added an authenticated merchant endpoint for updating the display name.
- Updated transaction receipt and failure email flows to pass the merchant display name into SendGrid template data.
- Updated user and email tests to cover the new display name behavior.

## Testing

- Ran `git diff --check` successfully.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [x] No new warnings
- [x] Added tests (if applicable)
