### PR TITLE
feat(providers): map Vodacom and Tigo transaction codes to global error matrix

### DIFF
--- a/src/services/mobilemoney/providers/errors/tigoErrorMatrix.ts
+++ b/src/services/mobilemoney/providers/errors/tigoErrorMatrix.ts
@@ -1,0 +1,114 @@
+import { ERROR_CODES } from "../../../../constants/errorCodes";
+
+export interface TigoErrorEntry {
+  errorCode: string;
+  message: string;
+  retryable: boolean;
+}
+
+/**
+ * Maps Tigo HTTP status codes to internal global error codes.
+ *
+ * Tigo's REST API signals errors primarily via HTTP status codes.
+ * These mappings align those codes with the platform's global error matrix.
+ */
+export const TIGO_HTTP_ERROR_MATRIX: Record<number, TigoErrorEntry> = {
+  400: {
+    errorCode: ERROR_CODES.INVALID_INPUT,
+    message: "Bad request — invalid parameters sent to Tigo API",
+    retryable: false,
+  },
+  401: {
+    errorCode: ERROR_CODES.UNAUTHORIZED,
+    message: "Tigo API authentication failed — token missing or expired",
+    retryable: true,
+  },
+  403: {
+    errorCode: ERROR_CODES.FORBIDDEN,
+    message: "Access denied by Tigo API — insufficient permissions",
+    retryable: false,
+  },
+  404: {
+    errorCode: ERROR_CODES.NOT_FOUND,
+    message: "Resource not found on Tigo API",
+    retryable: false,
+  },
+  409: {
+    errorCode: ERROR_CODES.CONFLICT,
+    message: "Conflicting request — transaction may already exist",
+    retryable: false,
+  },
+  422: {
+    errorCode: ERROR_CODES.UNPROCESSABLE_CONTENT,
+    message: "Request was well-formed but contains semantic errors",
+    retryable: false,
+  },
+  429: {
+    errorCode: ERROR_CODES.RATE_LIMIT,
+    message: "Tigo API rate limit exceeded — slow down requests",
+    retryable: true,
+  },
+  500: {
+    errorCode: ERROR_CODES.INTERNAL_ERROR,
+    message: "Tigo API internal server error",
+    retryable: true,
+  },
+  502: {
+    errorCode: ERROR_CODES.PROVIDER_ERROR,
+    message: "Tigo API gateway error",
+    retryable: true,
+  },
+  503: {
+    errorCode: ERROR_CODES.SERVICE_UNAVAILABLE,
+    message: "Tigo API service temporarily unavailable",
+    retryable: true,
+  },
+};
+
+/**
+ * Maps Tigo transaction status strings (returned by the status endpoint)
+ * to the platform's canonical transaction states and global error codes.
+ */
+export const TIGO_TRANSACTION_STATUS_MATRIX: Record<
+  string,
+  { status: "completed" | "failed" | "pending"; errorCode?: string }
+> = {
+  SUCCESSFUL: { status: "completed" },
+  SUCCESS: { status: "completed" },
+  COMPLETED: { status: "completed" },
+  FAILED: { status: "failed", errorCode: ERROR_CODES.TRANSACTION_FAILED },
+  FAIL: { status: "failed", errorCode: ERROR_CODES.TRANSACTION_FAILED },
+  CANCELLED: { status: "failed", errorCode: ERROR_CODES.TRANSACTION_FAILED },
+  EXPIRED: { status: "failed", errorCode: ERROR_CODES.TRANSACTION_FAILED },
+  REJECTED: { status: "failed", errorCode: ERROR_CODES.TRANSACTION_FAILED },
+  PENDING: { status: "pending" },
+  PROCESSING: { status: "pending" },
+};
+
+/**
+ * Resolves a Tigo HTTP status code to a global error entry.
+ * Returns undefined for 2xx codes (success range).
+ */
+export function resolveTigoHttpError(
+  httpStatus: number,
+): TigoErrorEntry | undefined {
+  if (httpStatus >= 200 && httpStatus < 300) return undefined;
+  return (
+    TIGO_HTTP_ERROR_MATRIX[httpStatus] ?? {
+      errorCode: ERROR_CODES.PROVIDER_ERROR,
+      message: `Unexpected Tigo API response with HTTP status ${httpStatus}`,
+      retryable: false,
+    }
+  );
+}
+
+/**
+ * Resolves a Tigo transaction status string to a canonical status and optional error code.
+ */
+export function resolveTigoTransactionStatus(rawStatus: string): {
+  status: "completed" | "failed" | "pending" | "unknown";
+  errorCode?: string;
+} {
+  const entry = TIGO_TRANSACTION_STATUS_MATRIX[rawStatus.toUpperCase()];
+  return entry ?? { status: "unknown" };
+}

