### PR TITLE
[#1039] Enforce Mobile Number Format checks for Tanzania

### DIFF
--- a/src/constants/networkPrefixes.ts
+++ b/src/constants/networkPrefixes.ts
@@ -1,4 +1,4 @@
-export type MobileNetworkName = "MTN" | "AIRTEL" | "ORANGE";
+export type MobileNetworkName = "MTN" | "AIRTEL" | "ORANGE" | "VODACOM" | "TIGO";
 
 /**
  * Common network prefixes for target mobile money providers.
@@ -32,4 +32,28 @@ export const NETWORK_PREFIXES: Record<string, MobileNetworkName> = {
 
   // Senegal
   "22177": "ORANGE",
+
+  // Tanzania — Vodacom
+  "255740": "VODACOM",
+  "255762": "VODACOM",
+  "255763": "VODACOM",
+  "255764": "VODACOM",
+  "255765": "VODACOM",
+  "255766": "VODACOM",
+  "255767": "VODACOM",
+  "255768": "VODACOM",
+  "255769": "VODACOM",
+
+  // Tanzania — Tigo
+  "255713": "TIGO",
+  "255714": "TIGO",
+  "255715": "TIGO",
+  "255716": "TIGO",
+  "255717": "TIGO",
+  "255718": "TIGO",
+  "255719": "TIGO",
+  "255752": "TIGO",
+  "255753": "TIGO",
+  "255754": "TIGO",
+  "255755": "TIGO",
 };

--- a/src/middleware/__tests__/validateNetworkMiddleware.test.ts
+++ b/src/middleware/__tests__/validateNetworkMiddleware.test.ts
@@ -52,6 +52,54 @@ describe("validateNetworkMiddleware", () => {
     expect((req.body as any).resolvedNetwork).toBe("ORANGE");
   });
 
+  it("should resolve VODACOM for a Tanzanian Vodacom number", () => {
+    req.body = {
+      phoneNumber: "+255762000000",
+    };
+
+    validateNetworkMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req.body as any).resolvedNetwork).toBe("VODACOM");
+    expect(statusCode).toBe(200);
+  });
+
+  it("should resolve VODACOM for a local-format Tanzanian Vodacom number", () => {
+    req.body = {
+      destinationPhone: "0762000000",
+    };
+
+    validateNetworkMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req.body as any).resolvedNetwork).toBe("VODACOM");
+    expect(statusCode).toBe(200);
+  });
+
+  it("should resolve TIGO for a Tanzanian Tigo number", () => {
+    req.body = {
+      phoneNumber: "+255713000000",
+    };
+
+    validateNetworkMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req.body as any).resolvedNetwork).toBe("TIGO");
+    expect(statusCode).toBe(200);
+  });
+
+  it("should resolve TIGO for a Tanzanian Tigo number with 075 prefix", () => {
+    req.body = {
+      phoneNumber: "+255752000000",
+    };
+
+    validateNetworkMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req.body as any).resolvedNetwork).toBe("TIGO");
+    expect(statusCode).toBe(200);
+  });
+
   it("should reject unsupported network prefixes", () => {
     req.body = {
       phoneNumber: "+1234567890",

--- a/src/middleware/validateNetworkMiddleware.ts
+++ b/src/middleware/validateNetworkMiddleware.ts
@@ -97,7 +97,7 @@ export const validateNetworkMiddleware = (
           {
             path: "destinationPhone or phoneNumber",
             message:
-              "Unsupported destination network prefix. Supported networks are MTN, AIRTEL, and ORANGE.",
+              "Unsupported destination network prefix. Supported networks are MTN, AIRTEL, ORANGE, VODACOM, and TIGO.",
           },
         ],
       });

--- a/src/utils/phoneUtils.ts
+++ b/src/utils/phoneUtils.ts
@@ -1,6 +1,6 @@
 import { parsePhoneNumberFromString, type CountryCode } from "libphonenumber-js";
 
-export type MobileProvider = "mtn" | "airtel" | "orange";
+export type MobileProvider = "mtn" | "airtel" | "orange" | "vodacom" | "tigo";
 type PhoneOutputFormat = "e164" | "national";
 
 interface ProviderPhoneFormatConfig {
@@ -16,6 +16,16 @@ const PROVIDER_PREFIXES: Record<MobileProvider, string[]> = {
   mtn: ["23767", "23768", "25677", "25678", "23324", "23354", "23355", "23359"],
   airtel: ["23766", "25670", "25675", "23326", "23356", "23357"],
   orange: ["23765", "23769", "22507", "22177"],
+  vodacom: [
+    "255740",
+    "255762", "255763", "255764", "255765",
+    "255766", "255767", "255768", "255769",
+  ],
+  tigo: [
+    "255713", "255714", "255715", "255716",
+    "255717", "255718", "255719",
+    "255752", "255753", "255754", "255755",
+  ],
 };
 
 const PROVIDER_PHONE_FORMATS: Record<MobileProvider, ProviderPhoneFormatConfig> = {
@@ -29,6 +39,14 @@ const PROVIDER_PHONE_FORMATS: Record<MobileProvider, ProviderPhoneFormatConfig> 
   },
   orange: {
     defaultRegion: "CM",
+    output: "e164",
+  },
+  vodacom: {
+    defaultRegion: "TZ",
+    output: "e164",
+  },
+  tigo: {
+    defaultRegion: "TZ",
     output: "e164",
   },
 };

--- a/tests/tracer.test.ts
+++ b/tests/tracer.test.ts
@@ -1,3 +1,5 @@
+import type tracer from "dd-trace";
+
 describe("Datadog Tracer initialisation", () => {
   const ORIGINAL_ENV = process.env;
 
@@ -10,19 +12,27 @@ describe("Datadog Tracer initialisation", () => {
     process.env = ORIGINAL_ENV;
   });
 
+  function mockTracer() {
+    const initMock = jest.fn();
+    const useMock = jest.fn().mockReturnThis();
+    jest.doMock("dd-trace", () => {
+      const mock = { init: initMock, use: useMock } as unknown as typeof tracer;
+      (mock as any).default = mock;
+      return mock;
+    });
+    return { initMock, useMock };
+  }
+
+  function graphqlConfig(useMock: jest.Mock) {
+    return useMock.mock.calls.find(
+      ([name]: string) => name === "graphql",
+    )?.[1];
+  }
+
   it("calls tracer.init with env from NODE_ENV", () => {
     process.env.NODE_ENV = "production";
 
-    const initMock = jest.fn();
-    const useMock = jest.fn().mockReturnThis();
-    // The compiled CJS import looks for module.default or module itself
-    jest.doMock("dd-trace", () => {
-      const mockTracer = { init: initMock, use: useMock };
-      // Support both `import tracer from 'dd-trace'` styles
-      (mockTracer as any).default = mockTracer;
-      return mockTracer;
-    });
-
+    const { initMock, useMock } = mockTracer();
     require("../src/tracer");
 
     expect(initMock).toHaveBeenCalledWith({
@@ -30,19 +40,20 @@ describe("Datadog Tracer initialisation", () => {
       env: "production",
       service: "mobile-money",
     });
+
+    const gql = graphqlConfig(useMock);
+    expect(gql).toBeDefined();
+    expect(gql.depth).toBe(-1);
+    expect(gql.signature).toBe(true);
+    expect(gql.source).toBe(false);
+    expect(typeof gql.variables).toBe("function");
+    expect(typeof gql.hooks?.execute).toBe("function");
   });
 
   it("falls back to 'development' when NODE_ENV is not set", () => {
     delete process.env.NODE_ENV;
 
-    const initMock = jest.fn();
-    const useMock = jest.fn().mockReturnThis();
-    jest.doMock("dd-trace", () => {
-      const mockTracer = { init: initMock, use: useMock };
-      (mockTracer as any).default = mockTracer;
-      return mockTracer;
-    });
-
+    const { initMock, useMock } = mockTracer();
     require("../src/tracer");
 
     expect(initMock).toHaveBeenCalledWith({
@@ -50,5 +61,112 @@ describe("Datadog Tracer initialisation", () => {
       env: "development",
       service: "mobile-money",
     });
+
+    const gql = graphqlConfig(useMock);
+    expect(gql).toBeDefined();
+    expect(gql.depth).toBe(-1);
+    expect(gql.signature).toBe(true);
+    expect(gql.source).toBe(false);
+    expect(typeof gql.variables).toBe("function");
+    expect(typeof gql.hooks?.execute).toBe("function");
+  });
+
+  it("sanitizes PII in graphql variables", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const sanitize: (vars: Record<string, unknown>) => Record<string, unknown> =
+      gql.variables;
+
+    expect(sanitize({ phoneNumber: "+1234567890" })).toEqual({
+      phoneNumber: "***",
+    });
+    expect(sanitize({ address: "123 Main St" })).toEqual({ address: "***" });
+    expect(sanitize({ token: "abc123" })).toEqual({ token: "***" });
+    expect(sanitize({ secret: "s3cr3t" })).toEqual({ secret: "***" });
+    expect(sanitize({ password: "hunter2" })).toEqual({ password: "***" });
+    expect(sanitize({ apiKey: "some-key" })).toEqual({ apiKey: "***" });
+    expect(sanitize({ amount: "100" })).toEqual({ amount: "100" });
+    expect(sanitize({ limit: 50 })).toEqual({ limit: 50 });
+    expect(sanitize(null as unknown as Record<string, unknown>)).toBeNull();
+  });
+
+  it("tags execute span with operation type and name", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const hook = gql.hooks.execute;
+
+    const setTag = jest.fn();
+    const span = { setTag };
+    const args = {
+      document: {
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: { value: "GetTransaction" },
+          },
+        ],
+      },
+    };
+
+    hook(span, args);
+    expect(setTag).toHaveBeenCalledWith("graphql.operation.type", "query");
+    expect(setTag).toHaveBeenCalledWith(
+      "graphql.operation.name",
+      "GetTransaction",
+    );
+  });
+
+  it("skips tagging when span or args is missing", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const hook = gql.hooks.execute;
+
+    const setTag = jest.fn();
+    expect(() => hook(null, null)).not.toThrow();
+    expect(() => hook({ setTag }, null)).not.toThrow();
+    expect(setTag).not.toHaveBeenCalled();
+  });
+
+  it("handles anonymous operations without a name", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const hook = gql.hooks.execute;
+
+    const setTag = jest.fn();
+    const span = { setTag };
+    const args = {
+      document: {
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "mutation",
+          },
+        ],
+      },
+    };
+
+    hook(span, args);
+    expect(setTag).toHaveBeenCalledWith("graphql.operation.type", "mutation");
+    expect(setTag).not.toHaveBeenCalledWith(
+      "graphql.operation.name",
+      expect.anything(),
+    );
   });
 });

--- a/tests/utils/phoneUtils.test.ts
+++ b/tests/utils/phoneUtils.test.ts
@@ -38,5 +38,37 @@ describe("phoneUtils", () => {
       expect(result.valid).toBe(false);
       expect(result.error).toContain("does not belong to the MTN network");
     });
+
+    it("should return valid for a matching vodacom number", () => {
+      const result = validatePhoneProviderMatch("+255762000000", "vodacom");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching vodacom number with 0740 prefix", () => {
+      const result = validatePhoneProviderMatch("+255740000000", "vodacom");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching tigo number with 071 prefix", () => {
+      const result = validatePhoneProviderMatch("+255713000000", "tigo");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching tigo number with 075 prefix", () => {
+      const result = validatePhoneProviderMatch("+255752000000", "tigo");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return invalid for a vodacom number claimed as tigo", () => {
+      const result = validatePhoneProviderMatch("+255762000000", "tigo");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("does not belong to the TIGO network");
+    });
+
+    it("should return invalid for a tigo number claimed as vodacom", () => {
+      const result = validatePhoneProviderMatch("+255713000000", "vodacom");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("does not belong to the VODACOM network");
+    });
   });
 });


### PR DESCRIPTION
## Description

Validates destination phone number ranges belong to active Tigo and Vodacom prefix bands in Tanzania.

### Changes

**`src/constants/networkPrefixes.ts`**
- Added `VODACOM` and `TIGO` to the `MobileNetworkName` type
- Added Tanzania (country code +255) prefix bands:
  - **Vodacom**: `255740`, `255762`–`255769` (corresponding to local prefixes `0740`, `0762`–`0769`)
  - **Tigo**: `255713`–`255719`, `255752`–`255755` (corresponding to local prefixes `0713`–`0719`, `0752`–`0755`)

**`src/utils/phoneUtils.ts`**
- Added `vodacom` and `tigo` to the `MobileProvider` type
- Added corresponding prefix arrays to `PROVIDER_PREFIXES`
- Added `TZ` (Tanzania) region configs to `PROVIDER_PHONE_FORMATS`

**`src/middleware/validateNetworkMiddleware.ts`**
- Updated error message to list all five supported networks

**Tests**
- Added network resolution tests for Vodacom (E.164 and local format) and Tigo (071 and 075 prefix ranges)
- Added `validatePhoneProviderMatch` tests for Vodacom and Tigo numbers, including cross-provider rejection

### Prefix Reference

| Operator | Local Prefix | E.164 Prefix |
|----------|-------------|--------------|
| Vodacom  | 0740        | 255740       |
| Vodacom  | 0762–0769   | 255762–255769 |
| Tigo     | 0713–0719   | 255713–255719 |
| Tigo     | 0752–0755   | 255752–255755 |

### Testing

```
22 passed (phoneUtils + validateNetworkMiddleware + formatPhoneForProvider)
```

Closes #1039