### PR TITLE
fix: resolve issues #1309, #1313, #1316

### DIFF
--- a/src/jobs/accountingWebhookJob.ts
+++ b/src/jobs/accountingWebhookJob.ts
@@ -4,6 +4,35 @@ import { AccountingService } from "../services/accounting";
 const accountingService = new AccountingService();
 
 /**
+ * Determine provider type from user's active accounting connections
+ */
+async function getProviderTypeForUser(userId: string): Promise<'quickbooks' | 'xero' | null> {
+  const result = await pool.query(
+    'SELECT provider FROM accounting_connections WHERE user_id = $1 AND is_active = true LIMIT 1',
+    [userId]
+  );
+  if (result.rows.length === 0) return null;
+  return result.rows[0].provider as 'quickbooks' | 'xero';
+}
+
+/**
+ * Log accounting sync error to dedicated table
+ */
+async function logAccountingSyncError(
+  transactionId: string,
+  providerType: 'quickbooks' | 'xero',
+  errorMessage: string,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO accounting_sync_errors
+       (transaction_id, provider_type, error_message, status)
+     VALUES ($1, $2, $3, 'pending')
+     ON CONFLICT DO NOTHING`,
+    [transactionId, providerType, errorMessage.slice(0, 500)],
+  );
+}
+
+/**
  * Accounting Webhook Job
  * Schedule: Every minute
  * Picks up completed transactions that haven't been synced to accounting yet
@@ -59,6 +88,11 @@ export async function runAccountingWebhookJob(): Promise<void> {
       });
     } catch (err) {
       console.error(`[accounting-webhook] Failed to sync transaction ${row.id}:`, err);
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      const providerType = await getProviderTypeForUser(row.user_id);
+      if (providerType) {
+        await logAccountingSyncError(row.id, providerType, errorMessage);
+      }
     }
   }
 }

--- a/src/middleware/disputeUpload.ts
+++ b/src/middleware/disputeUpload.ts
@@ -4,20 +4,16 @@ import crypto from 'crypto';
 import path from 'path';
 
 /**
- * Allowed file types for dispute evidence
+ * Allowed file types and extensions for dispute evidence
  */
 const ALLOWED_MIME_TYPES = [
   'application/pdf',
   'image/jpeg',
-  'image/jpg', 
+  'image/jpg',
   'image/png',
-  'image/gif',
-  'text/plain',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/vnd.ms-excel',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 ];
+
+const ALLOWED_EXTENSIONS = ['.pdf', '.jpeg', '.jpg', '.png'];
 
 /**
  * Maximum file size: 10MB
@@ -37,12 +33,18 @@ const fileFilter = (
   file: Express.Multer.File,
   cb: multer.FileFilterCallback
 ) => {
-  if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+  const hasAllowedMimeType = ALLOWED_MIME_TYPES.includes(file.mimetype);
+  const filename = String(file.originalname || '').toLowerCase();
+  const hasAllowedExtension = ALLOWED_EXTENSIONS.some((ext) =>
+    filename.endsWith(ext),
+  );
+
+  if (hasAllowedMimeType && hasAllowedExtension) {
     cb(null, true);
   } else {
     cb(
       new Error(
-        `Invalid file type. Allowed types: ${ALLOWED_MIME_TYPES.join(', ')}`
+        `Invalid file type or extension. Allowed types: PDF, JPG, PNG only`
       )
     );
   }
@@ -109,7 +111,7 @@ export const uploadMultiple = multer({
  */
 export const disputeUploadErrorMessages = {
   FILE_TOO_LARGE: `File size exceeds maximum limit of ${MAX_FILE_SIZE / (1024 * 1024)}MB`,
-  INVALID_FILE_TYPE: `Invalid file type. Allowed types: ${ALLOWED_MIME_TYPES.join(', ')}`,
+  INVALID_FILE_TYPE: `Invalid file type. Allowed types: PDF, JPG, PNG only`,
   TOO_MANY_FILES: `Maximum ${MAX_FILES} files allowed per upload`,
   NO_FILE_UPLOADED: 'No file uploaded',
   UPLOAD_FAILED: 'File upload failed',

--- a/src/queue/syncWorker.ts
+++ b/src/queue/syncWorker.ts
@@ -7,9 +7,27 @@ import {
   NetworkError,
   ValidationError,
 } from "../services/accounting/accountingService";
+import { pool } from "../config/database";
 
 // Create instance of our Accounting Service
 export const accountingService = new AccountingService();
+
+/**
+ * Log accounting sync error to dedicated table
+ */
+async function logAccountingSyncError(
+  transactionId: string,
+  providerType: 'quickbooks' | 'xero',
+  errorMessage: string,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO accounting_sync_errors
+       (transaction_id, provider_type, error_message, status)
+     VALUES ($1, $2, $3, 'pending')
+     ON CONFLICT DO NOTHING`,
+    [transactionId, providerType, errorMessage.slice(0, 500)],
+  );
+}
 
 /**
  * Sync Queue Processor Function
@@ -53,6 +71,7 @@ export async function processSyncJob(
       console.error(
         `[SyncWorker] [Job ${job.id}] Permanent error encountered during ${platform} sync: ${message}. Discarding future attempts.`,
       );
+      await logAccountingSyncError(transactionId, platform, message);
 
       try {
         await job.discard();

--- a/src/routes/statements.ts
+++ b/src/routes/statements.ts
@@ -3,8 +3,7 @@ import { pool } from "../config/database";
 import { requireAuth, AuthRequest } from "../middleware/auth";
 import { TimeoutPresets, haltOnTimedout } from "../middleware/timeout";
 import { decrypt } from "../utils/encryption";
-import jsPDF from "jspdf";
-import autoTable from "jspdf-autotable";
+import PDFDocument from "pdfkit";
 
 export const statementsRoutes = Router();
 
@@ -59,7 +58,6 @@ statementsRoutes.get(
         return res.status(401).json({ error: "User not authenticated" });
       }
 
-      // Validate year and month parameters
       const yearNum = parseInt(year, 10);
       const monthNum = parseInt(month, 10);
 
@@ -74,23 +72,19 @@ statementsRoutes.get(
         return res.status(400).json({ error: "Invalid year or month" });
       }
 
-      // Generate statement data
       const statement = await generateMonthlyStatement(userId, yearNum, monthNum);
 
       if (!statement) {
         return res.status(404).json({ error: "No data found for the specified period" });
       }
 
-      // Generate PDF
       const pdfBuffer = await generateStatementPDF(statement);
 
-      // Set response headers for PDF download
       const filename = `statement-${year}-${month.padStart(2, "0")}.pdf`;
       res.setHeader("Content-Type", "application/pdf");
       res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
       res.setHeader("Content-Length", pdfBuffer.length);
 
-      // Stream PDF to client
       res.send(pdfBuffer);
     } catch (error) {
       console.error("Error generating monthly statement:", error);
@@ -99,22 +93,17 @@ statementsRoutes.get(
   }
 );
 
-/**
- * Gather chronologically ordered transactions for a user in a specific month
- */
 async function generateMonthlyStatement(
   userId: string,
   year: number,
   month: number
 ): Promise<MonthlyStatement | null> {
   const client = await pool.connect();
-  
+
   try {
-    // Calculate date range for the month
     const startDate = new Date(year, month - 1, 1);
     const endDate = new Date(year, month, 0, 23, 59, 59, 999);
 
-    // Get user information
     const userResult = await client.query(
       "SELECT id, phone_number, kyc_level FROM users WHERE id = $1",
       [userId]
@@ -126,9 +115,9 @@ async function generateMonthlyStatement(
 
     const user = userResult.rows[0];
 
-    // Get transactions for the month, ordered chronologically
-    const transactionsResult = await client.query(`
-      SELECT 
+    const transactionsResult = await client.query(
+      `
+      SELECT
         id,
         reference_number as "referenceNumber",
         type,
@@ -138,36 +127,39 @@ async function generateMonthlyStatement(
         status,
         notes,
         created_at as "createdAt"
-      FROM transactions 
-      WHERE user_id = $1 
-        AND created_at >= $2 
+      FROM transactions
+      WHERE user_id = $1
+        AND created_at >= $2
         AND created_at <= $3
         AND status = 'completed'
       ORDER BY created_at ASC
-    `, [userId, startDate, endDate]);
+    `,
+      [userId, startDate, endDate]
+    );
 
-    // Calculate opening balance (sum of all completed transactions before this month)
-    const openingBalanceResult = await client.query(`
-      SELECT 
+    const openingBalanceResult = await client.query(
+      `
+      SELECT
         COALESCE(
-          SUM(CASE WHEN type = 'deposit' THEN amount::numeric ELSE -amount::numeric END), 
+          SUM(CASE WHEN type = 'deposit' THEN amount::numeric ELSE -amount::numeric END),
           0
         ) as opening_balance
-      FROM transactions 
-      WHERE user_id = $1 
+      FROM transactions
+      WHERE user_id = $1
         AND created_at < $2
         AND status = 'completed'
-    `, [userId, startDate]);
+    `,
+      [userId, startDate]
+    );
 
     const openingBalance = parseFloat(openingBalanceResult.rows[0]?.opening_balance || "0");
 
-    // Calculate monthly totals
     let totalDeposits = 0;
     let totalWithdrawals = 0;
 
     const transactions: StatementTransaction[] = transactionsResult.rows.map((row) => {
       const amount = parseFloat(row.amount);
-      
+
       if (row.type === "deposit") {
         totalDeposits += amount;
       } else {
@@ -215,118 +207,192 @@ async function generateMonthlyStatement(
   }
 }
 
-/**
- * Generate professional PDF statement with standard accounting header/footer
- */
-async function generateStatementPDF(statement: MonthlyStatement): Promise<Buffer> {
-  const doc = new jsPDF();
-  const pageWidth = doc.internal.pageSize.width;
-  const pageHeight = doc.internal.pageSize.height;
-  
-  // Company header
-  doc.setFontSize(20);
-  doc.setFont("helvetica", "bold");
-  doc.text("Mobile Money Services", pageWidth / 2, 20, { align: "center" });
-  
-  doc.setFontSize(16);
-  doc.text("Monthly Account Statement", pageWidth / 2, 30, { align: "center" });
-  
-  // Statement period and account info
-  doc.setFontSize(10);
-  doc.setFont("helvetica", "normal");
-  
-  const monthNames = [
-    "January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December"
-  ];
-  
-  const periodText = `${monthNames[statement.period.month - 1]} ${statement.period.year}`;
-  doc.text(`Statement Period: ${periodText}`, 20, 45);
-  doc.text(`Account: ${statement.user.phoneNumber}`, 20, 52);
-  doc.text(`KYC Level: ${statement.user.kycLevel.toUpperCase()}`, 20, 59);
-  doc.text(`Generated: ${new Date().toLocaleDateString()}`, 20, 66);
-  
-  // Account summary box
-  doc.setDrawColor(0, 0, 0);
-  doc.rect(20, 75, pageWidth - 40, 35);
-  
-  doc.setFontSize(12);
-  doc.setFont("helvetica", "bold");
-  doc.text("Account Summary", 25, 85);
-  
-  doc.setFontSize(10);
-  doc.setFont("helvetica", "normal");
-  
-  const formatCurrency = (amount: number) => 
-    new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 2,
-    }).format(amount);
-  
-  doc.text(`Opening Balance:`, 25, 95);
-  doc.text(formatCurrency(statement.summary.openingBalance), 120, 95);
-  
-  doc.text(`Total Deposits:`, 25, 102);
-  doc.text(formatCurrency(statement.summary.totalDeposits), 120, 102);
-  
-  doc.text(`Total Withdrawals:`, 25, 109);
-  doc.text(`(${formatCurrency(statement.summary.totalWithdrawals)})`, 120, 109);
-  
-  doc.setFont("helvetica", "bold");
-  doc.text(`Closing Balance:`, 25, 116);
-  doc.text(formatCurrency(statement.summary.closingBalance), 120, 116);
-  
-  // Transaction details table
-  if (statement.transactions.length > 0) {
-    const tableData = statement.transactions.map((tx) => [
-      new Date(tx.createdAt).toLocaleDateString(),
-      tx.referenceNumber,
-      tx.type.charAt(0).toUpperCase() + tx.type.slice(1),
-      tx.provider,
-      tx.type === "deposit" ? formatCurrency(parseFloat(tx.amount)) : "",
-      tx.type === "withdraw" ? formatCurrency(parseFloat(tx.amount)) : "",
-      tx.notes || "",
-    ]);
+function generateStatementPDF(statement: MonthlyStatement): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    try {
+      const doc = new PDFDocument({ size: "A4", margin: 50 });
+      const chunks: Buffer[] = [];
 
-    autoTable(doc, {
-      startY: 125,
-      head: [["Date", "Reference", "Type", "Provider", "Deposits", "Withdrawals", "Notes"]],
-      body: tableData,
-      styles: {
-        fontSize: 8,
-        cellPadding: 2,
-      },
-      headStyles: {
-        fillColor: [240, 240, 240],
-        textColor: [0, 0, 0],
-        fontStyle: "bold",
-      },
-      columnStyles: {
-        0: { cellWidth: 20 }, // Date
-        1: { cellWidth: 25 }, // Reference
-        2: { cellWidth: 18 }, // Type
-        3: { cellWidth: 20 }, // Provider
-        4: { cellWidth: 25, halign: "right" }, // Deposits
-        5: { cellWidth: 25, halign: "right" }, // Withdrawals
-        6: { cellWidth: 35 }, // Notes
-      },
-      margin: { left: 20, right: 20 },
-    });
-  } else {
-    doc.setFontSize(10);
-    doc.text("No transactions found for this period.", 20, 135);
-  }
-  
-  // Footer with legal disclaimer
-  const footerY = pageHeight - 30;
-  doc.setFontSize(8);
-  doc.setFont("helvetica", "normal");
-  doc.text("This statement is generated electronically and is valid without signature.", pageWidth / 2, footerY, { align: "center" });
-  doc.text("For inquiries, please contact customer support.", pageWidth / 2, footerY + 7, { align: "center" });
-  
-  // Page number
-  doc.text(`Page 1`, pageWidth - 30, footerY + 14);
-  
-  return Buffer.from(doc.output("arraybuffer"));
+      doc.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+      doc.on("end", () => resolve(Buffer.concat(chunks)));
+      doc.on("error", (err) => reject(err));
+
+      const pageWidth = doc.page.width;
+      const pageHeight = doc.page.height;
+      const margin = 50;
+
+      doc.font("Helvetica");
+
+      doc
+        .fontSize(20)
+        .font("Helvetica-Bold")
+        .text("Mobile Money Services", { align: "center" });
+
+      doc
+        .moveDown(0.3)
+        .fontSize(14)
+        .text("Monthly Account Statement", { align: "center" });
+
+      const monthNames = [
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+      ];
+      const periodText = `${monthNames[statement.period.month - 1]} ${statement.period.year}`;
+
+      doc
+        .moveDown(0.8)
+        .fontSize(10)
+        .font("Helvetica")
+        .text(`Statement Period: ${periodText}`, { continued: false })
+        .text(`Account: ${statement.user.phoneNumber}`)
+        .text(`KYC Level: ${statement.user.kycLevel.toUpperCase()}`)
+        .text(`Generated: ${new Date().toLocaleDateString()}`);
+
+      const formatCurrency = (amount: number) =>
+        new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "USD",
+          minimumFractionDigits: 2,
+        }).format(amount);
+
+      const summaryTop = doc.y;
+      doc
+        .fontSize(12)
+        .font("Helvetica-Bold")
+        .text("Account Summary", { continued: false });
+      doc.moveDown(0.2);
+      doc
+        .fontSize(10)
+        .font("Helvetica")
+        .text(`Opening Balance:    ${formatCurrency(statement.summary.openingBalance)}`)
+        .text(`Total Deposits:     ${formatCurrency(statement.summary.totalDeposits)}`)
+        .text(`Total Withdrawals:  (${formatCurrency(statement.summary.totalWithdrawals)})`)
+        .font("Helvetica-Bold")
+        .text(`Closing Balance:    ${formatCurrency(statement.summary.closingBalance)}`);
+
+      const summaryBoxY = summaryTop - 10;
+      const summaryBoxHeight = doc.y - summaryBoxY + 10;
+      doc
+        .moveTo(margin, summaryBoxY)
+        .lineTo(pageWidth - margin, summaryBoxY)
+        .lineTo(pageWidth - margin, summaryBoxY + summaryBoxHeight)
+        .lineTo(margin, summaryBoxY + summaryBoxHeight)
+        .closePath()
+        .stroke();
+
+      doc.moveDown(0.5);
+
+      const tableTop = doc.y;
+      const colWidths = [58, 73, 53, 59, 74, 74, 104];
+      const tableWidth = colWidths.reduce((a, b) => a + b, 0);
+      const tableStartX = margin;
+
+      const headerLabels = [
+        "Date",
+        "Reference",
+        "Type",
+        "Provider",
+        "Deposits",
+        "Withdrawals",
+        "Notes",
+      ];
+
+      doc
+        .font("Helvetica-Bold")
+        .fontSize(8)
+        .fillColor("#f0f0f0")
+        .rect(tableStartX, tableTop, tableWidth, 18)
+        .fill();
+
+      let x = tableStartX;
+      headerLabels.forEach((label, i) => {
+        doc.fillColor("#000000").text(label, x + 2, tableTop + 5, {
+          width: colWidths[i] - 4,
+          align: i >= 4 ? "right" : "left",
+        });
+        x += colWidths[i];
+      });
+
+      doc.y = tableTop + 18;
+
+      const rows = statement.transactions.map((tx) => [
+        new Date(tx.createdAt).toLocaleDateString(),
+        tx.referenceNumber,
+        tx.type.charAt(0).toUpperCase() + tx.type.slice(1),
+        tx.provider,
+        tx.type === "deposit" ? formatCurrency(parseFloat(tx.amount)) : "",
+        tx.type === "withdraw" ? formatCurrency(parseFloat(tx.amount)) : "",
+        tx.notes || "",
+      ]);
+
+      rows.forEach((row, rowIndex) => {
+        if (doc.y > pageHeight - 60) {
+          doc.addPage();
+          doc.moveDown(0.5);
+        }
+
+        const rowTop = doc.y;
+        const rowHeight = Math.max(14, row.reduce((max, cell, i) => {
+          const lines = doc.heightOfString(cell, { width: colWidths[i] - 4 });
+          return Math.max(max, Math.ceil(lines) + 8);
+        }, 0));
+
+        doc
+          .fillColor(rowIndex % 2 === 0 ? "#ffffff" : "#fafafa")
+          .rect(tableStartX, rowTop, tableWidth, rowHeight)
+          .fill();
+
+        x = tableStartX;
+        row.forEach((cell, i) => {
+          doc.fillColor("#000000").text(cell, x + 2, rowTop + 4, {
+            width: colWidths[i] - 4,
+            align: i >= 4 ? "right" : "left",
+          });
+          x += colWidths[i];
+        });
+
+        doc.y = rowTop + rowHeight;
+        doc
+          .strokeColor("#cccccc")
+          .lineWidth(0.5)
+          .moveTo(tableStartX, rowTop + rowHeight)
+          .lineTo(tableStartX + tableWidth, rowTop + rowHeight)
+          .stroke();
+      });
+
+      if (rows.length === 0) {
+        doc
+          .fontSize(10)
+          .font("Helvetica")
+          .text("No transactions found for this period.", margin, tableTop + 10);
+      }
+
+      doc.font("Helvetica").fontSize(8).fillColor("#000000");
+
+      const footerY = pageHeight - margin - 30;
+      const range = doc.bufferedPageRange();
+      for (let i = range.start; i < range.start + range.count; i++) {
+        doc.switchToPage(i);
+        doc.text(
+          "This statement is generated electronically and is valid without signature.",
+          margin,
+          footerY,
+          { align: "center", width: pageWidth - 2 * margin }
+        );
+        doc.text(
+          "For inquiries, please contact customer support.",
+          margin,
+          footerY + 10,
+          { align: "center", width: pageWidth - 2 * margin }
+        );
+        doc.text(`Page ${i + 1}`, pageWidth - margin - 20, footerY + 10, {
+          align: "right",
+        });
+      }
+
+      doc.end();
+    } catch (err) {
+      reject(err);
+    }
+  });
 }

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -1615,6 +1615,25 @@ export class AccountingService {
             err instanceof Error ? err.message : String(err),
           ],
         );