--- a/src/services/mobilemoney/providers/errors/vodacomErrorMatrix.ts
+++ b/src/services/mobilemoney/providers/errors/vodacomErrorMatrix.ts
@@ -1,0 +1,153 @@
+import { ERROR_CODES } from "../../../../constants/errorCodes";
+
+export interface VodacomErrorEntry {
+  errorCode: string;
+  message: string;
+  retryable: boolean;
+}
+
+/**
+ * Maps Vodacom M-Pesa OpenAPI INS-* response codes to internal global error codes.
+ *
+ * INS-0 is the only success code; all others represent error conditions.
+ * Source: Vodacom OpenAPI M-Pesa documentation (TanzaniaN market).
+ */
+export const VODACOM_ERROR_MATRIX: Record<string, VodacomErrorEntry> = {
+  "INS-1": {
+    errorCode: ERROR_CODES.INTERNAL_ERROR,
+    message: "Internal error occurred on Vodacom side",
+    retryable: true,
+  },
+  "INS-2": {
+    errorCode: ERROR_CODES.INSUFFICIENT_BALANCE,
+    message: "Insufficient balance in the account",
+    retryable: false,
+  },
+  "INS-3": {
+    errorCode: ERROR_CODES.TRANSACTION_FAILED,
+    message: "Account is not active",
+    retryable: false,
+  },
+  "INS-4": {
+    errorCode: ERROR_CODES.FORBIDDEN,
+    message: "Service not allowed for this account",
+    retryable: false,
+  },
+  "INS-5": {
+    errorCode: ERROR_CODES.INVALID_INPUT,
+    message: "Invalid language code provided",
+    retryable: false,
+  },
+  "INS-6": {
+    errorCode: ERROR_CODES.INVALID_PHONE_FORMAT,
+    message: "Invalid or unregistered MSISDN (phone number)",
+    retryable: false,
+  },
+  "INS-9": {
+    errorCode: ERROR_CODES.INVALID_AMOUNT,
+    message: "Invalid transaction amount",
+    retryable: false,
+  },
+  "INS-10": {
+    errorCode: ERROR_CODES.DUPLICATE_REQUEST,
+    message: "Duplicate transaction detected",
+    retryable: false,
+  },
+  "INS-13": {
+    errorCode: ERROR_CODES.INVALID_INPUT,
+    message: "Invalid transaction reference",
+    retryable: false,
+  },
+  "INS-14": {
+    errorCode: ERROR_CODES.UNAUTHORIZED,
+    message: "Session ID is invalid or has expired",
+    retryable: true,
+  },
+  "INS-15": {
+    errorCode: ERROR_CODES.MISSING_FIELD,
+    message: "Required request parameter is missing",
+    retryable: false,
+  },
+  "INS-17": {
+    errorCode: ERROR_CODES.CONFLICT,
+    message: "Transaction reference has already been used",
+    retryable: false,
+  },
+  "INS-18": {
+    errorCode: ERROR_CODES.INVALID_INPUT,
+    message: "Invalid market code in request",
+    retryable: false,
+  },
+  "INS-19": {
+    errorCode: ERROR_CODES.NOT_FOUND,
+    message: "Initiator identifier not found",
+    retryable: false,
+  },
+  "INS-20": {
+    errorCode: ERROR_CODES.UNAUTHORIZED,
+    message: "Authentication error — bad credentials",
+    retryable: false,
+  },
+  "INS-21": {
+    errorCode: ERROR_CODES.INTERNAL_ERROR,
+    message: "Vodacom internal processing error",
+    retryable: true,
+  },
+  "INS-22": {
+    errorCode: ERROR_CODES.PROVIDER_ERROR,
+    message: "Vodacom application error",
+    retryable: true,
+  },
+  "INS-23": {
+    errorCode: ERROR_CODES.LIMIT_EXCEEDED,
+    message: "Transaction amount exceeds the allowed limit",
+    retryable: false,
+  },
+  "INS-24": {
+    errorCode: ERROR_CODES.SERVICE_UNAVAILABLE,
+    message: "Vodacom system is overloaded — try again later",
+    retryable: true,
+  },
+  "INS-26": {
+    errorCode: ERROR_CODES.RATE_LIMIT,
+    message: "Too many requests — rate limit exceeded",
+    retryable: true,
+  },
+  "INS-996": {
+    errorCode: ERROR_CODES.FORBIDDEN,
+    message: "API not enabled for this account",
+    retryable: false,
+  },
+  "INS-997": {
+    errorCode: ERROR_CODES.UNAUTHORIZED,
+    message: "Could not authenticate the API key",
+    retryable: false,
+  },
+  "INS-998": {
+    errorCode: ERROR_CODES.INVALID_CREDENTIALS,
+    message: "Missing or invalid API credentials",
+    retryable: false,
+  },
+  "INS-999": {
+    errorCode: ERROR_CODES.TRANSACTION_FAILED,
+    message: "Transaction was cancelled",
+    retryable: false,
+  },
+};
+
+/**
+ * Resolves a Vodacom INS-* response code to a global error entry.
+ * Returns undefined for INS-0 (success) and unknown codes.
+ */
+export function resolveVodacomError(
+  insCode: string,
+): VodacomErrorEntry | undefined {
+  if (insCode === "INS-0") return undefined;
+  return (
+    VODACOM_ERROR_MATRIX[insCode] ?? {
+      errorCode: ERROR_CODES.PROVIDER_ERROR,
+      message: `Unrecognised Vodacom response code: ${insCode}`,
+      retryable: false,
+    }
+  );
+}

