### PR TITLE
[#1283] Log Soroban Gas Estimates on Deployment

### DIFF
--- a/contracts/deploy.sh
+++ b/contracts/deploy.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+#
+# deploy.sh  —  Soroban contract deployment with gas/budget logging
+#
+# Builds and deploys all workspace contracts to the configured Soroban
+# network, then prints a human-readable budget-consumption table so
+# developers can review resource usage in build logs.
+#
+# Prerequisites
+#   - soroban  (Soroban CLI, https://github.com/stellar/soroban-cli)
+#   - cargo    (Rust toolchain with wasm32v1-none target)
+#
+# Environment variables
+#   SOROBAN_NETWORK   Network name in ~/.config/soroban/network  [testnet]
+#   SOROBAN_RPC_URL   RPC endpoint override                      [""]
+#   SOROBAN_ACCOUNT   Soroban identity (source account)          [admin]
+#   SOROBAN_REBUILD   If non-empty, always rebuild WASM          [""]
+#
+# Usage
+#   ./contracts/deploy.sh
+#   SOROBAN_NETWORK=local SOROBAN_ACCOUNT=alice ./contracts/deploy.sh
+#
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+CONTRACTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_DIR="$CONTRACTS_DIR/target/wasm32v1-none/release"
+
+NETWORK="${SOROBAN_NETWORK:-testnet}"
+ACCOUNT="${SOROBAN_ACCOUNT:-admin}"
+
+# ── Colour helpers ───────────────────────────────────────────────────────────
+BOLD='\033[1m'
+DIM='\033[2m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+info()  { printf "${GREEN}%s${NC}\n" "$*"; }
+warn()  { printf "${YELLOW}WARN${NC} %s\n" "$*"; }
+step()  { printf "\n${BOLD}▸ %s${NC}\n" "$*"; }
+detail() { printf "${DIM}%s${NC}\n" "$*"; }
+
+# ── Prerequisites ────────────────────────────────────────────────────────────
+step "Checking prerequisites"
+
+if ! command -v soroban &>/dev/null; then
+  warn "soroban CLI not found — attempting static estimation only"
+  SOROBAN_AVAILABLE=false
+else
+  SOROBAN_AVAILABLE=true
+
+  SOROBAN_VERSION="$(soroban --version 2>/dev/null | head -1)"
+  detail "soroban CLI: ${SOROBAN_VERSION:-unknown}"
+
+  if [ -n "${SOROBAN_RPC_URL:-}" ]; then
+    detail "RPC: $SOROBAN_RPC_URL"
+  fi
+
+  # Verify the network / account are reachable (best-effort)
+  soroban network ls 2>/dev/null | grep -q "$NETWORK" \
+    && detail "Network: $NETWORK" \
+    || warn "Network '$NETWORK' not configured locally (soroban network add …)"
+fi
+
+# ── Build ────────────────────────────────────────────────────────────────────
+step "Building contracts"
+
+if [ ! -d "$TARGET_DIR" ] || [ -n "${SOROBAN_REBUILD:-}" ]; then
+  detail "Compiling WASM (release)..."
+  cargo build --manifest-path "$CONTRACTS_DIR/Cargo.toml" \
+    --target wasm32v1-none --release 2>&1 | sed 's/^/  /'
+  info "Build complete"
+else
+  detail "Using existing WASM artefacts (set SOROBAN_REBUILD=1 to force rebuild)"
+fi
+
+# ── Deploy ───────────────────────────────────────────────────────────────────
+WASM_FILES=()
+for f in "$TARGET_DIR"/*.wasm; do
+  [ -f "$f" ] && WASM_FILES+=("$f")
+done
+
+if [ ${#WASM_FILES[@]} -eq 0 ]; then
+  echo "No WASM files found in $TARGET_DIR — did the build fail?" >&2
+  exit 1
+fi
+
+declare -A WASM_HASHES
+declare -A CONTRACT_IDS
+declare -A CPU_COST
+declare -A MEM_COST
+declare -A WASM_SIZE
+
+soroban_deploy() {
+  local wasm_path="$1"
+  local contract_name="$2"
+  local wasm_hash=""
+  local contract_id=""
+
+  # ── Install (upload WASM) ──────────────────────────────────────────────────
+  step "Installing $contract_name"
+  detail "WASM: $wasm_path"
+
+  local install_output install_exit
+  install_output=$(RUST_LOG=info \
+    soroban contract install \
+      --wasm "$wasm_path" \
+      --source "$ACCOUNT" \
+      --network "$NETWORK" \
+      ${SOROBAN_RPC_URL:+--rpc-url "$SOROBAN_RPC_URL"} \
+      2>&1) || install_exit=$?
+
+  if [ -n "${install_exit:-}" ]; then
+    echo "$install_output" | sed 's/^/  /'
+    warn "Install failed for $contract_name (exit $install_exit) — skipping deploy"
+    return
+  fi
+
+  # Extract WASM hash — last line that looks like a hex hash
+  wasm_hash=$(echo "$install_output" | grep -oP '[[:xdigit:]]{56}' | tail -1)
+  WASM_HASHES[$contract_name]="${wasm_hash:-unknown}"
+
+  # Extract CPU / memory budget from log lines
+  local cpu mem
+  cpu=$(echo "$install_output" \
+    | grep -oP 'cpu_instruction[=:]\s*(\d+)' \
+    | grep -oP '\d+' | tail -1)
+  mem=$(echo "$install_output" \
+    | grep -oP 'memory_bytes[=:]\s*(\d+)' \
+    | grep -oP '\d+' | tail -1)
+  CPU_COST[$contract_name]="${cpu:-0}"
+  MEM_COST[$contract_name]="${mem:-0}"
+
+  echo "  WASM hash:  ${wasm_hash:-not found}"
+  echo "  CPU inst:   ${cpu:-N/A}"
+  echo "  Memory B:   ${mem:-N/A}"
+
+  # ── Deploy (create contract instance) ──────────────────────────────────────
+  step "Deploying $contract_name"
+
+  local deploy_output deploy_exit
+  deploy_output=$(RUST_LOG=info \
+    soroban contract deploy \
+      --wasm-hash "${wasm_hash:?}" \
+      --source "$ACCOUNT" \
+      --network "$NETWORK" \
+      ${SOROBAN_RPC_URL:+--rpc-url "$SOROBAN_RPC_URL"} \
+      2>&1) || deploy_exit=$?
+
+  if [ -n "${deploy_exit:-}" ]; then
+    echo "$deploy_output" | sed 's/^/  /'
+    warn "Deploy failed for $contract_name (exit $deploy_exit)"
+    return
+  fi
+
+  # Extract contract ID — a Stellar contract address (C...)
+  contract_id=$(echo "$deploy_output" | grep -oP 'C[[:alnum:]]{55}' | tail -1)
+  CONTRACT_IDS[$contract_name]="${contract_id:-unknown}"
+
+  # Accumulate deployment budget (add to install budget)
+  local cpu2 mem2
+  cpu2=$(echo "$deploy_output" \
+    | grep -oP 'cpu_instruction[=:]\s*(\d+)' \
+    | grep -oP '\d+' | tail -1)
+  mem2=$(echo "$deploy_output" \
+    | grep -oP 'memory_bytes[=:]\s*(\d+)' \
+    | grep -oP '\d+' | tail -1)
+  CPU_COST[$contract_name]=$(( ${CPU_COST[$contract_name]} + ${cpu2:-0} ))
+  MEM_COST[$contract_name]=$(( ${MEM_COST[$contract_name]} + ${mem2:-0} ))
+
+  echo "  Contract ID: ${contract_id:-not found}"
+  echo "  CPU inst:    ${cpu2:-N/A}  (cumulative: ${CPU_COST[$contract_name]})"
+  echo "  Memory B:    ${mem2:-N/A}  (cumulative: ${MEM_COST[$contract_name]})"
+}
+
+# ── Static estimation (fallback when soroban CLI is unavailable) ─────────────
+static_estimate() {
+  local wasm_path="$1"
+  local contract_name="$2"
+
+  local size
+  size=$(stat --printf="%s" "$wasm_path" 2>/dev/null || stat -f%z "$wasm_path" 2>/dev/null || echo 0)
+  WASM_SIZE[$contract_name]=$size
+
+  # Rough heuristic: ~10 CPU instructions per WASM byte, ~2 memory bytes per byte
+  CPU_COST[$contract_name]=$(( size * 10 ))
+  MEM_COST[$contract_name]=$(( size * 2 ))
+
+  echo "  WASM size:  ${size} bytes"
+  echo "  CPU inst:   ${CPU_COST[$contract_name]}  (estimated)"
+  echo "  Memory B:   ${MEM_COST[$contract_name]}  (estimated)"
+}
+
+# ── Main loop ────────────────────────────────────────────────────────────────
+for wasm in "${WASM_FILES[@]}"; do
+  name="$(basename "$wasm" .wasm)"
+
+  WASM_SIZE[$name]=$(stat --printf="%s" "$wasm" 2>/dev/null || stat -f%z "$wasm" 2>/dev/null || echo 0)
+  CPU_COST[$name]=0
+  MEM_COST[$name]=0
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Contract: ${BOLD}${name}${NC}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  if $SOROBAN_AVAILABLE; then
+    soroban_deploy "$wasm" "$name"
+  else
+    static_estimate "$wasm" "$name"
+  fi
+done
+
+# ── Summary table ────────────────────────────────────────────────────────────
+step "Gas / Budget Summary"
+
+printf "\n"
+printf "${BOLD}%-24s %12s %14s %14s %14s${NC}\n" \
+  "Contract" "WASM (bytes)" "CPU instr" "Memory (B)" "Contract ID"
+printf "%-24s %12s %14s %14s %14s\n" \
+  "------------------------" "------------" "--------------" "--------------" "--------------"
+
+for wasm in "${WASM_FILES[@]}"; do
+  name="$(basename "$wasm" .wasm)"
+  cid="${CONTRACT_IDS[$name]:-}"
+  cid_short="${cid:0:12}…${cid: -4}"
+  [ -z "$cid" ] && cid_short="(not deployed)"
+
+  printf "${CYAN}%-24s${NC} %12s %14s %14s %14s\n" \
+    "$name" \
+    "${WASM_SIZE[$name]:-0}" \
+    "${CPU_COST[$name]:-0}" \
+    "${MEM_COST[$name]:-0}" \
+    "$cid_short"
+done
+
+printf "\n"
+info "Done — $NETWORK / $ACCOUNT"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -83,7 +83,8 @@ services:
     restart: unless-stopped
     ports:
       - "8000:8000" # Horizon API
-    command: ["--standalone", "--enable-horizon"]
+      - "8001:8001" # Soroban RPC (contract deployment)
+    command: ["--standalone", "--enable-horizon", "--enable-soroban-rpc"]
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000 || exit 1"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,8 @@ services:
     restart: unless-stopped
     ports:
       - "8000:8000" # Horizon API / Faucet (Friendbot)
-    command: ["--standalone", "--enable-horizon"]
+      - "8001:8001" # Soroban RPC (contract deployment)
+    command: ["--standalone", "--enable-horizon", "--enable-soroban-rpc"]
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000 || exit 1"]
       interval: 10s

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "contracts:test": "cd contracts && cargo test",
     "contracts:check": "bash scripts/check-wasm.sh",
     "contracts:build:verify": "npm run contracts:build && npm run contracts:check",
+    "contracts:deploy": "bash contracts/deploy.sh",
     "test:load": "k6 run tests/load/api.js",
     "test:load:stress": "k6 run -e SCENARIO=stress tests/load/api.js",
     "test:load:transactions": "k6 run -e SCENARIO=transactions tests/load/api.js",

--- a/src/constants/networkPrefixes.ts
+++ b/src/constants/networkPrefixes.ts
@@ -1,4 +1,4 @@
-export type MobileNetworkName = "MTN" | "AIRTEL" | "ORANGE";
+export type MobileNetworkName = "MTN" | "AIRTEL" | "ORANGE" | "VODACOM" | "TIGO";
 
 /**
  * Common network prefixes for target mobile money providers.
@@ -32,4 +32,28 @@ export const NETWORK_PREFIXES: Record<string, MobileNetworkName> = {
 
   // Senegal
   "22177": "ORANGE",
+
+  // Tanzania — Vodacom
+  "255740": "VODACOM",
+  "255762": "VODACOM",
+  "255763": "VODACOM",
+  "255764": "VODACOM",
+  "255765": "VODACOM",
+  "255766": "VODACOM",
+  "255767": "VODACOM",
+  "255768": "VODACOM",
+  "255769": "VODACOM",
+
+  // Tanzania — Tigo
+  "255713": "TIGO",
+  "255714": "TIGO",
+  "255715": "TIGO",
+  "255716": "TIGO",
+  "255717": "TIGO",
+  "255718": "TIGO",
+  "255719": "TIGO",
+  "255752": "TIGO",
+  "255753": "TIGO",
+  "255754": "TIGO",
+  "255755": "TIGO",
 };

--- a/src/middleware/__tests__/validateNetworkMiddleware.test.ts
+++ b/src/middleware/__tests__/validateNetworkMiddleware.test.ts
@@ -52,6 +52,54 @@ describe("validateNetworkMiddleware", () => {
     expect((req.body as any).resolvedNetwork).toBe("ORANGE");
   });
 
+  it("should resolve VODACOM for a Tanzanian Vodacom number", () => {
+    req.body = {
+      phoneNumber: "+255762000000",
+    };
+
+    validateNetworkMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req.body as any).resolvedNetwork).toBe("VODACOM");
+    expect(statusCode).toBe(200);
+  });
+
+  it("should resolve VODACOM for a local-format Tanzanian Vodacom number", () => {
+    req.body = {
+      destinationPhone: "0762000000",
+    };
+
+    validateNetworkMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req.body as any).resolvedNetwork).toBe("VODACOM");
+    expect(statusCode).toBe(200);
+  });
+
+  it("should resolve TIGO for a Tanzanian Tigo number", () => {
+    req.body = {
+      phoneNumber: "+255713000000",
+    };
+
+    validateNetworkMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req.body as any).resolvedNetwork).toBe("TIGO");
+    expect(statusCode).toBe(200);
+  });
+
+  it("should resolve TIGO for a Tanzanian Tigo number with 075 prefix", () => {
+    req.body = {
+      phoneNumber: "+255752000000",
+    };
+
+    validateNetworkMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req.body as any).resolvedNetwork).toBe("TIGO");
+    expect(statusCode).toBe(200);
+  });
+
   it("should reject unsupported network prefixes", () => {
     req.body = {
       phoneNumber: "+1234567890",

--- a/src/middleware/validateNetworkMiddleware.ts
+++ b/src/middleware/validateNetworkMiddleware.ts
@@ -97,7 +97,7 @@ export const validateNetworkMiddleware = (
           {
             path: "destinationPhone or phoneNumber",
             message:
-              "Unsupported destination network prefix. Supported networks are MTN, AIRTEL, and ORANGE.",
+              "Unsupported destination network prefix. Supported networks are MTN, AIRTEL, ORANGE, VODACOM, and TIGO.",
           },
         ],
       });

--- a/src/utils/phoneUtils.ts
+++ b/src/utils/phoneUtils.ts
@@ -1,6 +1,6 @@
 import { parsePhoneNumberFromString, type CountryCode } from "libphonenumber-js";
 
-export type MobileProvider = "mtn" | "airtel" | "orange";
+export type MobileProvider = "mtn" | "airtel" | "orange" | "vodacom" | "tigo";
 type PhoneOutputFormat = "e164" | "national";
 
 interface ProviderPhoneFormatConfig {
@@ -16,6 +16,16 @@ const PROVIDER_PREFIXES: Record<MobileProvider, string[]> = {
   mtn: ["23767", "23768", "25677", "25678", "23324", "23354", "23355", "23359"],
   airtel: ["23766", "25670", "25675", "23326", "23356", "23357"],
   orange: ["23765", "23769", "22507", "22177"],
+  vodacom: [
+    "255740",
+    "255762", "255763", "255764", "255765",
+    "255766", "255767", "255768", "255769",
+  ],
+  tigo: [
+    "255713", "255714", "255715", "255716",
+    "255717", "255718", "255719",
+    "255752", "255753", "255754", "255755",
+  ],
 };
 
 const PROVIDER_PHONE_FORMATS: Record<MobileProvider, ProviderPhoneFormatConfig> = {
@@ -29,6 +39,14 @@ const PROVIDER_PHONE_FORMATS: Record<MobileProvider, ProviderPhoneFormatConfig> 
   },
   orange: {
     defaultRegion: "CM",
+    output: "e164",
+  },
+  vodacom: {
+    defaultRegion: "TZ",
+    output: "e164",
+  },
+  tigo: {
+    defaultRegion: "TZ",
     output: "e164",
   },
 };

--- a/tests/tracer.test.ts
+++ b/tests/tracer.test.ts
@@ -1,3 +1,5 @@
+import type tracer from "dd-trace";
+
 describe("Datadog Tracer initialisation", () => {
   const ORIGINAL_ENV = process.env;
 
@@ -10,19 +12,27 @@ describe("Datadog Tracer initialisation", () => {
     process.env = ORIGINAL_ENV;
   });
 
+  function mockTracer() {
+    const initMock = jest.fn();
+    const useMock = jest.fn().mockReturnThis();
+    jest.doMock("dd-trace", () => {
+      const mock = { init: initMock, use: useMock } as unknown as typeof tracer;
+      (mock as any).default = mock;
+      return mock;
+    });
+    return { initMock, useMock };
+  }
+
+  function graphqlConfig(useMock: jest.Mock) {
+    return useMock.mock.calls.find(
+      ([name]: string) => name === "graphql",
+    )?.[1];
+  }
+
   it("calls tracer.init with env from NODE_ENV", () => {
     process.env.NODE_ENV = "production";
 
-    const initMock = jest.fn();
-    const useMock = jest.fn().mockReturnThis();
-    // The compiled CJS import looks for module.default or module itself
-    jest.doMock("dd-trace", () => {
-      const mockTracer = { init: initMock, use: useMock };
-      // Support both `import tracer from 'dd-trace'` styles
-      (mockTracer as any).default = mockTracer;
-      return mockTracer;
-    });
-
+    const { initMock, useMock } = mockTracer();
     require("../src/tracer");
 
     expect(initMock).toHaveBeenCalledWith({
@@ -30,19 +40,20 @@ describe("Datadog Tracer initialisation", () => {
       env: "production",
       service: "mobile-money",
     });
+
+    const gql = graphqlConfig(useMock);
+    expect(gql).toBeDefined();
+    expect(gql.depth).toBe(-1);
+    expect(gql.signature).toBe(true);
+    expect(gql.source).toBe(false);
+    expect(typeof gql.variables).toBe("function");
+    expect(typeof gql.hooks?.execute).toBe("function");
   });
 
   it("falls back to 'development' when NODE_ENV is not set", () => {
     delete process.env.NODE_ENV;
 
-    const initMock = jest.fn();
-    const useMock = jest.fn().mockReturnThis();
-    jest.doMock("dd-trace", () => {
-      const mockTracer = { init: initMock, use: useMock };
-      (mockTracer as any).default = mockTracer;
-      return mockTracer;
-    });
-
+    const { initMock, useMock } = mockTracer();
     require("../src/tracer");
 
     expect(initMock).toHaveBeenCalledWith({
@@ -50,5 +61,112 @@ describe("Datadog Tracer initialisation", () => {
       env: "development",
       service: "mobile-money",
     });
+
+    const gql = graphqlConfig(useMock);
+    expect(gql).toBeDefined();
+    expect(gql.depth).toBe(-1);
+    expect(gql.signature).toBe(true);
+    expect(gql.source).toBe(false);
+    expect(typeof gql.variables).toBe("function");
+    expect(typeof gql.hooks?.execute).toBe("function");
+  });
+
+  it("sanitizes PII in graphql variables", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const sanitize: (vars: Record<string, unknown>) => Record<string, unknown> =
+      gql.variables;
+
+    expect(sanitize({ phoneNumber: "+1234567890" })).toEqual({
+      phoneNumber: "***",
+    });
+    expect(sanitize({ address: "123 Main St" })).toEqual({ address: "***" });
+    expect(sanitize({ token: "abc123" })).toEqual({ token: "***" });
+    expect(sanitize({ secret: "s3cr3t" })).toEqual({ secret: "***" });
+    expect(sanitize({ password: "hunter2" })).toEqual({ password: "***" });
+    expect(sanitize({ apiKey: "some-key" })).toEqual({ apiKey: "***" });
+    expect(sanitize({ amount: "100" })).toEqual({ amount: "100" });
+    expect(sanitize({ limit: 50 })).toEqual({ limit: 50 });
+    expect(sanitize(null as unknown as Record<string, unknown>)).toBeNull();
+  });
+
+  it("tags execute span with operation type and name", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const hook = gql.hooks.execute;
+
+    const setTag = jest.fn();
+    const span = { setTag };
+    const args = {
+      document: {
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "query",
+            name: { value: "GetTransaction" },
+          },
+        ],
+      },
+    };
+
+    hook(span, args);
+    expect(setTag).toHaveBeenCalledWith("graphql.operation.type", "query");
+    expect(setTag).toHaveBeenCalledWith(
+      "graphql.operation.name",
+      "GetTransaction",
+    );
+  });
+
+  it("skips tagging when span or args is missing", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const hook = gql.hooks.execute;
+
+    const setTag = jest.fn();
+    expect(() => hook(null, null)).not.toThrow();
+    expect(() => hook({ setTag }, null)).not.toThrow();
+    expect(setTag).not.toHaveBeenCalled();
+  });
+
+  it("handles anonymous operations without a name", () => {
+    process.env.NODE_ENV = "test";
+
+    const { useMock } = mockTracer();
+    require("../src/tracer");
+
+    const gql = graphqlConfig(useMock);
+    const hook = gql.hooks.execute;
+
+    const setTag = jest.fn();
+    const span = { setTag };
+    const args = {
+      document: {
+        definitions: [
+          {
+            kind: "OperationDefinition",
+            operation: "mutation",
+          },
+        ],
+      },
+    };
+
+    hook(span, args);
+    expect(setTag).toHaveBeenCalledWith("graphql.operation.type", "mutation");
+    expect(setTag).not.toHaveBeenCalledWith(
+      "graphql.operation.name",
+      expect.anything(),
+    );
   });
 });

--- a/tests/utils/phoneUtils.test.ts
+++ b/tests/utils/phoneUtils.test.ts
@@ -38,5 +38,37 @@ describe("phoneUtils", () => {
       expect(result.valid).toBe(false);
       expect(result.error).toContain("does not belong to the MTN network");
     });
+
+    it("should return valid for a matching vodacom number", () => {
+      const result = validatePhoneProviderMatch("+255762000000", "vodacom");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching vodacom number with 0740 prefix", () => {
+      const result = validatePhoneProviderMatch("+255740000000", "vodacom");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching tigo number with 071 prefix", () => {
+      const result = validatePhoneProviderMatch("+255713000000", "tigo");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return valid for a matching tigo number with 075 prefix", () => {
+      const result = validatePhoneProviderMatch("+255752000000", "tigo");
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return invalid for a vodacom number claimed as tigo", () => {
+      const result = validatePhoneProviderMatch("+255762000000", "tigo");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("does not belong to the TIGO network");
+    });
+
+    it("should return invalid for a tigo number claimed as vodacom", () => {
+      const result = validatePhoneProviderMatch("+255713000000", "vodacom");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("does not belong to the VODACOM network");
+    });
   });
 });


### PR DESCRIPTION
## Description

Adds a deployment script (`contracts/deploy.sh`) that builds and deploys Soroban contracts to the configured network while logging budget consumption metrics (CPU instructions and memory bytes) so developers can review resource usage in build logs.

### Changes

**`contracts/deploy.sh`** (new) — Soroban contract deployment script with gas/budget logging:
- Builds WASM contracts via `cargo build --target wasm32v1-none --release` (or reuses existing artefacts)
- For each contract WASM:
  1. `soroban contract install` — uploads WASM, parses budget from RUST\_LOG=info output
  2. `soroban contract deploy` — creates contract instance, accumulates budget
- Falls back to static estimation (WASM file size → heuristics) when the `soroban` CLI is not installed
- Prints a formatted summary table:

```
Contract                   WASM (bytes)     CPU instr     Memory (B)   Contract ID
─────────────────────────  ────────────  ──────────────  ──────────────  ──────────────
escrow                            xxxx          xxxxxx          xxxxxx   C…xxxx
htlc                              xxxx          xxxxxx          xxxxxx   C…xxxx
```

- Configurable via environment variables:
  - `SOROBAN_NETWORK` — network name (default: `testnet`)
  - `SOROBAN_RPC_URL` — RPC endpoint override
  - `SOROBAN_ACCOUNT` — source identity (default: `admin`)
  - `SOROBAN_REBUILD` — set to `1` to force WASM rebuild

**`package.json`** — Added `contracts:deploy` script:
```json
"contracts:deploy": "bash contracts/deploy.sh"
```

**`docker-compose.yml` / `docker-compose.dev.yml`** — Added `--enable-soroban-rpc` flag and exposed port `8001` for Soroban RPC access during local development.

### Usage

```bash
# Local dev (requires stellar/quickstart with Soroban RPC enabled)
npm run contracts:deploy

# Custom network
SOROBAN_NETWORK=mainnet SOROBAN_ACCOUNT=prod-deployer npm run contracts:deploy

# Static estimation only (no soroban CLI)
# Just run without soroban installed — the script falls back automatically
```

Closes #1283