### PR TITLE
Log Provider Status Changes on Dashboard

### DIFF
--- a/src/services/providerStatusService.ts
+++ b/src/services/providerStatusService.ts
@@ -1,4 +1,6 @@
+import { EventEmitter } from "events";
 import { pool } from "../config/database";
+import logger from "../utils/logger";
 
 export type ProviderName = "mtn" | "airtel" | "orange";
 export type StatusColor = "green" | "yellow" | "red";
@@ -16,6 +18,22 @@ export interface ProvidersStatusResult {
   providers: ProviderStatusSummary[];
   generatedAt: string;
 }
+
+// ─── Status change tracking ──────────────────────────────────────────────────
+
+const lastStatuses = new Map<ProviderName, StatusColor>();
+
+export const providerStatusEvents = new EventEmitter();
+
+providerStatusEvents.on("statusChange", (provider: ProviderName, oldStatus: StatusColor | undefined, newStatus: StatusColor) => {
+  if (newStatus === "red") {
+    logger.warn({ provider, oldStatus, newStatus }, `Provider ${provider} is offline (status: ${newStatus})`);
+  } else if (oldStatus === "red") {
+    logger.info({ provider, oldStatus, newStatus }, `Provider ${provider} is back online (status: ${newStatus})`);
+  } else {
+    logger.info({ provider, oldStatus, newStatus }, `Provider ${provider} status changed to ${newStatus}`);
+  }
+});
 
 // Green  : success rate >= 95%
 // Yellow : success rate >= 80%
@@ -74,6 +92,15 @@ export async function getProvidersStatus(): Promise<ProvidersStatusResult> {
       lastCalledAt: row.last_called_at ? row.last_called_at.toISOString() : null,
     };
   });
+
+  // Detect and emit status transitions
+  for (const p of providers) {
+    const oldStatus = lastStatuses.get(p.provider);
+    if (oldStatus !== p.status) {
+      providerStatusEvents.emit("statusChange", p.provider, oldStatus, p.status);
+      lastStatuses.set(p.provider, p.status);
+    }
+  }
 
   return { providers, generatedAt: new Date().toISOString() };
 }


### PR DESCRIPTION
Emit events when a provider goes offline to log files so administrators can easily find details in logs.

closing #1266 