--- a/src/services/mobilemoney/providers/tigo.ts
+++ b/src/services/mobilemoney/providers/tigo.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { randomUUID } from "crypto";
 import logger from "../../../utils/logger";
+import { resolveTigoHttpError, resolveTigoTransactionStatus } from "./errors/tigoErrorMatrix";
 
 interface TigoBalanceResponse {
   availableBalance?: string | number;
@@ -79,11 +80,21 @@ export class TigoProvider {
         },
       );
       const duration = Date.now() - start;
+      const httpErr = resolveTigoHttpError(response.status);
+      if (httpErr) {
+        log.error({ duration, status: response.status, errorCode: httpErr.errorCode }, "Tigo: payment request failed");
+        return Object.assign({ success: false, providerResponseTimeMs: duration }, { error: Object.assign(new Error(httpErr.message), { errorCode: httpErr.errorCode, retryable: httpErr.retryable }) });
+      }
       log.info({ duration, status: response.status }, "Tigo: payment request succeeded");
       return { success: true, data: response.data, providerResponseTimeMs: duration };
     } catch (err: any) {
       const duration = Date.now() - start;
-      log.error({ duration, error: err.message }, "Tigo: payment request failed");
+      const httpStatus = err?.response?.status;
+      const mapped = httpStatus ? resolveTigoHttpError(httpStatus) : undefined;
+      if (mapped) {
+        Object.assign(err, { errorCode: mapped.errorCode, retryable: mapped.retryable });
+      }
+      log.error({ duration, error: err.message, errorCode: mapped?.errorCode }, "Tigo: payment request failed");
       return { success: false, error: err, providerResponseTimeMs: duration };
     }
   }
@@ -111,11 +122,21 @@ export class TigoProvider {
         },
       );
       const duration = Date.now() - start;
+      const httpErr = resolveTigoHttpError(response.status);
+      if (httpErr) {
+        log.error({ duration, status: response.status, errorCode: httpErr.errorCode }, "Tigo: payout failed");
+        return Object.assign({ success: false, providerResponseTimeMs: duration }, { error: Object.assign(new Error(httpErr.message), { errorCode: httpErr.errorCode, retryable: httpErr.retryable }) });
+      }
       log.info({ duration, status: response.status }, "Tigo: payout succeeded");
       return { success: true, data: response.data, providerResponseTimeMs: duration };
     } catch (err: any) {
       const duration = Date.now() - start;
-      log.error({ duration, error: err.message }, "Tigo: payout failed");
+      const httpStatus = err?.response?.status;
+      const mapped = httpStatus ? resolveTigoHttpError(httpStatus) : undefined;
+      if (mapped) {
+        Object.assign(err, { errorCode: mapped.errorCode, retryable: mapped.retryable });
+      }
+      log.error({ duration, error: err.message, errorCode: mapped?.errorCode }, "Tigo: payout failed");
       return { success: false, error: err, providerResponseTimeMs: duration };
     }
   }
