### PR TITLE
fix(#1341): re-attach JetStream context after NATS reconnect

### DIFF
--- a/ingest-go/main.go
+++ b/ingest-go/main.go
@@ -271,8 +271,27 @@ var (
 	rdb *redis.Client
 	nc  *nats.Conn
 	js  nats.JetStreamContext
-	ctx = context.Background()
+	jsMu sync.RWMutex // guards js during reconnect
+	ctx  = context.Background()
 )
+
+// reattachJetStream re-creates the JetStreamContext after a reconnect.
+// Called inside the ReconnectHandler, which runs on the NATS client goroutine.
+func reattachJetStream() {
+	jsMu.Lock()
+	defer jsMu.Unlock()
+	if nc == nil {
+		return
+	}
+	newJS, err := nc.JetStream()
+	if err != nil {
+		log.Printf("[nats] failed to re-attach JetStream after reconnect: %v", err)
+		js = nil
+		return
+	}
+	js = newJS
+	log.Printf("[nats] JetStream context re-attached after reconnect")
+}
 
 func initMessaging() error {
 	if redisEnabled {
@@ -297,6 +316,7 @@ func initMessaging() error {
 			}),
 			nats.ReconnectHandler(func(nc *nats.Conn) {
 				log.Printf("[nats] reconnected to %s", nc.ConnectedUrl())
+				reattachJetStream()
 			}),
 			nats.ClosedHandler(func(nc *nats.Conn) {
 				log.Printf("[nats] connection permanently closed")
@@ -347,8 +367,14 @@ func publish(p *CallbackPayload) error {
 		}
 	}
 
-	if natsEnabled && js != nil {
-		if _, err := js.Publish(natsSubject, buf); err != nil {
+	if natsEnabled {
+		jsMu.RLock()
+		currentJS := js
+		jsMu.RUnlock()
+		if currentJS == nil {
+			return fmt.Errorf("nats jetstream unavailable (reconnecting)")
+		}
+		if _, err := currentJS.Publish(natsSubject, buf); err != nil {
 			return fmt.Errorf("nats publish: %w", err)
 		}
 	}


### PR DESCRIPTION
Closes #1341

Root cause: ReconnectHandler only logged — JetStream context stayed stale after network loss. Fix: jsMu RWMutex guards js, reattachJetStream() re-creates JetStreamContext on reconnect, publish() holds read lock. Streams restore correctly. Payout: ETH 0xeaCAb48a4bfA0CED0e668c166615927115655594