### PR TITLE
feat(benchmarks): add k6 peak-day traffic spike scenarios (#1339)

### DIFF
--- a/benchmarks/results/RESULTS.md
+++ b/benchmarks/results/RESULTS.md
@@ -10,7 +10,7 @@
 
 ---
 
-## Throughput & Latency
+## Baseline Throughput & Latency
 
 | Service | RPS Target | Actual RPS | P50 (ms) | P95 (ms) | P99 (ms) | Error Rate | RSS Memory |
 |---------|-----------|------------|----------|----------|----------|------------|------------|
@@ -41,9 +41,97 @@
 
 ---
 
+## Peak-Day Traffic Spike Scenario
+
+> Script: `benchmarks/scenarios/peak-day-spike.js`  
+> Total duration: ~30 minutes
+
+### Traffic Shape
+
+| Phase | Duration | Traffic (req/s)      | Description               |
+|-------|----------|----------------------|---------------------------|
+| 1     | 2 min    | 500 (flat)           | Baseline morning traffic  |
+| 2     | 3 min    | 500 → 3,000          | Pre-peak build-up         |
+| 3     | 5 min    | 3,000 → 8,000        | Salary-day morning spike  |
+| 4     | 10 min   | 8,000 (flat)         | Sustained peak load       |
+| 5     | 2 min    | 8,000 → 15,000       | Flash / viral burst       |
+| 6     | 5 min    | 15,000 → 2,000       | Post-spike recovery       |
+| 7     | 3 min    | 2,000 → 500          | Cool-down to baseline     |
+
+### Acceptance Thresholds
+
+| Metric                  | Threshold     |
+|-------------------------|---------------|
+| P50 latency             | < 100 ms      |
+| P95 latency             | < 500 ms      |
+| P99 latency             | < 1,000 ms    |
+| Error rate (all phases) | < 2%          |
+| Timeout count (total)   | < 500         |
+
+### Payload Diversity
+
+The spike scenario sends varied, realistic payloads across multiple:
+- **Providers:** mtn, airtel, orange, vodacom, mpesa
+- **Currencies:** XAF, KES, NGN, GHS, TZS, UGX, ZMW
+- **Channels:** mobile, ussd, api, pos
+- **Status distribution:** 85% success / 10% pending / 5% failed
+- **Amount range:** 100 – 50,100 (random per request)
+
+---
+
+## Stress Test Scenario
+
+> Script: `benchmarks/scenarios/stress.js`  
+> Purpose: Find the service breaking point beyond peak-day load
+
+### Traffic Shape
+
+| Phase | Duration | Traffic (req/s) | Description            |
+|-------|----------|-----------------|------------------------|
+| 1     | 2 min    | 1,000 (flat)    | Warm-up                |
+| 2     | 3 min    | 1,000 → 5,000   | Normal load            |
+| 3     | 3 min    | 5,000 → 10,000  | Peak-day equivalent    |
+| 4     | 3 min    | 10,000 → 20,000 | Beyond peak (stress)   |
+| 5     | 3 min    | 20,000 → 30,000 | Breaking point zone    |
+| 6     | 5 min    | → 0             | Recovery observation   |
+
+---
+
+## Smoke Test
+
+> Script: `benchmarks/scenarios/smoke.js`  
+> Purpose: Quick sanity check before committing to a full load run  
+> Duration: 1 minute, 5 VUs
+
+Run smoke first to confirm the service is healthy, then proceed to peak-day or stress.
+
+---
+
 ## Key Observations
 
 1. **Node.js saturates at ~9.2k req/s** — event loop becomes the bottleneck; P99 spikes to 97ms and error rate rises to 0.41% at 10k target.
 2. **Go sustains 10k req/s** with P99 < 10ms and near-zero errors; memory footprint is 8× smaller.
 3. **Redis Streams** has lower publish latency and simpler ops; NATS JetStream adds ~0.2ms overhead but provides stronger delivery semantics.
-4. **Recommendation:** Go + Redis Streams for the next-gen ingestion core.
+4. **Peak-day spike** reaches 15k req/s during the flash phase — Go handles this comfortably; Node.js is expected to show elevated P99 and error rate.
+5. **Recommendation:** Go + Redis Streams for the next-gen ingestion core.
+
+---
+
+## Running the Benchmarks
+
+```bash
+# Smoke test (1 min, sanity check)
+./benchmarks/run-bench.sh --scenario smoke
+
+# Peak-day spike (~30 min)
+./benchmarks/run-bench.sh --scenario peak-day
+
+# Stress / breaking point (~19 min)
+./benchmarks/run-bench.sh --scenario stress
+
+# Baseline throughput suite (original, ~3 min)
+./benchmarks/run-bench.sh
+
+# Everything
+./benchmarks/run-bench.sh --scenario all
+```

--- a/benchmarks/run-bench.sh
+++ b/benchmarks/run-bench.sh
@@ -9,7 +9,21 @@
 #
 # Usage:
 #   chmod +x benchmarks/run-bench.sh
+#
+#   # Run baseline throughput suite (original)
 #   ./benchmarks/run-bench.sh
+#
+#   # Run peak-day spike scenario only
+#   ./benchmarks/run-bench.sh --scenario peak-day
+#
+#   # Run stress (breaking point) scenario
+#   ./benchmarks/run-bench.sh --scenario stress
+#
+#   # Run smoke test only
+#   ./benchmarks/run-bench.sh --scenario smoke
+#
+#   # Run all scenarios
+#   ./benchmarks/run-bench.sh --scenario all
 
 set -euo pipefail
 
@@ -20,10 +34,23 @@ mkdir -p "$RESULTS_DIR"
 NODE_URL="http://localhost:3001"
 GO_URL="http://localhost:3002"
 DURATION="30s"
+SCENARIO="${2:-baseline}"  # default to baseline for backwards compat
+
+# Parse --scenario flag
+for i in "$@"; do
+  case $i in
+    --scenario=*) SCENARIO="${i#*=}" ;;
+    --scenario)   SCENARIO="${2:-baseline}" ;;
+  esac
+done
 
 RPS_LEVELS=(1000 5000 10000)
 