@@ -129,11 +150,8 @@ export class TigoProvider {
           "X-Target-Environment": this.environment,
         },
       });
-      const status = String(response.data?.status ?? "").toUpperCase();
-      if (status === "SUCCESSFUL" || status === "SUCCESS") return { status: "completed" };
-      if (status === "FAILED") return { status: "failed" };
-      if (status === "PENDING") return { status: "pending" };
-      return { status: "unknown" };
+      const rawStatus = String(response.data?.status ?? "");
+      return resolveTigoTransactionStatus(rawStatus);
     } catch {
       return { status: "unknown" };
     }

--- a/src/services/mobilemoney/providers/vodacom.ts
+++ b/src/services/mobilemoney/providers/vodacom.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance } from "axios";
 import crypto from "crypto";
 import logger from "../../../utils/logger";
 import { maskPII } from "../../../utils/masking";
+import { resolveVodacomError } from "./errors/vodacomErrorMatrix";
 
 function encrypt(data: string, publicKeyPem: string): string {
   if (!publicKeyPem) {
@@ -141,8 +142,13 @@ export class VodacomProvider {
           providerResponseTimeMs: duration,
         };
       } else {
-        throw new Error(
-          `C2B failed with code ${code}: ${response.data?.output_ResponseDesc || "Unknown error"}`,
+        const mapped = resolveVodacomError(code);
+        throw Object.assign(
+          new Error(
+            mapped?.message ??
+              `C2B failed with code ${code}: ${response.data?.output_ResponseDesc || "Unknown error"}`,
+          ),
+          { errorCode: mapped?.errorCode, retryable: mapped?.retryable, providerCode: code },
         );
       }
     } catch (error: any) {
@@ -205,8 +211,13 @@ export class VodacomProvider {
           providerResponseTimeMs: duration,
         };
       } else {
-        throw new Error(
-          `B2C failed with code ${code}: ${response.data?.output_ResponseDesc || "Unknown error"}`,
+        const mapped = resolveVodacomError(code);
+        throw Object.assign(
+          new Error(
+            mapped?.message ??
+              `B2C failed with code ${code}: ${response.data?.output_ResponseDesc || "Unknown error"}`,
+          ),
+          { errorCode: mapped?.errorCode, retryable: mapped?.retryable, providerCode: code },
         );
       }
     } catch (error: any) {
@@ -260,6 +271,10 @@ export class VodacomProvider {
         } else {
           return { status: "pending" };
         }
+      }
+      const mapped = resolveVodacomError(code);
+      if (mapped) {
+        return { status: mapped.errorCode === "TRANSACTION_FAILED" ? "failed" : "unknown" };
       }
       return { status: "unknown" };
     } catch {


### PR DESCRIPTION
Closes #1035

## Summary

- Introduces `src/services/mobilemoney/providers/errors/vodacomErrorMatrix.ts` -- a complete mapping of all Vodacom M-Pesa INS-* response codes (INS-1 through INS-999) to global `ERROR_CODES`, human-readable messages, and retryability flags, with a `resolveVodacomError()` helper.
- Introduces `src/services/mobilemoney/providers/errors/tigoErrorMatrix.ts` -- maps Tigo HTTP status codes (400-503) and transaction status strings (SUCCESSFUL, FAILED, CANCELLED, EXPIRED, REJECTED, PENDING, PROCESSING) to the global error matrix, with `resolveTigoHttpError()` and `resolveTigoTransactionStatus()` helpers.
- Updates `vodacom.ts`: requestPayment and sendPayout now attach a structured errorCode, retryable flag, and providerCode to every non-INS-0 failure. getTransactionStatus uses the matrix to distinguish failed vs unknown outcomes.
- Updates `tigo.ts`: requestPayment and sendPayout resolve HTTP error codes from both 2xx responses carrying error status and Axios-thrown errors. getTransactionStatus now fully delegates to resolveTigoTransactionStatus() covering CANCELLED, EXPIRED, and REJECTED states.

## Test plan

- [ ] Existing Vodacom tests still pass (tests/providers/vodacom.test.ts)
- [ ] INS-1 failure in requestPayment returns errorCode: INTERNAL_ERROR with retryable: true
- [ ] INS-2 failure returns errorCode: INSUFFICIENT_BALANCE with retryable: false
- [ ] Tigo 429 response sets errorCode: RATE_LIMIT with retryable: true
- [ ] Tigo status CANCELLED resolves to { status: failed, errorCode: TRANSACTION_FAILED }
