### PR TITLE
Standardize API versioning headers

### DIFF
--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -69,16 +69,19 @@ curl -X POST https://api.example.com/api/v2/transactions/deposit \
   -d '{"amount": 100, "phone": "+1234567890"}'
 ```
 
-### Method 2: Accept Header Versioning
+### Method 2: Accept-Version Header Versioning
 
-Specify version in the Accept header:
+Specify version in the `Accept-Version` header:
 
 ```bash
 curl -X POST https://api.example.com/api/transactions/deposit \
-  -H "Accept: application/json;version=v1" \
+  -H "Accept-Version: v1" \
   -H "Content-Type: application/json" \
   -d '{"amount": 100, "phone": "+1234567890"}'
 ```
+
+The legacy `Accept: application/json;version=v1` format is still accepted for
+backward compatibility, but `Accept-Version` is the preferred header.
 
 ### Method 3: Legacy Endpoints
 
@@ -101,7 +104,7 @@ All API responses include version information:
 ```
 HTTP/1.1 200 OK
 API-Version: v1
-Vary: Accept
+Vary: Accept, Accept-Version
 Deprecation: false
 Content-Type: application/json
 
@@ -113,7 +116,7 @@ Content-Type: application/json
 ### Header Meanings
 
 - **API-Version**: Current API version used for this request
-- **Vary**: Cache control - indicates Accept header affects response
+- **Vary**: Cache control - indicates version headers affect response
 - **Deprecation**: True if endpoint is deprecated
 - **Sunset**: Date when deprecated endpoint will be removed
 - **Link**: Alternative version URL (on Deprecation: true)
@@ -176,10 +179,13 @@ HTTP/1.1 400 Bad Request
 1. URL path (highest priority)
    - `/api/v1/transactions` → uses `v1`
 
-2. Accept header
+2. Accept-Version header
+   - `Accept-Version: v1` → uses `v1`
+
+3. Accept header
    - `Accept: application/json;version=v1` → uses `v1`
 
-3. Default
+4. Default
    - No version specified → uses `v1`
 
 ## Best Practices
@@ -214,8 +220,8 @@ npm test tests/api-versioning.test.ts
 # Test v1
 curl -i https://api.example.com/api/v1/transactions
 
-# Test Accept header
-curl -i -H "Accept: application/json;version=v1" \
+# Test Accept-Version header
+curl -i -H "Accept-Version: v1" \
   https://api.example.com/api/transactions
 
 # Test legacy endpoint
@@ -268,7 +274,7 @@ ORDER BY date DESC;
 
 ## FAQ
 
-**Q: Should I use URL versioning or Accept header?**
+**Q: Should I use URL versioning or Accept-Version header?**
 A: Use URL path versioning. It's clearer, easier to debug, and better for caching.
 
 **Q: How do I know which version to use?**

--- a/src/middleware/apiVersion.ts
+++ b/src/middleware/apiVersion.ts
@@ -24,9 +24,14 @@ export const CURRENT_VERSION = "v1";
 export const SUPPORTED_VERSIONS: string[] = ["v1"];
 export const DEPRECATED_VERSIONS: string[] = [];
 
