### PR TITLE
fix(#1333): sync Kotlin SDK bin/main imports + Gradle drift guard

### DIFF
--- a/sdk/bin/main/com/mobilemoney/sdk/MobileMoneySDK.kt
+++ b/sdk/bin/main/com/mobilemoney/sdk/MobileMoneySDK.kt
@@ -1,6 +1,7 @@
 package com.mobilemoney.sdk
 
 import com.mobilemoney.sdk.auth.AuthInterceptor
+import com.mobilemoney.sdk.cache.MemoryCacheInterceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -18,6 +19,7 @@ class MobileMoneySDK(
 ) {
     private val okHttpClient = OkHttpClient.Builder()
         .addInterceptor(AuthInterceptor(authToken))
+        .addInterceptor(MemoryCacheInterceptor())
         .build()
 
     private val retrofit = Retrofit.Builder()

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -115,3 +115,40 @@ signing {
         logger.warn("SDK: GPG signing credentials not found — artifacts will NOT be signed. Set signingKey and signingPassword for Maven Central publishing.")
     }
 }
+
+// ── Bin/src sync guard ────────────────────────────────────────────────────────
+// Keeps bin/main in sync with src/main to prevent import drift (issue #1333).
+// Run:  ./gradlew syncBinSources
+// CI:   add `syncBinSources` before `build` to fail on drift.
+
+val srcRoot = file("src/main/kotlin")
+val binRoot = file("bin/main")
+
+tasks.register<Sync>("syncBinSources") {
+    group = "build"
+    description = "Copy src/main/kotlin -> bin/main to eliminate import drift."
+    from(srcRoot)
+    into(binRoot)
+    preserve { include("**/*.kt") }
+}
+
+tasks.register<Exec>("checkBinSync") {
+    group = "verification"
+    description = "Fail the build when bin/main has drifted from src/main/kotlin."
+    dependsOn("syncBinSources")
+    commandLine("git", "diff", "--exit-code", "--name-only", binRoot.relativeTo(rootDir).path)
+    isIgnoreExitValue = false
+    doFirst {
+        logger.lifecycle("Checking bin/main for import drift...")
+    }
+    doLast {
+        if (executionResult.get().exitValue == 0) {
+            logger.lifecycle("bin/main is in sync with src/main/kotlin — no drift detected.")
+        } else {
+            throw GradleException(
+                "bin/main has drifted from src/main/kotlin. " +
+                "Run `./gradlew syncBinSources` and commit the result."
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #1333

Fixed MobileMoneySDK.kt in bin/main missing MemoryCacheInterceptor import+usage. Added syncBinSources and checkBinSync Gradle tasks to prevent future drift. Payout: ETH 0xeaCAb48a4bfA0CED0e668c166615927115655594