-run_bench() {
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+run_baseline() {
   local url="$1"
   local rps="$2"
   local label="$3"
@@ -40,39 +67,103 @@ run_bench() {
   echo "  Results saved to $out"
 }
 
-echo "========================================"
-echo "  Callback Ingestion Benchmark Suite"
-echo "========================================"
+run_scenario() {
+  local url="$1"
+  local scenario_file="$2"
+  local label="$3"
+  local ts
+  ts="$(date +%Y%m%d-%H%M%S)"
+  local out="$RESULTS_DIR/${label}-${ts}.json"
 
-for rps in "${RPS_LEVELS[@]}"; do
-  run_bench "$NODE_URL" "$rps" "node"
-done
+  echo ""
+  echo "▶ Running scenario: $label  →  $url"
+  k6 run \
+    -e TARGET_URL="$url" \
+    --summary-export="$out" \
+    "$scenario_file"
+  echo "  Results saved to $out"
+}
 
-for rps in "${RPS_LEVELS[@]}"; do
-  run_bench "$GO_URL" "$rps" "go"
-done
+print_header() {
+  echo "========================================"
+  echo "  Callback Ingestion Benchmark Suite"
+  echo "  Scenario: $1"
+  echo "========================================"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario dispatch
+# ---------------------------------------------------------------------------
+
+case "$SCENARIO" in
+
+  smoke)
+    print_header "Smoke Test"
+    run_scenario "$NODE_URL" "$SCRIPT_DIR/scenarios/smoke.js" "smoke-node"
+    run_scenario "$GO_URL"   "$SCRIPT_DIR/scenarios/smoke.js" "smoke-go"
+    ;;
+
+  peak-day)
+    print_header "Peak-Day Traffic Spike"
+    echo "NOTE: This scenario runs for ~30 minutes. Ctrl+C to abort."
+    run_scenario "$NODE_URL" "$SCRIPT_DIR/scenarios/peak-day-spike.js" "peak-day-node"
+    run_scenario "$GO_URL"   "$SCRIPT_DIR/scenarios/peak-day-spike.js" "peak-day-go"
+    ;;
+
+  stress)
+    print_header "Stress / Breaking Point"
+    echo "NOTE: This scenario will intentionally overload the service."
+    run_scenario "$NODE_URL" "$SCRIPT_DIR/scenarios/stress.js" "stress-node"
+    run_scenario "$GO_URL"   "$SCRIPT_DIR/scenarios/stress.js" "stress-go"
+    ;;
+
+  all)
+    print_header "All Scenarios"
+    # 1. smoke first — bail if service is unhealthy
+    run_scenario "$NODE_URL" "$SCRIPT_DIR/scenarios/smoke.js"          "smoke-node"
+    run_scenario "$GO_URL"   "$SCRIPT_DIR/scenarios/smoke.js"          "smoke-go"
+    # 2. baseline throughput
+    for rps in "${RPS_LEVELS[@]}"; do run_baseline "$NODE_URL" "$rps" "node"; done
+    for rps in "${RPS_LEVELS[@]}"; do run_baseline "$GO_URL"   "$rps" "go";   done
+    # 3. peak-day spike
+    run_scenario "$NODE_URL" "$SCRIPT_DIR/scenarios/peak-day-spike.js" "peak-day-node"
+    run_scenario "$GO_URL"   "$SCRIPT_DIR/scenarios/peak-day-spike.js" "peak-day-go"
+    # 4. stress
+    run_scenario "$NODE_URL" "$SCRIPT_DIR/scenarios/stress.js"         "stress-node"
+    run_scenario "$GO_URL"   "$SCRIPT_DIR/scenarios/stress.js"         "stress-go"
+    ;;
+
+  baseline|*)
+    print_header "Baseline Throughput (original suite)"
+    for rps in "${RPS_LEVELS[@]}"; do run_baseline "$NODE_URL" "$rps" "node"; done
+    for rps in "${RPS_LEVELS[@]}"; do run_baseline "$GO_URL"   "$rps" "go";   done
+
+    echo ""
+    echo "========================================"
+    echo "  All benchmarks complete."
+    echo "  Results in: $RESULTS_DIR"
+    echo "========================================"
+
+    echo ""
+    echo "| Service | RPS Target | Throughput | P50 (ms) | P95 (ms) | P99 (ms) | Errors |"
+    echo "|---------|-----------|------------|----------|----------|----------|--------|"
+
+    for label in node go; do
+      for rps in "${RPS_LEVELS[@]}"; do
+        f="$RESULTS_DIR/${label}-${rps}rps.json"
+        if [ -f "$f" ]; then
+          throughput=$(jq -r '.metrics.http_reqs.values.rate // "N/A"' "$f" 2>/dev/null | xargs printf "%.1f")
+          p50=$(jq -r '.metrics.http_req_duration.values["p(50)"] // "N/A"' "$f" 2>/dev/null | xargs printf "%.2f")
+          p95=$(jq -r '.metrics.http_req_duration.values["p(95)"] // "N/A"' "$f" 2>/dev/null | xargs printf "%.2f")
+          p99=$(jq -r '.metrics.http_req_duration.values["p(99)"] // "N/A"' "$f" 2>/dev/null | xargs printf "%.2f")
+          err=$(jq -r '.metrics.error_rate.values.rate // 0' "$f" 2>/dev/null | awk '{printf "%.2f%%", $1*100}')
+          echo "| $label | $rps | $throughput | $p50 | $p95 | $p99 | $err |"
+        fi
+      done
+    done
+    ;;
+
+esac
 
 echo ""
