### PR TITLE
fix(logging): align circuit breaker Loki alerts with warning severity

### DIFF
--- a/logging/loki-config.yaml
+++ b/logging/loki-config.yaml
@@ -47,7 +47,7 @@ ruler:
             sum(count_over_time({app="bridge"} |= "circuit breaker opened" [5m])) by (service) > 0
           for: 0s
           labels:
-            severity: critical
+            severity: warning
             component: circuit-breaker
           annotations:
             summary: "Circuit breaker activated for {{ $labels.service }}"
@@ -57,7 +57,7 @@ ruler:
             sum(count_over_time({app="bridge"} |= "failover" [5m])) by (service) > 0
           for: 0s
           labels:
-            severity: critical
+            severity: warning
             component: failover
           annotations:
             summary: "Failover detected for {{ $labels.service }}"


### PR DESCRIPTION
Closes #1344

---

## Description

The issue acceptance criteria specifies that circuit breaker activations should fire warning alerts.

This aligns the alert configuration with the documented requirements.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-This change updates the Loki alert rules to use warning severity instead of critical for:

- CircuitBreakerActivated
- CircuitBreakerFailover

## Testing

How did you test these changes?

## Checklist

- [x] Code follows project style
- [x] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
