### PR TITLE
Add global regex scrub filters to logger transports for PII master keys.

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -45,6 +45,79 @@ const LOG_DIR = process.env.LOG_DIR ?? path.join(process.cwd(), 'logs');
 const LOG_FILE_SIZE = process.env.LOG_FILE_SIZE ?? '10M';
 const configuredRetention = Number(process.env.LOG_FILE_RETENTION ?? 14);
 const LOG_FILE_RETENTION = Number.isFinite(configuredRetention) ? configuredRetention : 14;
+const SCRUB_CENSOR = '[REDACTED]';
+
+// ---------------------------------------------------------------------------
+// Global regex scrub filters — applied inside every transport so secrets
+// never reach stdout, rotating files, or Loki regardless of log verbosity.
+// ---------------------------------------------------------------------------
+
+/** Extra PII master-key field names not covered by generic REDACT_KEYS. */
+const PII_MASTER_KEY_FIELDS = [
+  'pii_master_key',
+  'piiMasterKey',
+  'PII_MASTER_KEY',
+  'db_encryption_key',
+  'dbEncryptionKey',
+  'DB_ENCRYPTION_KEY',
+];
+
+type ScrubFilter = { pattern: RegExp; replacement: string };
+
+function buildJsonKeyValueScrubFilters(keys: string[]): ScrubFilter[] {
+  return keys.flatMap((key) => {
+    const escaped = key.replace(/[_-]/g, '[_-]?');
+    return [
+      {
+        pattern: new RegExp(`("${escaped}"\\s*:\\s*")([^"\\\\]*(?:\\\\.[^"\\\\]*)*)(")`, 'gi'),
+        replacement: `$1${SCRUB_CENSOR}$3`,
+      },
+      {
+        pattern: new RegExp(`('${escaped}'\\s*:\\s*')([^']*)(')`, 'gi'),
+        replacement: `$1${SCRUB_CENSOR}$3`,
+      },
+    ];
+  });
+}
+
+const PII_SCRUB_REGEX_FILTERS: ScrubFilter[] = [
+  ...buildJsonKeyValueScrubFilters([...REDACT_KEYS, ...PII_MASTER_KEY_FIELDS]),
+  // Bearer tokens embedded in message strings
+  {
+    pattern: /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
+    replacement: `Bearer ${SCRUB_CENSOR}`,
+  },
+  // Stellar secret keys (S…)
+  {
+    pattern: /\bS[A-Z2-7]{55}\b/g,
+    replacement: SCRUB_CENSOR,
+  },
+];
+
+const PII_KEY_VALUE_PATTERN =
+  /\b(master[_-]?key|pii[_-]?master[_-]?key|db[_-]?encryption[_-]?key)\s*[=:]\s*['"]?[^\s'",}]+['"]?/gi;
+
+function scrubLogOutput(chunk: string): string {
+  let result = chunk.replace(
+    PII_KEY_VALUE_PATTERN,
+    (match, key: string) => `${key}=${SCRUB_CENSOR}`,
+  );
+
+  for (const { pattern, replacement } of PII_SCRUB_REGEX_FILTERS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+/** Wrap any pino destination so regex scrubbing runs before the transport prints. */
+function wrapStreamWithScrubbing(stream: DestinationStream): DestinationStream {
+  return {
+    write(msg: string) {
+      stream.write(scrubLogOutput(msg));
+    },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Transport configuration
@@ -105,11 +178,11 @@ function buildStreams(): StreamEntry[] | undefined {
   const streams: StreamEntry[] = [
     {
       level: LOG_LEVEL,
-      stream: process.stdout,
+      stream: wrapStreamWithScrubbing(process.stdout),
     },
     {
       level: LOG_LEVEL,
-      stream: buildFileStream(),
+      stream: wrapStreamWithScrubbing(buildFileStream()),
     },
   ];
 
@@ -117,21 +190,23 @@ function buildStreams(): StreamEntry[] | undefined {
     streams.push({
       // pino-loki runs in a worker thread — fully async, non-blocking
       level: LOG_LEVEL,
-      stream: pino.transport({
-        target: 'pino-loki',
-        options: {
-          host: lokiHost,
-          // Gracefully handle connection failures — never throw into the app
-          silenceErrors: true,
-          labels: {
-            service: SERVICE_NAME,
-            env: process.env.NODE_ENV ?? 'development',
+      stream: wrapStreamWithScrubbing(
+        pino.transport({
+          target: 'pino-loki',
+          options: {
+            host: lokiHost,
+            // Gracefully handle connection failures — never throw into the app
+            silenceErrors: true,
+            labels: {
+              service: SERVICE_NAME,
+              env: process.env.NODE_ENV ?? 'development',
+            },
+            // Batch up to 10 log lines or flush every 5 s, whichever comes first
+            batching: true,
+            interval: 5,
           },
-          // Batch up to 10 log lines or flush every 5 s, whichever comes first
-          batching: true,
-          interval: 5,
-        },
-      }),
+        }),
+      ),
     });
   }
 
@@ -170,11 +245,15 @@ const logger: Logger = pino(
     redact: {
       paths: [
         ...REDACT_KEYS,
+        ...PII_MASTER_KEY_FIELDS,
         ...REDACT_KEYS.map((key) => `*.${key}`),
+        ...PII_MASTER_KEY_FIELDS.map((key) => `*.${key}`),
         ...REDACT_KEYS.map((key) => `req.headers.${key}`),
         ...REDACT_KEYS.map((key) => `*.req.headers.${key}`),
+        ...PII_MASTER_KEY_FIELDS.map((key) => `req.headers.${key}`),
+        ...PII_MASTER_KEY_FIELDS.map((key) => `*.req.headers.${key}`),
       ],
-      censor: '[REDACTED]',
+      censor: SCRUB_CENSOR,
     },
 
     // ISO-8601 timestamps


### PR DESCRIPTION
## Summary
- Adds global regex scrub filters inside all logger transports (stdout, rotating file, Loki) so PII master keys and other secrets are stripped before any sink prints them.
- Extends pino path-based redaction with explicit `PII_MASTER_KEY` / `DB_ENCRYPTION_KEY` field paths.
- Regex filters catch JSON key-value pairs, free-form `key=value` patterns, Bearer tokens, and Stellar secret keys in serialized log lines.

## Changes
- `src/utils/logger.ts`
  - `PII_SCRUB_REGEX_FILTERS` — global regex filter set
  - `wrapStreamWithScrubbing()` — wraps every transport destination
  - `PII_MASTER_KEY_FIELDS` — added to pino `redact.paths`

## Acceptance criteria
- [x] Filters strip secrets before prints
- [x] PII keys never printed under any debug verbosity setting

Closes #1335