+
+        const providerType =
+          connection.provider === AccountingProvider.QUICKBOOKS
+            ? 'quickbooks'
+            : connection.provider === AccountingProvider.XERO
+              ? 'xero'
+              : null;
+
+        if (providerType) {
+          const errorMessage =
+            err instanceof Error ? err.message : String(err);
+          await pool.query(
+            `INSERT INTO accounting_sync_errors
+               (transaction_id, provider_type, error_message, status)
+             VALUES ($1, $2, $3, 'pending')
+             ON CONFLICT DO NOTHING`,
+            [transaction.id, providerType, errorMessage.slice(0, 500)],
+          );
+        }
       }
     }
   }

--- a/src/services/disputeS3Upload.ts
+++ b/src/services/disputeS3Upload.ts
@@ -117,31 +117,32 @@ export const disputeEvidenceExistsInS3 = async (key: string): Promise<boolean> =
 export const validateDisputeEvidenceFile = (file: Express.Multer.File): { valid: boolean; error?: string } => {
   const allowedMimeTypes = [
     'application/pdf',
-    'image/jpeg', 
+    'image/jpeg',
     'image/jpg',
     'image/png',
-    'image/gif',
-    'text/plain',
-    'application/msword',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    'application/vnd.ms-excel',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   ];
-  const maxSize = 10 * 1024 * 1024; // 10MB
-  
-  if (!allowedMimeTypes.includes(file.mimetype)) {
+  const allowedExtensions = ['.pdf', '.jpeg', '.jpg', '.png'];
+  const maxSize = 10 * 1024 * 1024;
+  const filename = String(file.originalname || '').toLowerCase();
+
+  const hasAllowedMimeType = allowedMimeTypes.includes(file.mimetype);
+  const hasAllowedExtension = allowedExtensions.some((ext) =>
+    filename.endsWith(ext),
+  );
+
+  if (!hasAllowedMimeType || !hasAllowedExtension) {
     return {
       valid: false,
-      error: `Invalid file type. Allowed types: ${allowedMimeTypes.join(', ')}`,
+      error: `Invalid file type or extension. Allowed types: PDF, JPG, PNG only`,
     };
   }
-  
+
   if (file.size > maxSize) {
     return {
       valid: false,
       error: `File size exceeds maximum limit of ${maxSize / (1024 * 1024)}MB`,
     };
   }
-  
+
   return { valid: true };
 };


### PR DESCRIPTION
Closes #1309, #1313, #1316

## Issue #1309 [MEDIUM] - Build Automated PDF Monthly Statement Generator
- Migrated src/routes/statements.ts from jspdf/autoTable to pdfkit to align with project-wide PDF generation conventions (pdfReceipt.ts, invoiceService.ts, complianceReportService.ts, sar.ts all use pdfkit).
- Rewrote generateStatementPDF() using PDFDocument event-based buffer collection pattern.
- Implemented manual table rendering with alternating row backgrounds, header styling, column alignment, and automatic page breaks.
- Added multi-page footer support with page numbers using doc.bufferedPageRange() following the same pattern as invoiceService.ts.
- All existing transaction query logic and statistics compilation (opening balance, deposits, withdrawals, closing balance) is preserved.

## Issue #1313 [GOOD FIRST ISSUE] - Standardize Accounting Sync Error Status Table
- The accounting_sync_errors table existed via migration 20260529_create_accounting_sync_errors.sql but was never populated.
- Modified src/services/accounting.ts syncTransaction() to INSERT into accounting_sync_errors (with provider_type derived from connection.provider) whenever a per-connection sync fails, in addition to the existing accounting_sync_queue update.
- Modified src/queue/syncWorker.ts processSyncJob() to log permanent (non-transient) errors to accounting_sync_errors using the platform variable from job data.
- Modified src/jobs/accountingWebhookJob.ts to query the user's active accounting connection for provider_type and INSERT into accounting_sync_errors when syncTransaction() throws an infrastructure error.
- All inserts use ON CONFLICT DO NOTHING to prevent duplicates and truncate error messages to 500 characters to respect the column width.

## Issue #1316 [GOOD FIRST ISSUE] - Check Dispute Evidence File Extensions
- Restrict dispute evidence uploads to PNG, PDF, JPG only.
- Removed insecure file types (GIF, text/plain, DOC, DOCX, XLS, XLSX) from ALLOWED_MIME_TYPES in both src/middleware/disputeUpload.ts and src/services/disputeS3Upload.ts.
- Added ALLOWED_EXTENSIONS = ['.pdf', '.jpeg', '.jpg', '.png'] and extension validation to both the multer fileFilter in the middleware and the validateDisputeEvidenceFile() service function, following the existing pattern in src/routes/kycRoutes.ts.
- Updated error messages to reflect the restricted allowed types.


closes #1313 


closes #1316 