### PR TITLE
feat(stellar): add strict G-address regex validator

### DIFF
--- a/src/utils/stellarAddressValidator.ts
+++ b/src/utils/stellarAddressValidator.ts
@@ -1,0 +1,46 @@
+/**
+ * Strict regex validator for Stellar G-addresses (Ed25519 public keys).
+ *
+ * Stellar G-addresses are base32-encoded Ed25519 public keys with a 4-byte
+ * network identifier prefix (0x30 for mainnet) and a 2-byte SHA-256 checksum.
+ *
+ * Format: 1 byte network ID + 32 bytes public key + 2 bytes checksum,
+ * all encoded in base32 (A-Z, 2-7) and prefixed with "G".
+ *
+ * Total length: 56 characters, always starting with "G".
+ *
+ * This regex provides a fast pre-flight check. For full validation, use
+ * `StellarSdk.StrKey.isValidEd25519PublicKey()` which also verifies the
+ * base32 decoding and checksum.
+ *
+ * @see https://stellar.github.io/stellar-sdk/StrKey.html
+ */
+
+// Base32-encoded Ed25519 public key with network ID prefix and checksum.
+// G (1 char) + base32(1 + 32 + 2) = 1 + 55 = 56 chars total.
+// Base32 alphabet: A-Z (26 chars) + 2-7 (6 chars) = 32 chars.
+export const STELLAR_G_ADDRESS_REGEX = /^G[A-Z2-7]{55}$/;
+
+/**
+ * Validate a Stellar G-address using strict regex matching.
+ *
+ * Returns false for any string that does not match the expected format:
+ * - Must start with "G"
+ * - Must be exactly 56 characters
+ * - Must contain only base32 characters (A-Z, 2-7)
+ *
+ * This is a fast pre-flight check. For cryptographic validation, use
+ * `StellarSdk.StrKey.isValidEd25519PublicKey()` instead.
+ *
+ * @param address - The address string to validate
+ * @returns true if the address matches the G-address format
+ *
+ * @example
+ * isValidGAddress("GAZC2ODRSME7QBKX6FYI4JRZG2P5FE2E2MGZV5I355P46I4XQXXI2I2Y") // true
+ * isValidGAddress("invalid") // false
+ * isValidGAddress("M...") // false (M-address, not G-address)
+ */
+export function isValidGAddress(address: string): boolean {
+  if (typeof address !== "string") return false;
+  return STELLAR_G_ADDRESS_REGEX.test(address);
+}

