### PR TITLE
Feat/db connection leak detector

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import {
 import { requireAuth } from "./middleware/auth";
 import { responseTime } from "./middleware/responseTime";
 import { requestId } from "./middleware/requestId";
+import { dbConnectionLeakDetector } from "./middleware/dbConnectionLeakDetector";
 import { i18nMiddleware } from "./utils/i18n";
 import { metricsMiddleware } from "./middleware/metrics";
 import { validateStellarNetwork, logStellarNetwork } from "./config/stellar";
@@ -177,6 +178,7 @@ app.use(
 app.use(responseTime);
 app.use(requestId);
 app.use(i18nMiddleware);
+app.use(dbConnectionLeakDetector);
 
 app.use((req: Request, res: Response, next: NextFunction) => {
   if (isShuttingDown) {

--- a/src/middleware/dbConnectionLeakDetector.ts
+++ b/src/middleware/dbConnectionLeakDetector.ts
@@ -1,0 +1,251 @@
+import { Request, Response, NextFunction } from "express";
+import { PoolClient } from "pg";
+import logger from "../utils/logger";
+import { Counter, Gauge, Histogram, register } from "../utils/metrics";
+
+const LEAK_LOG_THRESHOLD_MS = parseInt(
+  process.env.DB_LEAK_LOG_THRESHOLD_MS || "5000",
+);
+const LEAK_ALERT_THRESHOLD_SECONDS = parseInt(
+  process.env.DB_LEAK_ALERT_THRESHOLD_SECONDS || "30",
+);
+
+export const dbConnectionLeaksTotal = new Counter({
+  name: "db_connection_leaks_total",
+  help: "Total number of detected database connection leaks",
+  labelNames: ["type"],
+  registers: [register],
+});
+
+export const dbLeakedConnectionsGauge = new Gauge({
+  name: "db_leaked_connections",
+  help: "Number of currently leaked database connections",
+  registers: [register],
+});
+
+export const dbConnectionCheckoutDurationSeconds = new Histogram({
+  name: "db_connection_checkout_duration_seconds",
+  help: "Duration of database connection checkout in seconds",
+  labelNames: ["pool"],
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+  registers: [register],
+});
+
+export interface TrackedConnection {
+  client: PoolClient;
+  checkedOutAt: number;
+  checkoutStack: string;
+  endpoint: string;
+  method: string;
+  requestId?: string;
+}
+
+const connectionTrackers = new Map<number, TrackedConnection>();
+
+function extractEndpoint(stack: string): string {
+  const match = stack.match(/at\s+.*?\s+\((.+):\d+:\d+\)/);
+  if (match) {
+    const filePath = match[1];
+    const fileName = filePath.split("/").pop() || filePath;
+    return fileName;
+  }
+  return "unknown";
+}
+
+function setupClientLeakDetection(
+  client: PoolClient,
+  trackedConn: TrackedConnection,
+): void {
+  const originalRelease = client.release.bind(client);
+  const connectionId = client.processID;
+
+  (client as any).release = function (): void {
+    connectionTrackers.delete(connectionId);
+
+    const heldForMs = Date.now() - trackedConn.checkedOutAt;
+
+    dbConnectionCheckoutDurationSeconds.observe(
+      { pool: "primary" },
+      heldForMs / 1000,
+    );
+
+    if (heldForMs > LEAK_LOG_THRESHOLD_MS) {
+      dbConnectionLeaksTotal.inc({ type: "slow_return" });
+      logger.warn({
+        type: "db_connection_slow_return",
+        connectionId,
+        durationMs: heldForMs,
+        thresholdMs: LEAK_LOG_THRESHOLD_MS,
+        endpoint: trackedConn.endpoint,
+        method: trackedConn.method,
+        checkoutStack: trackedConn.checkoutStack,
+        message: "Database connection returned slowly",
+      });
+    }
+
+    return originalRelease.apply(this, arguments as any);
+  };
+}
+
+export interface LeakDetectorOptions {
+  leakLogThresholdMs?: number;
+  leakAlertThresholdSeconds?: number;
+}
+
+export function trackConnectionCheckout(
+  client: PoolClient,
+  options?: LeakDetectorOptions & { endpoint?: string; method?: string; requestId?: string },
+): void {
+  const error = new Error("Connection checkout tracker");
+  const stack =
+    error.stack?.split("\n").slice(3).join("\n") || "Stack trace unavailable";
+
+  const trackedConn: TrackedConnection = {
+    client,
+    checkedOutAt: Date.now(),
+    checkoutStack: stack,
+    endpoint: options?.endpoint || extractEndpoint(stack),
+    method: options?.method || "UNKNOWN",
+    requestId: options?.requestId,
+  };
+
+  connectionTrackers.set(client.processID, trackedConn);
+  setupClientLeakDetection(client, trackedConn);
+}
+
+function findLeakedConnections(): TrackedConnection[] {
+  const leaked: TrackedConnection[] = [];
+  const now = Date.now();
+
+  for (const [, conn] of connectionTrackers) {
+    const heldForSeconds = (now - conn.checkedOutAt) / 1000;
+    if (heldForSeconds > LEAK_ALERT_THRESHOLD_SECONDS) {
+      leaked.push(conn);
+    }
+  }
+
+  return leaked;
+}
+
+function getEndpointFromRequest(req: Request): string {
+  const route = req.route?.path || req.path;
+  return `${req.method} ${route}`;
+}
+
+function checkForUnreturnedConnections(endpoint: string, req: Request): void {
+  const unreturned: TrackedConnection[] = [];
+
+  for (const [, conn] of connectionTrackers) {
+    if (conn.endpoint === endpoint && conn.method === req.method) {
+      unreturned.push(conn);
+    }
+  }
+
+  if (unreturned.length > 0) {
+    unreturned.forEach((conn) => {
+      dbConnectionLeaksTotal.inc({ type: "unreturned_after_request" });
+      logger.error({
+        type: "db_connection_unreturned",
+        endpoint,
+        method: req.method,
+        heldForMs: Date.now() - conn.checkedOutAt,
+        checkoutStack: conn.checkoutStack,
+        requestId: req.headers["x-request-id"] as string | undefined,
+        message: "Database connection still checked out after request completed",
+      });
+    });
+  }
+}
+
+export function dbConnectionLeakDetector(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const endpoint = getEndpointFromRequest(req);
+
+  const checkInterval = setInterval(() => {
+    const leaked = findLeakedConnections();
+    if (leaked.length > 0) {
+      dbLeakedConnectionsGauge.set(leaked.length);
+      leaked.forEach((conn) => {
+        logger.error({
+          type: "db_connection_leak",
+          endpoint,
+          method: req.method,
+          heldForMs: Date.now() - conn.checkedOutAt,
+          checkoutStack: conn.checkoutStack,
+          requestId: req.headers["x-request-id"] as string | undefined,
+          message: "Database connection leak detected - connection not returned",
+        });
+      });
+    }
+  }, 1000);
+
+  req.on("close", () => {
+    clearInterval(checkInterval);
+    checkForUnreturnedConnections(endpoint, req);
+  });
+
+  res.on("finish", () => {
+    clearInterval(checkInterval);
+  });
+
+  next();
+}
+
+export function startPeriodicLeakCheck(
+  intervalMs: number = 60000,
+): ReturnType<typeof setInterval> | null {
+  if (process.env.NODE_ENV === "test") {
+    return null;
+  }
+
+  return setInterval(() => {
+    const leaked = findLeakedConnections();
+    if (leaked.length > 0) {
+      dbLeakedConnectionsGauge.set(leaked.length);
+      leaked.forEach((conn) => {
+        dbConnectionLeaksTotal.inc({ type: "hung_connection" });
+        logger.error({
+          type: "db_connection_hung",
+          heldForMs: Date.now() - conn.checkedOutAt,
+          checkoutStack: conn.checkoutStack,
+          endpoint: conn.endpoint,
+          method: conn.method,
+          message: "Hung database connection detected",
+        });
+      });
+    }
+  }, intervalMs);
+}
+
+export function getLeakedConnections(): TrackedConnection[] {
+  return findLeakedConnections();
+}
+
+export function forceReleaseAllConnections(): number {
+  let released = 0;
+  for (const [, conn] of connectionTrackers) {
+    try {
+      conn.client?.release();
+      released++;
+    } catch (err) {
+      logger.error({
+        type: "db_connection_force_release_failed",
+        error: String(err),
+        message: "Failed to force-release connection during cleanup",
+      });
+    }
+  }
+  connectionTrackers.clear();
+  return released;
+}
+
+export function getConnectionTrackerCount(): number {
+  return connectionTrackers.size;
+}
+
+export function getTrackedConnections(): Map<number, TrackedConnection> {
+  return connectionTrackers;
+}

--- a/tests/middleware/dbConnectionLeakDetector.test.ts
+++ b/tests/middleware/dbConnectionLeakDetector.test.ts
@@ -1,0 +1,292 @@
+import {
+  dbConnectionLeakDetector,
+  getConnectionTrackerCount,
+  getLeakedConnections,
+  forceReleaseAllConnections,
+  trackConnectionCheckout,
+  getTrackedConnections,
+  TrackedConnection,
+} from "../../src/middleware/dbConnectionLeakDetector";
+import { PoolClient } from "pg";
+
+jest.mock("../../src/utils/logger");
+
+describe("DB Connection Leak Detector Middleware", () => {
+  beforeEach(() => {
+    getTrackedConnections().clear();
+    Object.defineProperty(process.env, "DB_LEAK_LOG_THRESHOLD_MS", {
+      value: "100",
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.env, "DB_LEAK_ALERT_THRESHOLD_SECONDS", {
+      value: "1",
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.DB_LEAK_LOG_THRESHOLD_MS;
+    delete process.env.DB_LEAK_ALERT_THRESHOLD_SECONDS;
+  });
+
+  describe("dbConnectionLeakDetector middleware", () => {
+    it("should call next() to continue request processing", () => {
+      const mockReq = {
+        method: "GET",
+        path: "/test",
+        headers: {},
+        on: jest.fn(),
+        route: { path: "/test" },
+      } as any;
+      const mockRes = {
+        on: jest.fn(),
+      } as any;
+      const mockNext = jest.fn();
+
+      dbConnectionLeakDetector(mockReq, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it("should set up request cleanup on close/finish events", () => {
+      const mockReq = {
+        method: "GET",
+        path: "/test",
+        headers: {},
+        on: jest.fn(),
+        route: { path: "/test" },
+      } as any;
+      const mockRes = {
+        on: jest.fn(),
+      } as any;
+      const mockNext = jest.fn();
+
+      dbConnectionLeakDetector(mockReq, mockRes, mockNext);
+
+      expect(mockReq.on).toHaveBeenCalledWith("close", expect.any(Function));
+      expect(mockRes.on).toHaveBeenCalledWith("finish", expect.any(Function));
+    });
+  });
+
+  describe("trackConnectionCheckout", () => {
+    it("should track connection checkout with stack trace", () => {
+      const mockClient = {
+        processID: 99999,
+        release: jest.fn().mockReturnValue({}),
+      } as unknown as PoolClient;
+
+      trackConnectionCheckout(mockClient);
+
+      const tracked = getTrackedConnections().get(mockClient.processID);
+      expect(tracked).toBeDefined();
+      expect(tracked?.checkoutStack).toContain("Error");
+      expect(getConnectionTrackerCount()).toBe(1);
+    });
+
+    it("should accept custom endpoint and method", () => {
+      const mockClient = {
+        processID: 88888,
+        release: jest.fn().mockReturnValue({}),
+      } as unknown as PoolClient;
+
+      trackConnectionCheckout(mockClient, {
+        endpoint: "custom-endpoint.ts",
+        method: "POST",
+        requestId: "test-request-id",
+      });
+
+      const tracked = getTrackedConnections().get(mockClient.processID);
+      expect(tracked?.endpoint).toBe("custom-endpoint.ts");
+      expect(tracked?.method).toBe("POST");
+      expect(tracked?.requestId).toBe("test-request-id");
+    });
+
+    it("should wrap client release with leak detection", () => {
+      const mockClient = {
+        processID: 77777,
+        release: jest.fn().mockReturnValue({}),
+      } as unknown as PoolClient;
+
+      trackConnectionCheckout(mockClient, { endpoint: "test.ts", method: "GET" });
+
+      const wrappedRelease = (mockClient as any).release;
+      const tracked = getTrackedConnections().get(mockClient.processID);
+
+      expect(typeof wrappedRelease).toBe("function");
+      expect(tracked).toBeDefined();
+    });
+
+    it("should remove connection from tracking on release", () => {
+      const mockClient = {
+        processID: 66666,
+        release: jest.fn().mockReturnValue({}),
+      } as unknown as PoolClient;
+
+      trackConnectionCheckout(mockClient, { endpoint: "test.ts", method: "GET" });
+      expect(getConnectionTrackerCount()).toBe(1);
+
+      (mockClient as any).release();
+      expect(getConnectionTrackerCount()).toBe(0);
+    });
+
+    it("should record slow connection return as warning", () => {
+      const mockClient = {
+        processID: 55555,
+        release: jest.fn(),
+      } as unknown as PoolClient;
+
+      const originalRelease = mockClient.release.bind(mockClient);
+
+      trackConnectionCheckout(mockClient, { endpoint: "test.ts", method: "GET" });
+
+      (mockClient as any).release = jest.fn().mockReturnValue({});
+
+      const wrappedRelease = (mockClient as any).release;
+      (wrappedRelease as jest.Mock).mockImplementation(function (this: any) {
+        const tracked = getTrackedConnections().get(mockClient.processID);
+        if (tracked) {
+          tracked.checkedOutAt = Date.now() - 200;
+        }
+        return originalRelease();
+      });
+
+      (mockClient as any).release();
+
+      expect(require("../../src/utils/logger").default.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe("getLeakedConnections", () => {
+    it("should return empty array when no connections are leaked", () => {
+      const freshConnection = {
+        processID: 33333,
+        release: jest.fn(),
+      } as unknown as PoolClient;
+
+      getTrackedConnections().set(freshConnection.processID, {
+        client: freshConnection,
+        checkedOutAt: Date.now(),
+        checkoutStack: "fresh stack",
+        endpoint: "fresh.ts",
+        method: "POST",
+      });
+
+      const leaked = getLeakedConnections();
+      expect(leaked.length).toBe(0);
+    });
+
+    it("should return connections held longer than threshold", () => {
+      const oldConnection = {
+        processID: 22222,
+        release: jest.fn(),
+      } as unknown as PoolClient;
+
+      getTrackedConnections().set(oldConnection.processID, {
+        client: oldConnection,
+        checkedOutAt: Date.now() - 5000,
+        checkoutStack: "old stack",
+        endpoint: "old.ts",
+        method: "GET",
+      });
+
+      const leaked = getLeakedConnections();
+      expect(leaked.length).toBe(1);
+      expect(leaked[0].client.processID).toBe(22222);
+    });
+  });
+
+  describe("forceReleaseAllConnections", () => {
+    it("should force release all tracked connections", () => {
+      const mockClient1 = {
+        processID: 44444,
+        release: jest.fn().mockReturnValue({}),
+      } as unknown as PoolClient;
+      const mockClient2 = {
+        processID: 11111,
+        release: jest.fn().mockReturnValue({}),
+      } as unknown as PoolClient;
+
+      getTrackedConnections().set(mockClient1.processID, {
+        client: mockClient1,
+        checkedOutAt: Date.now(),
+        checkoutStack: "stack 1",
+        endpoint: "file1.ts",
+        method: "GET",
+      });
+      getTrackedConnections().set(mockClient2.processID, {
+        client: mockClient2,
+        checkedOutAt: Date.now(),
+        checkoutStack: "stack 2",
+        endpoint: "file2.ts",
+        method: "POST",
+      });
+
+      const released = forceReleaseAllConnections();
+
+      expect(released).toBe(2);
+      expect(mockClient1.release).toHaveBeenCalled();
+      expect(mockClient2.release).toHaveBeenCalled();
+      expect(getConnectionTrackerCount()).toBe(0);
+    });
+
+    it("should handle errors during force release gracefully", () => {
+      const mockClient = {
+        processID: 99999,
+        release: jest.fn().mockImplementation(() => {
+          throw new Error("Release failed");
+        }),
+      } as unknown as PoolClient;
+
+      getTrackedConnections().set(mockClient.processID, {
+        client: mockClient,
+        checkedOutAt: Date.now(),
+        checkoutStack: "stack",
+        endpoint: "file.ts",
+        method: "GET",
+      });
+
+      const released = forceReleaseAllConnections();
+
+      expect(released).toBe(1);
+      expect(require("../../src/utils/logger").default.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("getConnectionTrackerCount", () => {
+    it("should return correct count of tracked connections", () => {
+      getTrackedConnections().clear();
+
+      const mockClient = {
+        processID: 77777,
+        release: jest.fn(),
+      } as unknown as PoolClient;
+
+      getTrackedConnections().set(mockClient.processID, {
+        client: mockClient,
+        checkedOutAt: Date.now(),
+        checkoutStack: "stack",
+        endpoint: "file.ts",
+        method: "GET",
+      });
+
+      expect(getConnectionTrackerCount()).toBe(1);
+    });
+
+    it("should return 0 when no connections are tracked", () => {
+      getTrackedConnections().clear();
+      expect(getConnectionTrackerCount()).toBe(0);
+    });
+  });
+
+  describe("startPeriodicLeakCheck", () => {
+    it("should return null in test environment", () => {
+      const interval = require("../../src/middleware/dbConnectionLeakDetector")
+        .startPeriodicLeakCheck as typeof startPeriodicLeakCheck;
+
+      const result = interval(1000);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/middleware/dbConnectionLeakDetector.test.ts
+++ b/tests/middleware/dbConnectionLeakDetector.test.ts
@@ -1,3 +1,5 @@
+import { PoolClient } from "pg";
+
 import {
   dbConnectionLeakDetector,
   getConnectionTrackerCount,
@@ -5,9 +7,7 @@ import {
   forceReleaseAllConnections,
   trackConnectionCheckout,
   getTrackedConnections,
-  TrackedConnection,
 } from "../../src/middleware/dbConnectionLeakDetector";
-import { PoolClient } from "pg";
 
 jest.mock("../../src/utils/logger");
 


### PR DESCRIPTION
# Closes #877 
## Summary
Implements middleware to detect unreturned or hung postgres client connections during request cycles.

## Changes
- Added `dbConnectionLeakDetector` middleware that monitors connection lifecycle
- Created `trackConnectionCheckout()` function to wrap connection checkouts with tracking
- Added Prometheus metrics for leak detection:
  - `db_connection_leaks_total` - Total number of detected connection leaks by type
  - `db_leaked_connections` - Current count of leaked connections
  - `db_connection_checkout_duration_seconds` - Duration connections are held
- Logs anomalies with stack traces when:
  - Connections aren't returned within threshold (hung connections)
  - Connections are held longer than expected (slow returns)
  - Connections remain checked out after request completes (unreturned)
- Added utilities: `getLeakedConnections()`, `forceReleaseAllConnections()`, `getConnectionTrackerCount()`

## Configuration
- `DB_LEAK_LOG_THRESHOLD_MS` - Milliseconds threshold for logging slow returns (default: 5000)
- `DB_LEAK_ALERT_THRESHOLD_SECONDS` - Seconds threshold for leak detection (default: 30)

## Testing
- Comprehensive test suite covering middleware behavior, tracking, leak detection, and force release