### PR TITLE
feat(cli): add multi-signature approval gate for escrow release

### DIFF
--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -136,3 +136,18 @@ export async function getQueueMetrics() {
     throw new Error(extractMessage(err));
   }
 }
+
+export async function releaseEscrow(
+  escrowId: string,
+  signatures: { signerIndex: number; key: string }[],
+): Promise<{ message: string; txHash?: string }> {
+  try {
+    const { data } = await buildClient().post<{
+      message: string;
+      txHash?: string;
+    }>(`/api/admin/escrow/${escrowId}/release`, { signatures });
+    return data;
+  } catch (err) {
+    throw new Error(extractMessage(err));
+  }
+}

--- a/cli/src/commands/escrow.ts
+++ b/cli/src/commands/escrow.ts
@@ -1,0 +1,82 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import inquirer from "inquirer";
+import { releaseEscrow } from "../api";
+import { printError } from "../dashboard";
+
+export function registerEscrowCommand(program: Command): void {
+  const escrow = program.command("escrow").description("Escrow management");
+
+  escrow
+    .command("release <escrowId>")
+    .description("Release escrowed funds via multi-signature approval")
+    .option(
+      "-t, --threshold <number>",
+      "number of approval signatures required",
+      "2",
+    )
+    .action(async (escrowId: string, opts: { threshold: string }) => {
+      const threshold = parseInt(opts.threshold, 10);
+      if (isNaN(threshold) || threshold < 1) {
+        printError("--threshold must be a positive integer", undefined, "ERR_ESCROW");
+        process.exit(1);
+      }
+
+      console.log(
+        chalk.cyan(`\nEscrow release: ${chalk.bold(escrowId)}`),
+      );
+      console.log(
+        chalk.yellow(`Requires ${threshold} approval signature(s).\n`),
+      );
+
+      const signatures: { signerIndex: number; key: string }[] = [];
+
+      for (let i = 0; i < threshold; i++) {
+        console.log(chalk.dim(`— Signer ${i + 1} of ${threshold} —`));
+
+        const { key } = await inquirer.prompt<{ key: string }>([
+          {
+            type: "password",
+            name: "key",
+            message: `Signing key for signer ${i + 1}:`,
+            mask: "*",
+            validate: (v: string) =>
+              v.trim().length > 0 ? true : "Signing key is required",
+          },
+        ]);
+
+        signatures.push({ signerIndex: i, key: key.trim() });
+      }
+
+      const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([
+        {
+          type: "confirm",
+          name: "confirmed",
+          message: chalk.red(
+            `Release funds from escrow ${chalk.bold(escrowId)}? This cannot be undone.`,
+          ),
+          default: false,
+        },
+      ]);
+
+      if (!confirmed) {
+        console.log(chalk.yellow("Aborted."));
+        process.exit(0);
+      }
+
+      try {
+        const result = await releaseEscrow(escrowId, signatures);
+        console.log(`\n${chalk.green("✓")} ${result.message}`);
+        if (result.txHash) {
+          console.log(`  Tx hash: ${chalk.cyan(result.txHash)}`);
+        }
+      } catch (err) {
+        printError(
+          `Release failed: ${err instanceof Error ? err.message : String(err)}`,
+          err instanceof Error ? err : undefined,
+          "ERR_ESCROW_RELEASE",
+        );
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import { registerProfileCommand } from "./commands/profile";
 import { registerRetryCommand } from "./commands/retry";
 import { registerStatusCommand } from "./commands/status";
 import { registerDashboardCommand } from "./commands/dashboard";
+import { registerEscrowCommand } from "./commands/escrow";
 import { printError } from "./dashboard";
 
 const program = new Command("momo-cli")
@@ -18,6 +19,7 @@ registerRetryCommand(program);
 registerConfigCommand(program);
 registerProfileCommand(program);
 registerDashboardCommand(program);
+registerEscrowCommand(program);
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
closes #1318 

## Summary

Adds `momo-cli escrow release <escrowId>` — an interactive command that collects N signing keys before releasing escrowed funds.

## Changes

- **`cli/src/commands/escrow.ts`** (new) — `escrow release` command with interactive multi-sig prompts
- **`cli/src/api.ts`** — `releaseEscrow(escrowId, signatures)` posts to `/api/admin/escrow/:id/release`
- **`cli/src/index.ts`** — registers the new command

## Behaviour

- `--threshold <N>` (default: 2) controls how many approvers must sign
- Each signing key is collected with a masked password prompt (never echoed)
- A final confirmation prompt (default: No) guards against accidental release
- Aborts cleanly if threshold is invalid or user declines confirmation

## Testing

Pre-commit hooks passed: ESLint + Jest (no related tests broken).