### PR TITLE
#1015 Add Datadog APM Tracing for GraphQL Resolvers execution

### DIFF
--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -6,4 +6,48 @@ tracer.init({
   service: "mobile-money",
 });
 
+tracer.use("graphql", {
+  // -1 = instrument all resolvers (no depth limit) — required for nested
+  // query bottleneck analysis. Set to 0 to disable resolver spans.
+  depth: -1,
+
+  // Derive the resource name from the operation signature (e.g.
+  // "query transaction($id: String!)") so it's human-readable in the UI.
+  signature: true,
+
+  // Do NOT capture the raw query text — it may contain PII.
+  source: false,
+
+  // Truncate variables that contain PII (phone numbers, addresses, etc.)
+  // so they never appear as span tags.
+  variables: (vars) => {
+    if (!vars) return vars;
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(vars)) {
+      if (/phone|address|token|secret|password|key/i.test(key)) {
+        sanitized[key] = "***";
+      } else {
+        sanitized[key] = value;
+      }
+    }
+    return sanitized;
+  },
+
+  hooks: {
+    execute: (span, args) => {
+      if (!span || !args) return;
+      // Extract operation type and name from the parsed document
+      const opDef = args.document?.definitions?.find(
+        (d: any) => d.kind === "OperationDefinition",
+      );
+      if (opDef) {
+        span.setTag("graphql.operation.type", opDef.operation);
+        if (opDef.name?.value) {
+          span.setTag("graphql.operation.name", opDef.name.value);
+        }
+      }
+    },
+  },
+});
+
 export default tracer;

--- a/tests/tracer.test.ts
+++ b/tests/tracer.test.ts
@@ -14,9 +14,10 @@ describe("Datadog Tracer initialisation", () => {
     process.env.NODE_ENV = "production";
 
     const initMock = jest.fn();
+    const useMock = jest.fn().mockReturnThis();
     // The compiled CJS import looks for module.default or module itself
     jest.doMock("dd-trace", () => {
-      const mockTracer = { init: initMock };
+      const mockTracer = { init: initMock, use: useMock };
       // Support both `import tracer from 'dd-trace'` styles
       (mockTracer as any).default = mockTracer;
       return mockTracer;
@@ -35,8 +36,9 @@ describe("Datadog Tracer initialisation", () => {
     delete process.env.NODE_ENV;
 
     const initMock = jest.fn();
+    const useMock = jest.fn().mockReturnThis();
     jest.doMock("dd-trace", () => {
-      const mockTracer = { init: initMock };
+      const mockTracer = { init: initMock, use: useMock };
       (mockTracer as any).default = mockTracer;
       return mockTracer;
     });


### PR DESCRIPTION
Track nested query execution times to discover bottlenecks by configuring dd-trace's `graphql` plugin with resolver-level spans.