### PR TITLE
feat: reserve liquidity monitoring with seasonal peak adjustment

### DIFF
--- a/src/jobs/balanceMonitorJob.ts
+++ b/src/jobs/balanceMonitorJob.ts
@@ -3,6 +3,9 @@ import * as StellarSdk from "stellar-sdk";
 import { getStellarServer } from "../config/stellar";
 import { notifySlackAlert } from "../services/loggers";
 import { calculateStellarReserve, formatReserveInfo } from "../utils/stellarReserveCalculator";
+import { ledgerService } from "../services/ledgerService";
+import { MTNProvider } from "../services/mobilemoney/providers/mtn";
+import { AirtelService } from "../services/mobilemoney/providers/airtel";
 
 /**
  * Balance Monitor Job
@@ -187,4 +190,28 @@ async function checkBalancesAndAlert(): Promise<void> {
 
 export async function runBalanceMonitorJob(): Promise<void> {
   await checkBalancesAndAlert();
+
+  // Fetch provider wallet balances and check reserve liquidity ratios
+  try {
+    const mtn = new MTNProvider();
+    const airtel = new AirtelService();
+    const [mtnResult, airtelResult] = await Promise.all([
+      mtn.getOperationalBalance().catch(() => null),
+      airtel.getOperationalBalance().catch(() => null),
+    ]);
+
+    const walletBalances: Record<string, number> = {};
+    if (mtnResult?.success && mtnResult.data) {
+      walletBalances['mtn'] = (mtnResult.data as any).availableBalance ?? 0;
+    }
+    if (airtelResult?.success && airtelResult.data) {
+      walletBalances['airtel'] = (airtelResult.data as any).availableBalance ?? 0;
+    }
+
+    if (Object.keys(walletBalances).length > 0) {
+      await ledgerService.checkReserveLiquidity(walletBalances);
+    }
+  } catch (err) {
+    logger.error('[balance-monitor] Reserve liquidity check failed:', err);
+  }
 }

--- a/src/services/__tests__/ledgerService.reserveLiquidity.test.ts
+++ b/src/services/__tests__/ledgerService.reserveLiquidity.test.ts
@@ -1,0 +1,99 @@
+import { LedgerService } from "../ledgerService";
+import { Pool } from "pg";
+
+jest.mock("../loggers", () => ({
+  notifySlackAlert: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../pagerDutyService", () => ({
+  createPagerDutyService: jest.fn(() => ({
+    handleBalanceShortfall: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { notifySlackAlert } from "../loggers";
+import { createPagerDutyService } from "../pagerDutyService";
+
+function makePool(rows: { provider: string; volume: string }[]): Pool {
+  return {
+    query: jest.fn().mockResolvedValue({ rows }),
+    connect: jest.fn(),
+  } as unknown as Pool;
+}
+
+describe("LedgerService.checkReserveLiquidity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.RESERVE_LIQUIDITY_RATIO;
+    delete process.env.RESERVE_PEAK_MONTHS;
+    delete process.env.RESERVE_SEASONAL_PEAK_MULTIPLIER;
+  });
+
+  it("triggers PagerDuty and Slack when balance is below 110% of 30-day volume", async () => {
+    // 30-day volume = 1000; balance = 1000; ratio = 1.0 < 1.1 → alert
+    const service = new LedgerService(makePool([{ provider: "mtn", volume: "1000" }]));
+    await service.checkReserveLiquidity({ mtn: 1000 });
+
+    const pd = (createPagerDutyService as jest.Mock).mock.results[0].value;
+    expect(pd.handleBalanceShortfall).toHaveBeenCalledWith(
+      "mtn",
+      "reserve-liquidity",
+      expect.any(Number),
+      1000
+    );
+    expect(notifySlackAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT alert when balance is at or above 110% of 30-day volume", async () => {
+    // 30-day volume = 1000; balance = 1100; ratio = 1.1 → no alert
+    const service = new LedgerService(makePool([{ provider: "airtel", volume: "1000" }]));
+    await service.checkReserveLiquidity({ airtel: 1100 });
+
+    const pd = (createPagerDutyService as jest.Mock).mock.results[0].value;
+    expect(pd.handleBalanceShortfall).not.toHaveBeenCalled();
+    expect(notifySlackAlert).not.toHaveBeenCalled();
+  });
+
+  it("skips providers with zero 30-day velocity", async () => {
+    const service = new LedgerService(makePool([])); // no ledger data
+    await service.checkReserveLiquidity({ mtn: 500 });
+
+    const pd = (createPagerDutyService as jest.Mock).mock.results[0].value;
+    expect(pd.handleBalanceShortfall).not.toHaveBeenCalled();
+  });
+
+  it("applies seasonal peak multiplier during peak months", async () => {
+    // Force current month to be a peak month
+    const currentMonth = new Date().getMonth() + 1;
+    process.env.RESERVE_PEAK_MONTHS = String(currentMonth);
+    process.env.RESERVE_SEASONAL_PEAK_MULTIPLIER = "1.5";
+
+    // volume=1000, seasonal=1.5 → expectedVolume=1500, threshold=1650
+    // balance=1400 → ratio = 1400/1500 ≈ 0.93 < 1.1 → alert
+    const service = new LedgerService(makePool([{ provider: "mtn", volume: "1000" }]));
+    await service.checkReserveLiquidity({ mtn: 1400 });
+
+    const pd = (createPagerDutyService as jest.Mock).mock.results[0].value;
+    // threshold passed should be 1500 * 1.1 = 1650
+    expect(pd.handleBalanceShortfall).toHaveBeenCalledWith(
+      "mtn",
+      "reserve-liquidity",
+      expect.closeTo(1650, 5),
+      1400
+    );
+  });
+
+  it("does not alert outside peak months", async () => {
+    // Set a peak month that is NOT the current month
+    const nonPeakMonth = ((new Date().getMonth() + 1) % 12) + 1; // always different
+    process.env.RESERVE_PEAK_MONTHS = String(nonPeakMonth);
+    process.env.RESERVE_SEASONAL_PEAK_MULTIPLIER = "2.0";
+
+    // volume=1000, no seasonal → threshold=1100; balance=1100 → no alert
+    const service = new LedgerService(makePool([{ provider: "mtn", volume: "1000" }]));
+    await service.checkReserveLiquidity({ mtn: 1100 });
+
+    const pd = (createPagerDutyService as jest.Mock).mock.results[0].value;
+    expect(pd.handleBalanceShortfall).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/ledgerService.ts
+++ b/src/services/ledgerService.ts
@@ -1,6 +1,8 @@
 import { Pool } from 'pg';
 import { pool } from '../config/database';
 import { UserModel } from '../models/users';
+import { notifySlackAlert } from './loggers';
+import { createPagerDutyService } from './pagerDutyService';
 
 /**
  * Double-Entry Ledger Service
@@ -651,6 +653,97 @@ export class LedgerService {
       hasMore,
       limit: pageLimit,
     };
+  }
+
+  /**
+   * Compute 30-day payout velocity per provider from the ledger.
+   * Returns total credit amount on account 1100 (Mobile Money Float) per provider.
+   */
+  private async get30DayVelocityByProvider(): Promise<Map<string, number>> {
+    const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const result = await this.pool.query<{ provider: string; volume: string }>(
+      `SELECT
+         COALESCE(le.metadata->>'provider', 'unknown') AS provider,
+         SUM(le.credit_amount)                         AS volume
+       FROM ledger_entries le
+       JOIN accounts a ON le.account_id = a.id
+       WHERE a.code = '1100'
+         AND le.entry_date >= $1
+       GROUP BY le.metadata->>'provider'`,
+      [since]
+    );
+    const map = new Map<string, number>();
+    for (const row of result.rows) {
+      map.set(row.provider, parseFloat(row.volume) || 0);
+    }
+    return map;
+  }
+
+  /**
+   * Seasonal peak multiplier: boost expected volume by RESERVE_SEASONAL_PEAK_MULTIPLIER
+   * during months declared as peak (default: December=12 and April=4 for
+   * African mobile-money holiday cycles). Configurable via env vars.
+   */
+  private seasonalMultiplier(): number {
+    const peakMonths = (process.env.RESERVE_PEAK_MONTHS || '12,4')
+      .split(',')
+      .map(m => parseInt(m.trim(), 10));
+    const currentMonth = new Date().getMonth() + 1; // 1-based
+    if (peakMonths.includes(currentMonth)) {
+      return parseFloat(process.env.RESERVE_SEASONAL_PEAK_MULTIPLIER || '1.25');
+    }
+    return 1;
+  }
+
+  /**
+   * Check reserve liquidity for each provider.
+   * Triggers PagerDuty + Slack alerts when wallet balance / (30-day volume) < 110%.
+   *
+   * @param walletBalances  map of provider → current wallet balance (same currency as ledger)
+   */
+  async checkReserveLiquidity(
+    walletBalances: Record<string, number>
+  ): Promise<void> {
+    const RATIO_THRESHOLD = parseFloat(process.env.RESERVE_LIQUIDITY_RATIO || '1.1');
+    const velocity = await this.get30DayVelocityByProvider();
+    const seasonal = this.seasonalMultiplier();
+    const pagerDuty = createPagerDutyService();
+
+    for (const [provider, balance] of Object.entries(walletBalances)) {
+      const rawVolume = velocity.get(provider) ?? 0;
+      if (rawVolume === 0) continue; // no recent activity — skip
+
+      const expectedVolume = rawVolume * seasonal;
+      const ratio = balance / expectedVolume;
+
+      if (ratio < RATIO_THRESHOLD) {
+        const shortfallAmount = expectedVolume * RATIO_THRESHOLD - balance;
+
+        // PagerDuty alert
+        await pagerDuty.handleBalanceShortfall(
+          provider,
+          'reserve-liquidity',
+          expectedVolume * RATIO_THRESHOLD,
+          balance
+        );
+
+        // Slack alert
+        await notifySlackAlert(
+          {
+            statusCode: 500,
+            method: 'MONITOR',
+            path: `/reserve-liquidity/${provider}`,
+            timestamp: new Date().toISOString(),
+            error: new Error(
+              `Reserve liquidity below 110%: ${provider} balance=${balance.toFixed(2)} ` +
+              `expected=${expectedVolume.toFixed(2)} ratio=${(ratio * 100).toFixed(1)}% ` +
+              `shortfall=${shortfallAmount.toFixed(2)} seasonal_mult=${seasonal}`
+            ),
+          },
+          { appName: 'reserve-liquidity-monitor' }
+        );
+      }
+    }
   }
 }
 


### PR DESCRIPTION
- Add get30DayVelocityByProvider to query 30-day ledger credit volume per provider
- Add seasonalMultiplier using RESERVE_PEAK_MONTHS and RESERVE_SEASONAL_PEAK_MULTIPLIER env vars
- Add checkReserveLiquidity method to LedgerService: compares wallet balances against expected 30-day payout volume and triggers PagerDuty + Slack alerts when ratio < 110%
- Integrate checkReserveLiquidity into runBalanceMonitorJob (balanceMonitorJob.ts) fetching live MTN and Airtel wallet balances each run
- Add 5 unit tests covering alert trigger, no-alert, zero-velocity skip, seasonal multiplier, and non-peak-month cases

Closes #1486

## Description

Brief description of changes.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

-
-
-

## Testing

How did you test these changes?

## Checklist

- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)

## Screenshots (if applicable)

## Additional Notes
