### PR TITLE
fix(#1461): add standardized error handler to bridge-starter-node

### DIFF
--- a/bridge-starter-node/src/app.ts
+++ b/bridge-starter-node/src/app.ts
@@ -47,6 +47,64 @@ app.get("/", (_req: Request, res: Response) => {
 
 app.use("/api", webhookRoutes);
 
+// ── Standardized error handler ───────────────────────────────────────────────
+// Aligns error responses with the main API bridge fields so developer
+// experience is consistent across both the starter template and the main API.
+//
+// Response shape:
+//   {
+//     "success": false,
+//     "error":   <string — human-readable>,
+//     "code":    <string — machine-readable, e.g. "INTERNAL_ERROR">,
+//     "status":  <number — mirrors HTTP status>,
+//     "requestId": <string | undefined — from x-request-id header>
+//   }
+interface BridgeErrorBody {
+  success: false;
+  error: string;
+  code: string;
+  status: number;
+  requestId?: string;
+  details?: Record<string, unknown>;
+}
+
+app.use((err: Error & { statusCode?: number; code?: string; details?: Record<string, unknown> }, req: Request, res: Response, _next: NextFunction) => {
+  const statusCode =
+    typeof err.statusCode === "number" && err.statusCode >= 400
+      ? err.statusCode
+      : 500;
+
+  const code = err.code ?? (statusCode >= 500 ? "INTERNAL_ERROR" : "BAD_REQUEST");
+  const requestId = (req.headers["x-request-id"] as string | undefined) ?? undefined;
+
+  logger.error(
+    {
+      code,
+      statusCode,
+      requestId,
+      message: err.message,
+      ...(process.env.NODE_ENV !== "production" && { stack: err.stack }),
+    },
+    "Request error",
+  );
+
+  const body: BridgeErrorBody = {
+    success: false,
+    error: err.message || "An unexpected error occurred",
+    code,
+    status: statusCode,
+    requestId,
+  };
+
+  // Include details only outside production to avoid leaking internals.
+  if (process.env.NODE_ENV !== "production" && err.details) {
+    body.details = err.details;
+  }
+
+  res.status(statusCode).json(body);
+});
+
 app.listen(config.port, () => {
   logger.info({ port: config.port }, "Server started");
 });
+


### PR DESCRIPTION
Closes #1461

Adds a global 4-parameter Express error handler to `bridge-starter-node/src/app.ts` that emits the same bridge error fields as the main API: `{ success: false, error, code, status, requestId, details? }`. Details suppressed in production. requestId forwarded from `x-request-id` header. All errors logged via pino with code + statusCode metadata.

Payout: ETH `0xeaCAb48a4bfA0CED0e668c166615927115655594`