### PR TITLE
feat(docs-portal): embed interactive GraphQL Playground (#1026)

### DIFF
--- a/docs-portal/docusaurus.config.ts
+++ b/docs-portal/docusaurus.config.ts
@@ -44,6 +44,7 @@ const config: Config = {
       items: [
         { to: '/', label: 'Overview', position: 'left' },
         { to: '/api', label: 'Reference', position: 'left' },
+        { to: '/graphql', label: 'GraphQL Playground', position: 'left' },
         {
           href: 'https://github.com/sublime247/mobile-money',
           label: 'GitHub',
@@ -56,7 +57,10 @@ const config: Config = {
       links: [
         {
           title: 'Docs',
-          items: [{ label: 'API Reference', to: '/api' }],
+          items: [
+            { label: 'API Reference', to: '/api' },
+            { label: 'GraphQL Playground', to: '/graphql' },
+          ],
         },
       ],
       copyright: `Copyright © ${new Date().getFullYear()} Mobile Money`,

--- a/docs-portal/src/components/GraphQLPlayground.tsx
+++ b/docs-portal/src/components/GraphQLPlayground.tsx
@@ -1,0 +1,209 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+/**
+ * Embeds the Apollo Sandbox (Explorer) via the CDN embed script.
+ * This avoids adding a heavy npm dependency — the Apollo team publishes
+ * a lightweight embed helper at https://embeddable-sandbox.cdn.apollographql.com.
+ *
+ * Developers can switch the endpoint URL to point at their local or
+ * staging Mobile Money GraphQL server.
+ */
+
+const DEFAULT_ENDPOINT = 'http://localhost:4000/graphql';
+
+const DEFAULT_DOCUMENT = `# Welcome to the Mobile Money GraphQL Playground!
+# Try running one of these example queries:
+
+# ── Fetch your current user ──────────────────
+query Me {
+  me {
+    id
+    subject
+  }
+}
+
+# ── List recent transactions ─────────────────
+# query RecentTransactions {
+#   transactions(limit: 10, offset: 0) {
+#     id
+#     referenceNumber
+#     type
+#     amount
+#     phoneNumber
+#     provider
+#     status
+#     createdAt
+#   }
+# }
+
+# ── Look up a single transaction ─────────────
+# query GetTransaction {
+#   transaction(id: "txn_abc123") {
+#     id
+#     referenceNumber
+#     providerReference
+#     type
+#     amount
+#     phoneNumber
+#     provider
+#     stellarAddress
+#     status
+#     tags
+#     retryCount
+#     createdAt
+#     jobProgress
+#   }
+# }
+
+# ── Initiate a deposit ───────────────────────
+# mutation InitiateDeposit {
+#   deposit(input: {
+#     amount: "5000"
+#     phoneNumber: "+256700000000"
+#     provider: "MTN"
+#     stellarAddress: "GABCDEF..."
+#   }) {
+#     transactionId
+#     referenceNumber
+#     status
+#     jobId
+#   }
+# }
+
+# ── Open a dispute ───────────────────────────
+# mutation OpenNewDispute {
+#   openDispute(input: {
+#     transactionId: "txn_abc123"
+#     reason: "Amount not received"
+#     reportedBy: "customer@example.com"
+#   }) {
+#     id
+#     transactionId
+#     reason
+#     status
+#     createdAt
+#   }
+# }
+`;
+
+export default function GraphQLPlayground(): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [endpoint, setEndpoint] = useState(DEFAULT_ENDPOINT);
+  const [inputValue, setInputValue] = useState(DEFAULT_ENDPOINT);
+  const [loaded, setLoaded] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Clear previous embed
+    containerRef.current.innerHTML = '';
+    setLoaded(false);
+
+    // Load the Apollo Sandbox embed script
+    const script = document.createElement('script');
+    script.src = 'https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js';
+    script.async = true;
+    script.onload = () => {
+      // @ts-expect-error — loaded from CDN script, not typed
+      if (window.EmbeddedSandbox) {
+        // @ts-expect-error — loaded from CDN script, not typed
+        new window.EmbeddedSandbox({
+          target: '#graphql-playground-container',
+          initialEndpoint: endpoint,
+          initialState: {
+            document: DEFAULT_DOCUMENT,
+            displayOptions: {
+              theme: document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light',
+            },
+          },
+          includeCookies: false,
+        });
+        setLoaded(true);
+      }
+    };
+    document.body.appendChild(script);
+
+    return () => {
+      // Cleanup script on unmount
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+    };
+  }, [endpoint]);
+
+  const handleEndpointChange = () => {
+    const trimmed = inputValue.trim();
+    if (trimmed && trimmed !== endpoint) {
+      setEndpoint(trimmed);
+    }
+  };
+
+  return (
+    <div className="graphql-playground-wrapper">
+      {/* ── Configuration Bar ─────────────────────────────────── */}
+      <div className="graphql-config-bar">
+        <div className="graphql-config-bar__header">
+          <div className="graphql-config-bar__badge">
+            <span className="graphql-config-bar__dot" />
+            GraphQL Playground
+          </div>
+          <button
+            className="graphql-config-bar__toggle"
+            onClick={() => setCollapsed(!collapsed)}
+            aria-label={collapsed ? 'Expand settings' : 'Collapse settings'}
+          >
+            {collapsed ? '▼ Show Settings' : '▲ Hide Settings'}
+          </button>
+        </div>
+
+        {!collapsed && (
+          <div className="graphql-config-bar__body">
+            <p className="graphql-config-bar__hint">
+              Point this to your running Mobile Money GraphQL server.
+              Default: <code>{DEFAULT_ENDPOINT}</code>
+            </p>
+            <div className="graphql-config-bar__controls">
+              <label htmlFor="graphql-endpoint-input" className="graphql-config-bar__label">
+                Endpoint URL
+              </label>
+              <div className="graphql-config-bar__input-group">
+                <input
+                  id="graphql-endpoint-input"
+                  type="url"
+                  className="graphql-config-bar__input"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleEndpointChange();
+                  }}
+                  placeholder="http://localhost:4000/graphql"
+                />
+                <button
+                  className="graphql-config-bar__button"
+                  onClick={handleEndpointChange}
+                  disabled={inputValue.trim() === endpoint}
+                >
+                  Connect
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ── Sandbox Container ─────────────────────────────────── */}
+      {!loaded && (
+        <div className="graphql-playground-loading">
+          <div className="graphql-playground-loading__spinner" />
+          <span>Loading Apollo Sandbox…</span>
+        </div>
+      )}
+      <div
+        id="graphql-playground-container"
+        ref={containerRef}
+        className="graphql-playground-embed"
+      />
+    </div>
+  );
+}

--- a/docs-portal/src/css/custom.css
+++ b/docs-portal/src/css/custom.css
@@ -26,3 +26,200 @@ button.copyButton_node_modules-\@docusaurus-theme-classic-src-theme-CodeBlock-st
 pre code {
   position: relative;
 }
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   GraphQL Playground
+   ══════════════════════════════════════════════════════════════════════════════ */
+
+.graphql-playground-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 60px); /* navbar height */
+  overflow: hidden;
+}
+
+/* ── Config Bar ──────────────────────────────────────────────────────────────── */
+
+.graphql-config-bar {
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+  border-bottom: 1px solid rgba(99, 102, 241, 0.25);
+  color: #e0e0ff;
+  padding: 0.75rem 1.25rem;
+  flex-shrink: 0;
+}
+
+.graphql-config-bar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.graphql-config-bar__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.025em;
+  color: #c4b5fd;
+}
+
+.graphql-config-bar__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #34d399;
+  box-shadow: 0 0 6px rgba(52, 211, 153, 0.6);
+  animation: graphql-pulse 2s ease-in-out infinite;
+}
+
+@keyframes graphql-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.graphql-config-bar__toggle {
+  background: rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  color: #a5b4fc;
+  border-radius: 6px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.graphql-config-bar__toggle:hover {
+  background: rgba(99, 102, 241, 0.3);
+  color: #e0e7ff;
+}
+
+.graphql-config-bar__body {
+  margin-top: 0.6rem;
+}
+
+.graphql-config-bar__hint {
+  font-size: 0.82rem;
+  color: #94a3b8;
+  margin: 0 0 0.5rem;
+  line-height: 1.4;
+}
+
+.graphql-config-bar__hint code {
+  background: rgba(99, 102, 241, 0.15);
+  color: #a5b4fc;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.78rem;
+}
+
+.graphql-config-bar__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.graphql-config-bar__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+}
+
+.graphql-config-bar__input-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.graphql-config-bar__input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 8px;
+  color: #e2e8f0;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.graphql-config-bar__input:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.graphql-config-bar__button {
+  padding: 0.5rem 1.25rem;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.graphql-config-bar__button:hover:not(:disabled) {
+  background: linear-gradient(135deg, #818cf8, #a78bfa);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.35);
+}
+
+.graphql-config-bar__button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Loading State ───────────────────────────────────────────────────────────── */
+
+.graphql-playground-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem;
+  color: var(--ifm-color-primary);
+  font-size: 0.95rem;
+}
+
+.graphql-playground-loading__spinner {
+  width: 22px;
+  height: 22px;
+  border: 3px solid rgba(99, 102, 241, 0.2);
+  border-top-color: #6366f1;
+  border-radius: 50%;
+  animation: graphql-spin 0.7s linear infinite;
+}
+
+@keyframes graphql-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Sandbox Embed ───────────────────────────────────────────────────────────── */
+
+.graphql-playground-embed {
+  flex: 1;
+  min-height: 0;
+}
+
+.graphql-playground-embed iframe {
+  width: 100% !important;
+  height: 100% !important;
+  border: none;
+}
+
+/* ── Responsive tweaks ───────────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .graphql-config-bar__input-group {
+    flex-direction: column;
+  }
+
+  .graphql-config-bar__button {
+    width: 100%;
+  }
+}

--- a/docs-portal/src/pages/graphql.tsx
+++ b/docs-portal/src/pages/graphql.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
+export default function GraphQLPage(): React.JSX.Element {
+  return (
+    <Layout
+      title="GraphQL Playground"
+      description="Interactive GraphQL Playground to explore and test the Mobile Money GraphQL API schema"
+    >
+      <BrowserOnly fallback={<p style={{ padding: '2rem' }}>Loading GraphQL Playground...</p>}>
+        {() => {
+          const GraphQLPlayground = require('../components/GraphQLPlayground').default;
+          return <GraphQLPlayground />;
+        }}
+      </BrowserOnly>
+    </Layout>
+  );
+}

--- a/docs-portal/src/pages/index.tsx
+++ b/docs-portal/src/pages/index.tsx
@@ -11,9 +11,12 @@ export default function Home(): React.JSX.Element {
           This portal publishes a searchable, first-class API reference for partners using the
           canonical <code>openapi.yaml</code> in this repository.
         </p>
-        <p>
+        <p style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
           <Link className="button button--primary button--lg" to="/api">
             Open API Reference
+          </Link>
+          <Link className="button button--secondary button--lg" to="/graphql">
+            GraphQL Playground
           </Link>
         </p>
       </main>


### PR DESCRIPTION
Integrate Apollo Sandbox Explorer within the documentation portal so developers can browse and test the Mobile Money GraphQL schema directly from the docs site.

Changes:
- Add GraphQLPlayground component using Apollo Sandbox CDN embed
- Add /graphql page route with BrowserOnly lazy loading
- Add navbar and footer links to GraphQL Playground
- Add homepage button linking to the playground
- Add responsive CSS with config bar, loading state, and full-height embed
- Pre-populate editor with example queries matching the schema (me, transactions, deposit, dispute)

## Description

Brief description of changes.

## Related Issue

closes #1026 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
