### PR TITLE
feat: add readiness endpoint with dependency verification to ingest-node

### DIFF
--- a/ingest-node/src/index.ts
+++ b/ingest-node/src/index.ts
@@ -449,6 +449,39 @@ app.get("/metrics", async (_req, reply) => {
 });
 
 // ---------------------------------------------------------------------------
+// Readiness endpoint – verifies underlying message queues before reporting ready
+// ---------------------------------------------------------------------------
+
+async function checkDependencies(): Promise<boolean> {
+  // Verify Redis connection if enabled
+  if (REDIS_ENABLED && redisPool) {
+    try {
+      await redisPool.executeCommand(async (client) => client.ping());
+    } catch (err) {
+      console.error('[ready] Redis ping failed', err);
+      return false;
+    }
+  }
+  // Verify NATS connection if enabled
+  if (NATS_ENABLED && nats) {
+    if (nats.isClosed()) {
+      console.error('[ready] NATS connection closed');
+      return false;
+    }
+  }
+  return true;
+}
+
+app.get("/ready", async (_req, reply) => {
+  const healthy = await checkDependencies();
+  if (healthy) {
+    return reply.status(200).send({ status: "ready" });
+  } else {
+    return reply.status(503).send({ status: "unavailable" });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Boot
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
this pr closes #1342 Added a /ready endpoint that checks the health of underlying message queues before reporting node readiness.
Implemented checkDependencies() to ping Redis (if enabled) and verify NATS connection status.
Returns 200 OK with { status: "ready" } when all dependencies are healthy, otherwise 503 Service Unavailable with { status: "unavailable" }.
Updated code documentation and structured sections for clarity.
The new endpoint fulfills the issue [MEDIUM] Implement Ingest Health-Check Dependency Verification by exposing liveness queries and ensuring correct status reporting.