### PR TITLE
fix: add currency checking layers for Airtel Money East Africa (TZS/KES) support (closes #1041)

### DIFF
--- a/src/services/mobilemoney/providers/airtel.ts
+++ b/src/services/mobilemoney/providers/airtel.ts
@@ -93,6 +93,15 @@ interface AirtelProviderOptions extends Partial<AirtelProviderConfig> {
 const DEFAULT_SESSION_TTL_MS = 20 * 60 * 1000;
 const DEFAULT_REFRESH_SKEW_MS = 60 * 1000;
 
+// East Africa Airtel markets and their mandatory currencies.
+// Mixing a Central/West Africa currency (e.g. XAF, NGN) with an East Africa
+// country code (or vice versa) causes silent failures at the Airtel API layer.
+const EAST_AFRICA_COUNTRY_CURRENCIES: Record<string, string> = {
+  KE: "KES",
+  TZ: "TZS",
+  UG: "UGX",
+};
+
 // ============================================================================
 // AIRTEL SERVICE
 // ============================================================================
@@ -191,6 +200,19 @@ export class AirtelService {
       case "TZ": return "TZS";
       case "NG": return "NGN";
       default: return "NGN";
+    }
+  }
+
+  private validateEastAfricaCurrency(): void {
+    const country = this.countryCode.toUpperCase();
+    const expectedCurrency = EAST_AFRICA_COUNTRY_CURRENCIES[country];
+    if (!expectedCurrency) return;
+    if (this.currency !== expectedCurrency) {
+      throw new Error(
+        `Airtel East Africa: country "${country}" requires currency "${expectedCurrency}" ` +
+        `but is configured with "${this.currency}". ` +
+        `Set AIRTEL_CURRENCY_${country}=${expectedCurrency} or pass currency: "${expectedCurrency}" in options.`,
+      );
     }
   }
 
@@ -304,6 +326,7 @@ export class AirtelService {
     const startTime = Date.now();
 
     try {
+      this.validateEastAfricaCurrency();
       const reference = `AIRTEL-${Date.now()}`;
 
       const response =
@@ -363,6 +386,7 @@ export class AirtelService {
     const startTime = Date.now();
 
     try {
+      this.validateEastAfricaCurrency();
       const reference = `AIRTEL-PAYOUT-${Date.now()}`;
 
       const response =


### PR DESCRIPTION
## Summary
Adds explicit currency validation for Airtel Money East Africa markets (KE, TZ, UG) to prevent silent misbehaviour when a Central Africa currency (XAF, NGN) is sent on an East Africa API path.

## Changes
- `src/services/mobilemoney/providers/airtel.ts` — added `EAST_AFRICA_COUNTRY_CURRENCIES` map and `validateEastAfricaCurrency()` private method; called at the top of `requestPayment()` and `sendPayout()` before any network call is made

## Approach
- Validation fires before any reference is generated or network call is made
- Non-East-Africa markets (NG, CM, etc.) are completely unaffected
- Failure surfaces as `{ success: false, error }` via the existing catch block — no new error handling needed, caller response shape is unchanged
- Error message includes the exact env var name to fix (e.g. `AIRTEL_CURRENCY_KE=KES`) for fast debugging
- Zero new packages

Closes #1041