### PR TITLE
[#1015] Add Datadog APM Tracing for GraphQL Resolvers execution

### DIFF
--- a/tests/tracer.test.ts
+++ b/tests/tracer.test.ts
@@ -1,3 +1,5 @@
+import type tracer from "dd-trace";
+
 describe("Datadog Tracer initialisation", () => {
   const ORIGINAL_ENV = process.env;
 
@@ -10,19 +12,27 @@ describe("Datadog Tracer initialisation", () => {
     process.env = ORIGINAL_ENV;
   });
 
+  function mockTracer() {
+    const initMock = jest.fn();
+    const useMock = jest.fn().mockReturnThis();
+    jest.doMock("dd-trace", () => {
+      const mock = { init: initMock, use: useMock } as unknown as typeof tracer;
+      (mock as any).default = mock;
+      return mock;
+    });
+    return { initMock, useMock };
+  }
+
+  function graphqlConfig(useMock: jest.Mock) {
+    return useMock.mock.calls.find(
+      ([name]: string) => name === "graphql",
+    )?.[1];
+  }
+
   it("calls tracer.init with env from NODE_ENV", () => {
     process.env.NODE_ENV = "production";
 
-    const initMock = jest.fn();
-    const useMock = jest.fn().mockReturnThis();
-    // The compiled CJS import looks for module.default or module itself
-    jest.doMock("dd-trace", () => {
-      const mockTracer = { init: initMock, use: useMock };
-      // Support both `import tracer from 'dd-trace'` styles
-      (mockTracer as any).default = mockTracer;
-      return mockTracer;
-    });
-
+    const { initMock, useMock } = mockTracer();
     require("../src/tracer");
 
     expect(initMock).toHaveBeenCalledWith({
@@ -30,19 +40,20 @@ describe("Datadog Tracer initialisation", () => {
       env: "production",
       service: "mobile-money",
     });
+
+    const gql = graphqlConfig(useMock);
+    expect(gql).toBeDefined();
+    expect(gql.depth).toBe(-1);
+    expect(gql.signature).toBe(true);
+    expect(gql.source).toBe(false);
+    expect(typeof gql.variables).toBe("function");
+    expect(typeof gql.hooks?.execute).toBe("function");
   });
 
   it("falls back to 'development' when NODE_ENV is not set", () => {
     delete process.env.NODE_ENV;
 
-    const initMock = jest.fn();
-    const useMock = jest.fn().mockReturnThis();
-    jest.doMock("dd-trace", () => {
-      const mockTracer = { init: initMock, use: useMock };
-      (mockTracer as any).default = mockTracer;
-      return mockTracer;
-    });
-
+    const { initMock, useMock } = mockTracer();
     require("../src/tracer");
 
     expect(initMock).toHaveBeenCalledWith({
@@ -50,5 +61,112 @@ describe("Datadog Tracer initialisation", () => {
       env: "development",
       service: "mobile-money",
     });
+
+    const gql = graphqlConfig(useMock);
+    expect(gql).toBeDefined();
+    expect(gql.depth).toBe(-1);
+    expect(gql.signature).toBe(true);
+    expect(gql.source).toBe(false);
+    expect(typeof gql.variables).toBe("function");
+    expect(typeof gql.hooks?.execute).toBe("function");
+  });
+
+  it("sanitizes PII in graphql variables", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const sanitize: (vars: Record<string, unknown>) => Record<string, unknown> =
+      gql.variables;
+
+    expect(sanitize({ phoneNumber: "+1234567890" })).toEqual({
+      phoneNumber: "***",
+    });
+    expect(sanitize({ address: "123 Main St" })).toEqual({ address: "***" });
+    expect(sanitize({ token: "abc123" })).toEqual({ token: "***" });
+    expect(sanitize({ secret: "s3cr3t" })).toEqual({ secret: "***" });
+    expect(sanitize({ password: "hunter2" })).toEqual({ password: "***" });
+    expect(sanitize({ apiKey: "some-key" })).toEqual({ apiKey: "***" });
+    expect(sanitize({ amount: "100" })).toEqual({ amount: "100" });
+    expect(sanitize({ limit: 50 })).toEqual({ limit: 50 });
+    expect(sanitize(null as unknown as Record<string, unknown>)).toBeNull();
+  });
+
+  it("tags execute span with operation type and name", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const hook = gql.hooks.execute;
+
+    const setTag = jest.fn();
+    const span = { setTag };
+    const args = {
+      document: {
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: { value: "GetTransaction" },
+          },
+        ],
+      },
+    };
+
+    hook(span, args);
+    expect(setTag).toHaveBeenCalledWith("graphql.operation.type", "query");
+    expect(setTag).toHaveBeenCalledWith(
+      "graphql.operation.name",
+      "GetTransaction",
+    );
+  });
+
+  it("skips tagging when span or args is missing", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const hook = gql.hooks.execute;
+
+    const setTag = jest.fn();
+    expect(() => hook(null, null)).not.toThrow();
+    expect(() => hook({ setTag }, null)).not.toThrow();
+    expect(setTag).not.toHaveBeenCalled();
+  });
+
+  it("handles anonymous operations without a name", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const hook = gql.hooks.execute;
+
+    const setTag = jest.fn();
+    const span = { setTag };
+    const args = {
+      document: {
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "mutation",
+          },
+        ],
+      },
+    };
+
+    hook(span, args);
+    expect(setTag).toHaveBeenCalledWith("graphql.operation.type", "mutation");
+    expect(setTag).not.toHaveBeenCalledWith(
+      "graphql.operation.name",
+      expect.anything(),
+    );
   });
 });


### PR DESCRIPTION
## Description

Adds Datadog APM tracing for GraphQL resolver execution using the dd-trace `graphql` plugin. This enables tracking nested query execution times to discover performance bottlenecks.

### Changes

**`src/tracer.ts`** — Configured the `graphql` plugin with:
- `depth: -1` — instrument all resolvers at every nesting level for full bottleneck visibility
- `signature: true` — human-readable operation names in the Datadog UI (e.g. `query GetTransaction($id: String!)`)
- `source: false` — do not capture raw query text (PII concern)
- `variables` sanitizer — redacts `phone`, `address`, `token`, `secret`, `password`, `key` from span tags
- `hooks.execute` — tags the execute span with `graphql.operation.type` and `graphql.operation.name`

**`tests/tracer.test.ts`** — Added comprehensive test coverage:
- Verifies `tracer.init()` is called with correct env and service
- Verifies the graphql plugin is registered with expected options (`depth`, `signature`, `source`, `variables`, `hooks`)
- Tests PII sanitization for all sensitive variable patterns
- Tests the execute hook correctly tags operation type and name
- Covers edge cases: `null` args, missing span, anonymous operations

### How it works

The dd-trace `graphql` plugin instruments the graphql-js `execute` function (used internally by Apollo Server). It creates a span tree like:

```
graphql.execute
  └─ graphql.resolve (transaction: Transaction)
       ├─ graphql.resolve (id: String)
       ├─ graphql.resolve (referenceNumber: String)
       └─ graphql.resolve (amount: String)
```

Each resolver span includes `graphql.field.name`, `graphql.field.path`, and `graphql.field.type` tags, enabling drill-down into the slowest nested resolvers.

Closes #1015