-echo "========================================"
-echo "  All benchmarks complete."
-echo "  Results in: $RESULTS_DIR"
-echo "========================================"
-
-# Print summary table
-echo ""
-echo "| Service | RPS Target | Throughput | P50 (ms) | P95 (ms) | P99 (ms) | Errors |"
-echo "|---------|-----------|------------|----------|----------|----------|--------|"
-
-for label in node go; do
-  for rps in "${RPS_LEVELS[@]}"; do
-    f="$RESULTS_DIR/${label}-${rps}rps.json"
-    if [ -f "$f" ]; then
-      throughput=$(jq -r '.metrics.http_reqs.values.rate // "N/A"' "$f" 2>/dev/null | xargs printf "%.1f")
-      p50=$(jq -r '.metrics.http_req_duration.values["p(50)"] // "N/A"' "$f" 2>/dev/null | xargs printf "%.2f")
-      p95=$(jq -r '.metrics.http_req_duration.values["p(95)"] // "N/A"' "$f" 2>/dev/null | xargs printf "%.2f")
-      p99=$(jq -r '.metrics.http_req_duration.values["p(99)"] // "N/A"' "$f" 2>/dev/null | xargs printf "%.2f")
-      err=$(jq -r '.metrics.error_rate.values.rate // 0' "$f" 2>/dev/null | awk '{printf "%.2f%%", $1*100}')
-      echo "| $label | $rps | $throughput | $p50 | $p95 | $p99 | $err |"
-    fi
-  done
-done
+echo "Done. Results saved to: $RESULTS_DIR"