--- a/tests/stellar/stellarAddressValidator.test.ts
+++ b/tests/stellar/stellarAddressValidator.test.ts
@@ -1,0 +1,68 @@
+import { isValidGAddress, STELLAR_G_ADDRESS_REGEX } from "../../src/utils/stellarAddressValidator";
+
+describe("STELLAR_G_ADDRESS_REGEX", () => {
+  it("matches valid 56-character G-addresses", () => {
+    // Real mainnet G-addresses (56 chars)
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAZC2ODRSME7QBKX6FYI4JRZG2P5FE2E2MGZV5I355P46I4XQXXI2I2Y")).toBe(true);
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAAIZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CA")).toBe(true);
+    expect(STELLAR_G_ADDRESS_REGEX.test("GCKFBEI2TKW7AMMHV4O3435O7G4ZDV4S5DTD4URC7MMS772BR2W2RHDI")).toBe(true);
+  });
+
+  it("rejects M-addresses (muxed accounts)", () => {
+    // M-addresses start with "M" and are longer (64 chars)
+    expect(STELLAR_G_ADDRESS_REGEX.test("MA7QYHYXGM6GSCJ24Y73FZ2FAYBGQ4MWU7MF2J55W2E2ZC32G33QZ2K")).toBe(false);
+    expect(STELLAR_G_ADDRESS_REGEX.test("MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")).toBe(false);
+  });
+
+  it("rejects addresses that are too short", () => {
+    expect(STELLAR_G_ADDRESS_REGEX.test("G")).toBe(false);
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAA")).toBe(false);
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAAIZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6C")).toBe(false); // 55 chars
+  });
+
+  it("rejects addresses that are too long", () => {
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAAIZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CAAA")).toBe(false); // 59 chars
+  });
+
+  it("rejects addresses with invalid base32 characters", () => {
+    // Base32 uses A-Z and 2-7 (no 0, 1, 8, 9)
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAA0ZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CA")).toBe(false); // contains 0
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAA1ZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CA")).toBe(false); // contains 1
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAA8ZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CA")).toBe(false); // contains 8
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAA9ZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CA")).toBe(false); // contains 9
+    expect(STELLAR_G_ADDRESS_REGEX.test("GAAIZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6C!")).toBe(false); // special char
+  });
+
+  it("rejects lowercase addresses", () => {
+    expect(STELLAR_G_ADDRESS_REGEX.test("gaaizr7hskr6o64mhgga6nf7y6bzb d7kb4gcmf7p4p2p7x3qzjxvq6ca")).toBe(false);
+    expect(STELLAR_G_ADDRESS_REGEX.test("gazc2odrsme7qbkx6fyi4jrzg2p5fe2e2mgzv5i355p46i4xqxi2i2y")).toBe(false);
+  });
+
+  it("rejects empty and null-like inputs", () => {
+    expect(STELLAR_G_ADDRESS_REGEX.test("")).toBe(false);
+    expect(STELLAR_G_ADDRESS_REGEX.test("   ")).toBe(false);
+  });
+});
+
+describe("isValidGAddress", () => {
+  it("returns true for valid G-addresses", () => {
+    expect(isValidGAddress("GAZC2ODRSME7QBKX6FYI4JRZG2P5FE2E2MGZV5I355P46I4XQXXI2I2Y")).toBe(true);
+    expect(isValidGAddress("GAAIZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CA")).toBe(true);
+  });
+
+  it("returns false for non-string inputs", () => {
+    expect(isValidGAddress(null as any)).toBe(false);
+    expect(isValidGAddress(undefined as any)).toBe(false);
+    expect(isValidGAddress(123 as any)).toBe(false);
+    expect(isValidGAddress({} as any)).toBe(false);
+  });
+
+  it("returns false for invalid formats", () => {
+    expect(isValidGAddress("")).toBe(false);
+    expect(isValidGAddress("invalid")).toBe(false);
+    expect(isValidGAddress("M7QYHYXGM6GSCJ24Y73FZ2FAYBGQ4MWU7MF2J55W2E2ZC32G33QZ2K")).toBe(false);
+    expect(isValidGAddress("GAAZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CA")).toBe(false); // too short
+    expect(isValidGAddress("GAAIZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CAAA")).toBe(false); // too long
+    expect(isValidGAddress("GAA0ZR7HSKR6O64MHGGA6NF7Y6BZBD7KB4GCMF7P4P2P7X3QZJXVQ6CA")).toBe(false); // invalid char 0
+  });
+});


### PR DESCRIPTION
## Problem

Stellar G-addresses (Ed25519 public keys) are used throughout the codebase in payment routing, clawback, and balance checks. Currently there's no dedicated validator — callers either use `StellarSdk.StrKey.isValidEd25519PublicKey()` directly or do ad-hoc checks. A regex-based pre-flight validator provides a fast, zero-dependency format check before any cryptographic validation.

## Fix

Added `src/utils/stellarAddressValidator.ts` with:

- **`STELLAR_G_ADDRESS_REGEX`** — `/^G[A-Z2-7]{55}$/` matches exactly 56-character base32-encoded G-addresses (1 byte network ID + 32 bytes public key + 2 bytes checksum, all base32-encoded, prefixed with "G")
- **`isValidGAddress(address)`** — type-safe wrapper that checks `typeof` before regex matching, returns `false` for non-string inputs

## Test Plan

- [x] 10 unit tests covering:
  - Valid real mainnet G-addresses (3)
  - M-addresses rejected (muxed accounts)
  - Too short / too long addresses rejected
  - Invalid base32 characters rejected (0, 1, 8, 9)
  - Lowercase addresses rejected
  - Empty/null inputs handled gracefully

## Files Changed

- `src/utils/stellarAddressValidator.ts` — new utility module
- `tests/stellar/stellarAddressValidator.test.ts` — 10 unit tests

Closes #1280