+const normalizeApiVersion = (version: string): string | undefined => {
+  const match = version.trim().match(/^v?(\d+)$/i);
+  return match ? `v${match[1]}` : undefined;
+};
+
 /**
- * Middleware: Extract API version from URL or Accept header
- * Priority: URL path > Accept header > default (v1)
+ * Middleware: Extract API version from URL or request headers
+ * Priority: URL path > Accept-Version header > Accept header > default (v1)
  */
 export const apiVersionMiddleware: RequestHandler = (req, res, next) => {
   const versionedReq = req as VersionedRequest;
@@ -35,17 +40,29 @@ export const apiVersionMiddleware: RequestHandler = (req, res, next) => {
     let version = CURRENT_VERSION;
 
     // 1. Check URL path for version (e.g., /api/v1/transactions)
-    const pathMatch = versionedReq.path.match(/^\/api\/(v\d+)\//);
+    const pathMatch = versionedReq.path.match(/^\/api\/(v\d+)(?:\/|$)/i);
     if (pathMatch) {
-      version = pathMatch[1];
-    }
+      version = normalizeApiVersion(pathMatch[1]) || CURRENT_VERSION;
+    } else {
+      // 2. Check Accept-Version header (e.g., Accept-Version: v1)
+      const acceptVersionHeader = versionedReq.get("accept-version");
+      const headerVersion = acceptVersionHeader
+        ? normalizeApiVersion(acceptVersionHeader)
+        : undefined;
 
-    // 2. Check Accept header (e.g., Accept: application/vnd.api+json;version=v1)
-    const acceptHeader = versionedReq.get("accept");
-    if (acceptHeader && acceptHeader.includes("version=")) {
-      const versionMatch = acceptHeader.match(/version=(v\d+)/);
-      if (versionMatch) {
-        version = versionMatch[1];
+      if (headerVersion) {
+        version = headerVersion;
+      } else {
+        // 3. Check Accept header (e.g., Accept: application/vnd.api+json;version=v1)
+        const acceptHeader = versionedReq.get("accept");
+        const versionMatch = acceptHeader?.match(/(?:^|[;\s])version=(v?\d+)/i);
+        const acceptVersion = versionMatch
+          ? normalizeApiVersion(versionMatch[1])
+          : undefined;
+
+        if (acceptVersion) {
+          version = acceptVersion;
+        }
       }
     }
 
@@ -55,7 +72,8 @@ export const apiVersionMiddleware: RequestHandler = (req, res, next) => {
 
     // Add version to response headers
     res.setHeader("API-Version", version);
-    res.setHeader("Vary", "Accept");
+    res.vary("Accept");
+    res.vary("Accept-Version");
 
     // Log version information in development
     if (process.env.NODE_ENV === "development") {

--- a/tests/api-versioning.test.ts
+++ b/tests/api-versioning.test.ts
@@ -91,6 +91,59 @@ describe("API Versioning", () => {
     });
   });
 
+  describe("Version Extraction from Accept-Version Header", () => {
+    it("should extract version from Accept-Version header", (done) => {
+      request(app)
+        .get("/api/test")
+        .set("Accept-Version", "v1")
+        .expect(200)
+        .expect((res: any) => {
+          if (res.body.version !== "v1")
+            throw new Error("Accept-Version header version not used");
+          if (res.headers["api-version"] !== "v1")
+            throw new Error("API-Version header not set from Accept-Version");
+        })
+        .end(done);
+    });
+
+    it("should normalize numeric Accept-Version values", (done) => {
+      request(app)
+        .get("/api/test")
+        .set("Accept-Version", "1")
+        .expect(200)
+        .expect((res: any) => {
+          if (res.headers["api-version"] !== "v1")
+            throw new Error("Numeric Accept-Version header not normalized");
+        })
+        .end(done);
+    });
+
+    it("should prioritize URL path over Accept-Version header", (done) => {
+      request(app)
+        .get("/api/v1/test")
+        .set("Accept-Version", "v99")
+        .expect(200)
+        .expect((res: any) => {
+          if (res.headers["api-version"] !== "v1")
+            throw new Error("URL path should take priority over Accept-Version");
+        })
+        .end(done);
+    });
+
+    it("should reject unsupported Accept-Version header values", (done) => {
+      request(app)
+        .get("/api/test")
+        .set("Accept-Version", "v99")
+        .expect(400)
+        .expect((res: any) => {
+          if (res.body.error !== "Unsupported API Version") {
+            throw new Error("Unsupported Accept-Version was not rejected");
+          }
+        })
+        .end(done);
+    });
+  });
+
   describe("Version Validation", () => {
     it("should reject unsupported versions", (done) => {
       request(app)
@@ -177,6 +230,8 @@ describe("API Versioning", () => {
           if (!res.headers["vary"]) throw new Error("Missing Vary header");
           if (!res.headers["vary"].includes("Accept"))
             throw new Error("Vary should include Accept");
+          if (!res.headers["vary"].includes("Accept-Version"))
+            throw new Error("Vary should include Accept-Version");
         })
         .end(done);
     });


### PR DESCRIPTION
Close #881 

## Summary of the issue

API versioning currently supports URL prefixes such as `/api/v1`, but does not support the maintainer-requested `Accept-Version` header for selecting an API version.

## Root cause

The API version middleware only resolved versions from the URL path and the legacy `Accept: ...;version=v1` format. It did not inspect `Accept-Version`, and the existing implementation could allow the `Accept` header to override a version explicitly provided in the URL path.

## Solution implemented

Updated the API version resolver to support `Accept-Version` while preserving existing URL-prefix and legacy `Accept` header behavior. Version resolution now follows the documented priority:

1. URL path
2. `Accept-Version` header
3. Legacy `Accept` header version parameter
4. Default current version

## Key changes made

- Added API version normalization for values like `v1` and `1`.
- Added `Accept-Version` header support in `apiVersionMiddleware`.
- Preserved legacy `Accept: application/json;version=v1` support.
- Ensured URL path versioning takes precedence over header-based versioning.
- Updated response cache variation with `Vary: Accept, Accept-Version`.
- Added focused Jest coverage for `Accept-Version` behavior and precedence.
- Updated API versioning documentation to describe `Accept-Version`.

## Trade-offs or considerations

- Only configured supported versions are accepted. Unsupported header values such as `Accept-Version: v99` correctly return the existing unsupported-version response.
- Legacy `Accept` header versioning remains supported for backward compatibility, but `Accept-Version` is now documented as the preferred header.

## Testing steps

```bash
npx jest --runTestsByPath tests/api-versioning.test.ts --runInBand --forceExit
npx tsc --noEmit --skipLibCheck --esModuleInterop src/middleware/apiVersion.ts
Thank you very much and please if there are more additional feature regarding this task, let me know, i really apprecaite!1