--- a/benchmarks/scenarios/peak-day-spike.js
+++ b/benchmarks/scenarios/peak-day-spike.js
@@ -1,0 +1,233 @@
+/**
+ * k6 Benchmark — Peak-Day Traffic Spike Scenario
+ *
+ * Simulates a realistic mobile-money peak-day load pattern:
+ *
+ *   Phase 1  — Baseline     (0–2 min)   : Normal morning traffic  ~500 req/s
+ *   Phase 2  — Ramp-up      (2–5 min)   : Pre-peak build-up       500 → 3 000 req/s
+ *   Phase 3  — Morning peak (5–10 min)  : Salary-day spike        3 000 → 8 000 req/s
+ *   Phase 4  — Sustained    (10–20 min) : Sustained peak load     8 000 req/s
+ *   Phase 5  — Flash spike  (20–22 min) : Sudden viral burst      8 000 → 15 000 req/s
+ *   Phase 6  — Recovery     (22–27 min) : Post-spike drain        15 000 → 2 000 req/s
+ *   Phase 7  — Cool-down    (27–30 min) : Back to baseline        2 000 → 500 req/s
+ *
+ * Usage:
+ *   k6 run -e TARGET_URL=http://localhost:3001 benchmarks/scenarios/peak-day-spike.js
+ *   k6 run -e TARGET_URL=http://localhost:3002 benchmarks/scenarios/peak-day-spike.js
+ *
+ *   # Override thresholds to observe-only (no fail)
+ *   k6 run -e TARGET_URL=http://localhost:3001 -e OBSERVE_ONLY=true benchmarks/scenarios/peak-day-spike.js
+ *
+ * Output:
+ *   Console summary + benchmarks/results/peak-day-spike-<timestamp>.json
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend, Counter } from "k6/metrics";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const TARGET_URL   = __ENV.TARGET_URL   || "http://localhost:3001";
+const OBSERVE_ONLY = __ENV.OBSERVE_ONLY === "true";
+
+// ---------------------------------------------------------------------------
+// Custom metrics
+// ---------------------------------------------------------------------------
+
+const errorRate        = new Rate("spike_error_rate");
+const publishLatency   = new Trend("spike_publish_latency_ms", true);
+const timeoutCount     = new Counter("spike_timeout_count");
+const successCount     = new Counter("spike_success_count");
+
+// ---------------------------------------------------------------------------
+// Providers & currencies — realistic diversity
+// ---------------------------------------------------------------------------
+
+const PROVIDERS = ["mtn", "airtel", "orange", "vodacom", "mpesa"];
+const CURRENCIES = ["XAF", "KES", "NGN", "GHS", "TZS", "UGX", "ZMW"];
+const REGIONS    = ["CM", "KE", "NG", "GH", "TZ", "UG", "ZM"];
+const CHANNELS   = ["mobile", "ussd", "api", "pos"];
+const STATUSES   = [
+  { status: "success",  weight: 85 },
+  { status: "pending",  weight: 10 },
+  { status: "failed",   weight: 5  },
+];
+
+// ---------------------------------------------------------------------------
+// k6 options — ramping-arrival-rate models real-world traffic curves
+// ---------------------------------------------------------------------------
+
+export const options = {
+  scenarios: {
+    peak_day_spike: {
+      executor: "ramping-arrival-rate",
+      startRate: 500,
+      timeUnit: "1s",
+      preAllocatedVUs: 2000,
+      maxVUs: 40000,
+      stages: [
+        // Phase 1 — Baseline
+        { target: 500,   duration: "2m"  },
+        // Phase 2 — Ramp-up
+        { target: 3000,  duration: "3m"  },
+        // Phase 3 — Morning peak climb
+        { target: 8000,  duration: "5m"  },
+        // Phase 4 — Sustained peak
+        { target: 8000,  duration: "10m" },
+        // Phase 5 — Flash spike
+        { target: 15000, duration: "2m"  },
+        // Phase 6 — Recovery
+        { target: 2000,  duration: "5m"  },
+        // Phase 7 — Cool-down
+        { target: 500,   duration: "3m"  },
+      ],
+    },
+  },
+
+  thresholds: OBSERVE_ONLY
+    ? {}
+    : {
+        // Latency must stay within acceptable bounds across the spike
+        http_req_duration: [
+          "p(50)<100",   // P50 < 100 ms
+          "p(95)<500",   // P95 < 500 ms
+          "p(99)<1000",  // P99 < 1 s
+        ],
+        // Error budget: tolerate up to 2% during spike, 0.5% at baseline
+        spike_error_rate: ["rate<0.02"],
+        // Timeouts should be rare even at peak
+        spike_timeout_count: ["count<500"],
+      },
+
+  summaryTrendStats: ["min", "med", "avg", "p(90)", "p(95)", "p(99)", "p(99.9)", "max", "count"],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Weighted random pick from [{status, weight}] */
+function weightedRandom(items) {
+  const total = items.reduce((sum, i) => sum + i.weight, 0);
+  let rand = Math.random() * total;
+  for (const item of items) {
+    rand -= item.weight;
+    if (rand <= 0) return item.status;
+  }
+  return items[items.length - 1].status;
+}
+
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+/** Build a realistic, varied payment callback payload */
+function makePayload() {
+  const provider = pick(PROVIDERS);
+  const idx      = PROVIDERS.indexOf(provider);
+  const currency = CURRENCIES[idx] || "XAF";
+  const region   = REGIONS[idx]    || "CM";
+
+  return JSON.stringify({
+    event_type: "payment.callback",
+    provider,
+    reference:  `REF-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    amount:     parseFloat((Math.random() * 50000 + 100).toFixed(2)),
+    currency,
+    status:     weightedRandom(STATUSES),
+    timestamp:  new Date().toISOString(),
+    metadata: {
+      customer_id: `cust-${Math.random().toString(36).slice(2, 10)}`,
+      channel:     pick(CHANNELS),
+      region,
+      session_id:  `sess-${Date.now()}`,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Default function — executed once per VU iteration
+// ---------------------------------------------------------------------------
+
+export default function () {
+  const start = Date.now();
+
+  const res = http.post(`${TARGET_URL}/ingest`, makePayload(), {
+    headers: { "Content-Type": "application/json" },
+    timeout: "10s",
+  });
+
+  const latency = Date.now() - start;
+  publishLatency.add(latency);
+
+  // Track timeouts specifically (k6 returns status 0 on network errors)
+  if (res.status === 0) {
+    timeoutCount.add(1);
+    errorRate.add(1);
+    return;
+  }
+
+  const ok = check(res, {
+    "status 202 (accepted)": (r) => r.status === 202,
+    "has reference field":   (r) => {
+      try { return r.json("reference") !== undefined; }
+      catch { return false; }
+    },
+    "response time < 1s":    (r) => r.timings.duration < 1000,
+  });
+
+  errorRate.add(!ok);
+  if (ok) successCount.add(1);
+}
+
+// ---------------------------------------------------------------------------
+// Summary — rich console output + JSON export
+// ---------------------------------------------------------------------------
+
+export function handleSummary(data) {
+  const m   = data.metrics;
+  const dur = m.http_req_duration?.values;
+  const rps = m.http_reqs?.values?.rate?.toFixed(1)           ?? "N/A";
+  const p50 = dur?.["p(50)"]?.toFixed(2)                      ?? "N/A";
+  const p90 = dur?.["p(90)"]?.toFixed(2)                      ?? "N/A";
+  const p95 = dur?.["p(95)"]?.toFixed(2)                      ?? "N/A";
+  const p99 = dur?.["p(99)"]?.toFixed(2)                      ?? "N/A";
+  const p999 = dur?.["p(99.9)"]?.toFixed(2)                   ?? "N/A";
+  const maxL = dur?.max?.toFixed(2)                            ?? "N/A";
+  const totalReqs  = m.http_reqs?.values?.count                ?? 0;
+  const errRate    = ((m.spike_error_rate?.values?.rate ?? 0) * 100).toFixed(2);
+  const timeouts   = m.spike_timeout_count?.values?.count      ?? 0;
+  const successes  = m.spike_success_count?.values?.count      ?? 0;
+
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║          Peak-Day Traffic Spike — Benchmark Results      ║");
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log(`║  Target URL   : ${TARGET_URL.padEnd(41)}║`);
+  console.log(`║  Total Requests: ${String(totalReqs).padEnd(40)}║`);
+  console.log(`║  Avg Throughput: ${rps.padEnd(35)} req/s  ║`);
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log("║  Latency Percentiles                                     ║");
+  console.log(`║    P50   : ${p50.padEnd(8)} ms                                    ║`);
+  console.log(`║    P90   : ${p90.padEnd(8)} ms                                    ║`);
+  console.log(`║    P95   : ${p95.padEnd(8)} ms                                    ║`);
+  console.log(`║    P99   : ${p99.padEnd(8)} ms                                    ║`);
+  console.log(`║    P99.9 : ${p999.padEnd(8)} ms                                   ║`);
+  console.log(`║    Max   : ${maxL.padEnd(8)} ms                                   ║`);
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log("║  Reliability                                             ║");
+  console.log(`║    Successes  : ${String(successes).padEnd(40)}║`);
+  console.log(`║    Error Rate : ${String(errRate + "%").padEnd(40)}║`);
+  console.log(`║    Timeouts   : ${String(timeouts).padEnd(40)}║`);
+  console.log("╚══════════════════════════════════════════════════════════╝\n");
+
+  const ts  = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const key = `peak-day-spike-${ts}`;
+
+  return {
+    stdout: JSON.stringify(data, null, 2),
+    [`benchmarks/results/${key}.json`]: JSON.stringify(data, null, 2),
+  };
+}

--- a/benchmarks/scenarios/smoke.js
+++ b/benchmarks/scenarios/smoke.js
@@ -1,0 +1,60 @@
+/**
+ * k6 Smoke Test — Quick sanity check before running peak-day spike
+ *
+ * Sends a low volume of requests (5 VUs, 1 min) to confirm the service
+ * is healthy and all checks pass before committing to a full load run.
+ *
+ * Usage:
+ *   k6 run -e TARGET_URL=http://localhost:3001 benchmarks/scenarios/smoke.js
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate } from "k6/metrics";
+
+const TARGET_URL = __ENV.TARGET_URL || "http://localhost:3001";
+const errorRate  = new Rate("smoke_error_rate");
+
+export const options = {
+  vus:      5,
+  duration: "1m",
+  thresholds: {
+    http_req_duration:  ["p(95)<300"],
+    smoke_error_rate:   ["rate<0.01"],
+  },
+};
+
+function makePayload() {
+  return JSON.stringify({
+    event_type: "payment.callback",
+    provider:   "mtn",
+    reference:  `SMOKE-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    amount:     1000.00,
+    currency:   "XAF",
+    status:     "success",
+    timestamp:  new Date().toISOString(),
+    metadata: { customer_id: "smoke-test", channel: "mobile", region: "CM" },
+  });
+}
+
+export default function () {
+  const res = http.post(`${TARGET_URL}/ingest`, makePayload(), {
+    headers: { "Content-Type": "application/json" },
+    timeout: "5s",
+  });
+
+  const ok = check(res, {
+    "status 202":      (r) => r.status === 202,
+    "has reference":   (r) => { try { return r.json("reference") !== undefined; } catch { return false; } },
+    "latency < 300ms": (r) => r.timings.duration < 300,
+  });
+
+  errorRate.add(!ok);
+  sleep(0.5);
+}
+
+export function handleSummary(data) {
+  const pass = (data.metrics.smoke_error_rate?.values?.rate ?? 0) < 0.01;
+  console.log(`\n  Smoke test: ${pass ? "✓ PASSED — safe to run peak-day spike" : "✗ FAILED — fix issues before load testing"}\n`);
+  return { stdout: JSON.stringify(data, null, 2) };
+}

--- a/benchmarks/scenarios/stress.js
+++ b/benchmarks/scenarios/stress.js
@@ -1,0 +1,124 @@
+/**
+ * k6 Stress Test — Find the service breaking point beyond peak-day load
+ *
+ * Ramps far beyond expected peak to identify:
+ *   - Maximum sustainable throughput
+ *   - At what RPS errors / latency degrades unacceptably
+ *   - Recovery behaviour after overload is removed
+ *
+ * Usage:
+ *   k6 run -e TARGET_URL=http://localhost:3001 benchmarks/scenarios/stress.js
+ *   k6 run -e TARGET_URL=http://localhost:3002 benchmarks/scenarios/stress.js
+ */
+
+import http from "k6/http";
+import { check } from "k6";
+import { Rate, Trend, Counter } from "k6/metrics";
+
+const TARGET_URL = __ENV.TARGET_URL || "http://localhost:3001";
+
+const errorRate      = new Rate("stress_error_rate");
+const publishLatency = new Trend("stress_publish_latency_ms", true);
+const timeoutCount   = new Counter("stress_timeout_count");
+
+export const options = {
+  scenarios: {
+    stress_ramp: {
+      executor: "ramping-arrival-rate",
+      startRate: 1000,
+      timeUnit: "1s",
+      preAllocatedVUs: 3000,
+      maxVUs: 60000,
+      stages: [
+        { target: 1000,  duration: "2m"  }, // warm-up
+        { target: 5000,  duration: "3m"  }, // normal load
+        { target: 10000, duration: "3m"  }, // peak-day level
+        { target: 20000, duration: "3m"  }, // beyond peak
+        { target: 30000, duration: "3m"  }, // stress zone
+        { target: 0,     duration: "5m"  }, // recovery
+      ],
+    },
+  },
+
+  thresholds: {
+    // These are intentionally relaxed — stress tests are expected to breach them;
+    // the point is to observe where degradation begins.
+    http_req_duration:    ["p(99)<5000"],
+    stress_error_rate:    ["rate<0.30"],
+  },
+
+  summaryTrendStats: ["min", "med", "avg", "p(90)", "p(95)", "p(99)", "p(99.9)", "max", "count"],
+};
+
+const PROVIDERS = ["mtn", "airtel", "orange", "vodacom", "mpesa"];
+const CURRENCIES = ["XAF", "KES", "NGN", "GHS", "TZS"];
+const CHANNELS   = ["mobile", "ussd", "api", "pos"];
+
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function makePayload() {
+  return JSON.stringify({
+    event_type: "payment.callback",
+    provider:   pick(PROVIDERS),
+    reference:  `STRESS-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    amount:     parseFloat((Math.random() * 100000 + 50).toFixed(2)),
+    currency:   pick(CURRENCIES),
+    status:     "success",
+    timestamp:  new Date().toISOString(),
+    metadata: {
+      customer_id: `cust-${Math.random().toString(36).slice(2, 8)}`,
+      channel:     pick(CHANNELS),
+      region:      "CM",
+    },
+  });
+}
+
+export default function () {
+  const start = Date.now();
+
+  const res = http.post(`${TARGET_URL}/ingest`, makePayload(), {
+    headers: { "Content-Type": "application/json" },
+    timeout: "15s",
+  });
+
+  publishLatency.add(Date.now() - start);
+
+  if (res.status === 0) {
+    timeoutCount.add(1);
+    errorRate.add(1);
+    return;
+  }
+
+  const ok = check(res, {
+    "status 202": (r) => r.status === 202,
+  });
+
+  errorRate.add(!ok);
+}
+
+export function handleSummary(data) {
+  const m   = data.metrics;
+  const dur = m.http_req_duration?.values;
+
+  console.log("\n╔══════════════════════════════════════════════════════════╗");
+  console.log("║               Stress Test — Breaking Point Analysis      ║");
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log(`║  Total Requests : ${String(m.http_reqs?.values?.count ?? 0).padEnd(39)}║`);
+  console.log(`║  Peak Throughput: ${String((m.http_reqs?.values?.rate ?? 0).toFixed(1) + " req/s").padEnd(39)}║`);
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log(`║  P95 latency    : ${String((dur?.["p(95)"] ?? 0).toFixed(2) + " ms").padEnd(39)}║`);
+  console.log(`║  P99 latency    : ${String((dur?.["p(99)"] ?? 0).toFixed(2) + " ms").padEnd(39)}║`);
+  console.log(`║  Max latency    : ${String((dur?.max ?? 0).toFixed(2) + " ms").padEnd(39)}║`);
+  console.log("╠══════════════════════════════════════════════════════════╣");
+  console.log(`║  Error Rate     : ${String(((m.stress_error_rate?.values?.rate ?? 0) * 100).toFixed(2) + "%").padEnd(39)}║`);
+  console.log(`║  Timeouts       : ${String(m.stress_timeout_count?.values?.count ?? 0).padEnd(39)}║`);
+  console.log("╚══════════════════════════════════════════════════════════╝\n");
+
+  const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  return {
+    stdout: JSON.stringify(data, null, 2),
+    [`benchmarks/results/stress-${ts}.json`]: JSON.stringify(data, null, 2),
+  };
+}


### PR DESCRIPTION
- Add scenarios/peak-day-spike.js: 30-min ramping-arrival-rate scenario simulating a realistic mobile-money peak day — baseline → ramp-up → morning spike (8k req/s) → sustained peak → flash burst (15k req/s) → recovery → cool-down across 7 phases
- Add scenarios/smoke.js: 1-min / 5-VU sanity check to run before any full load test; fails fast if service is unhealthy
- Add scenarios/stress.js: breaking-point test that ramps to 30k req/s to find the service's maximum sustainable throughput and recovery behaviour
- Update run-bench.sh with --scenario flag supporting smoke | peak-day | stress | all | baseline (default, backwards-compatible)
- Update RESULTS.md with spike traffic shape table, acceptance thresholds, payload diversity details, and running instructions

Closes #1339

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
