### PR TITLE
feat: Add API Request ID to logger & standardize bridge error responses

### DIFF
--- a/bridge-starter-node/src/app.ts
+++ b/bridge-starter-node/src/app.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response, NextFunction } from "express";
 import webhookRoutes from "./routes/webhook";
 import { config } from "./config/env";
-import logger from "./logger";
+import logger, { requestContext } from "./logger";
 
 const app = express();
 
@@ -38,7 +38,12 @@ app.use((req: Request, res: Response, next: NextFunction) => {
     );
   });
 
-  next();
+  const traceId = req.headers["x-request-id"] as string | undefined;
+  if (traceId) {
+    requestContext.run({ trace_id: traceId }, () => next());
+  } else {
+    next();
+  }
 });
 
 app.get("/", (_req: Request, res: Response) => {

--- a/bridge-starter-node/src/logger.ts
+++ b/bridge-starter-node/src/logger.ts
@@ -30,6 +30,9 @@
  */
 
 import pino, { type Logger, type TransportSingleOptions } from "pino";
+import { AsyncLocalStorage } from "async_hooks";
+
+export const requestContext = new AsyncLocalStorage<{ trace_id: string }>();
 
 const SERVICE_NAME = "bridge-starter-node";
 const LOG_LEVEL = process.env.LOG_LEVEL ?? "info";
@@ -66,6 +69,11 @@ const logger: Logger = pino(
     base: {
       service: SERVICE_NAME,
       env: process.env.NODE_ENV ?? "development",
+    },
+
+    mixin() {
+      const store = requestContext.getStore();
+      return store && store.trace_id ? { trace_id: store.trace_id } : {};
     },
 
     // Emit level as an uppercase string label (INFO, WARN, …) to match the

--- a/bridge-starter-node/src/middleware/auth.ts
+++ b/bridge-starter-node/src/middleware/auth.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import crypto from "crypto";
 import { config } from "../config/env";
 import logger from "../logger";
+import { formatErrorResponse } from "../utils/errors";
 
 /**
  * Verifies the HMAC-SHA256 signature on incoming webhook requests.
@@ -41,7 +42,7 @@ export const verifyWebhookSignature = (
       { path: req.path, method: req.method },
       "Webhook rejected: missing signature header",
     );
-    return res.status(401).json({ error: "Missing signature header" });
+    return res.status(401).json(formatErrorResponse(401, "UNAUTHORIZED", "Missing signature header"));
   }
 
   if (!config.webhookSecret) {
@@ -49,7 +50,7 @@ export const verifyWebhookSignature = (
       { path: req.path, method: req.method },
       "WEBHOOK_SECRET not configured; rejecting webhook request",
     );
-    return res.status(500).json({ error: "Server misconfigured" });
+    return res.status(500).json(formatErrorResponse(500, "INTERNAL_ERROR", "Server misconfigured"));
   }
 
   const raw = getRawBody(req);
@@ -83,7 +84,7 @@ export const verifyWebhookSignature = (
     { path: req.path, method: req.method },
     "Webhook rejected: invalid signature",
   );
-  return res.status(401).json({ error: "Invalid signature" });
+  return res.status(401).json(formatErrorResponse(401, "UNAUTHORIZED", "Invalid signature"));
 };
 
 export default verifyWebhookSignature;

--- a/bridge-starter-node/src/middleware/verifySignature.ts
+++ b/bridge-starter-node/src/middleware/verifySignature.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import crypto from "crypto";
 import { config } from "../config/env";
 import logger from "../logger";
+import { formatErrorResponse } from "../utils/errors";
 
 /**
  * Verifies the HMAC-SHA256 signature on incoming webhook requests.
@@ -23,7 +24,7 @@ export const verifyWebhookSignature = (
       { path: req.path, method: req.method },
       "Webhook rejected: missing x-bridge-signature header",
     );
-    res.status(401).json({ error: "Missing signature" });
+    res.status(401).json(formatErrorResponse(401, "UNAUTHORIZED", "Missing signature"));
     return;
   }
 
@@ -53,7 +54,7 @@ export const verifyWebhookSignature = (
       { path: req.path, method: req.method },
       "Webhook rejected: invalid signature",
     );
-    res.status(401).json({ error: "Invalid signature" });
+    res.status(401).json(formatErrorResponse(401, "UNAUTHORIZED", "Invalid signature"));
     return;
   }
 

--- a/bridge-starter-node/src/utils/errors.ts
+++ b/bridge-starter-node/src/utils/errors.ts
@@ -1,0 +1,16 @@
+export const formatErrorResponse = (
+  statusCode: number,
+  code: string,
+  message: string,
+  requestId?: string,
+  details?: Record<string, unknown>
+) => ({
+  code,
+  message,
+  message_en: message,
+  timestamp: new Date().toISOString(),
+  statusCode,
+  requestId,
+  details,
+  error: message,
+});

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { UAParser } from "ua-parser-js";
-import logger, { childLogger } from "../utils/logger";
+import logger, { childLogger, requestContext } from "../utils/logger";
 
 /**
  * Request pathname without query string (avoids logging ?api_key=…, ?token=…, etc.).
@@ -103,5 +103,13 @@ export function requestLogger(
   res.on("finish", writeLog);
   res.on("close", writeLog);
 
-  next();
+  const traceId =
+    (req.headers["x-trace-id"] as string | undefined) ??
+    (req.headers["x-request-id"] as string | undefined);
+
+  if (traceId) {
+    requestContext.run({ trace_id: traceId }, () => next());
+  } else {
+    next();
+  }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,6 +3,9 @@ import path from 'path';
 import os from 'os';
 import pino, { DestinationStream, Level, Logger, StreamEntry } from 'pino';
 import { REDACT_KEYS } from './redact';
+import { AsyncLocalStorage } from 'async_hooks';
+
+export const requestContext = new AsyncLocalStorage<{ trace_id: string }>();
 
 /**
  * Centralized Pino Logger — feature/centralized-logging
@@ -234,6 +237,11 @@ const logger: Logger = pino(
     base: {
       service: SERVICE_NAME,
       instance_id: INSTANCE_ID,
+    },
+
+    mixin() {
+      const store = requestContext.getStore();
+      return store && store.trace_id ? { trace_id: store.trace_id } : {};
     },
 
     // Format the level as uppercase string for Loki/Grafana label filters


### PR DESCRIPTION
**Description**:
This pull request addresses two developer experience issues relating to observability and standardizing API structures.

Closes #1459, Closes #1461.

**What was done**:
1. **API Request ID in Loggers (#1459)**: 
   - Created an `AsyncLocalStorage` request context to hold the `trace_id`.
   - Used Pino's `mixin` configuration option in both the main API (`src/utils/logger.ts`) and the starter template (`bridge-starter-node/src/logger.ts`) to transparently bind `trace_id` properties to all log traces.
   - Updated middleware so that nested or child loggers automatically emit trace identifiers across the request lifecycle without manually passing logger instances.
2. **Standardized Error Layout in bridge-starter-node (#1461)**: 
   - Extracted standard error formatting logic into `bridge-starter-node/src/utils/errors.ts`.
   - Refactored `auth` and `verifySignature` middlewares inside `bridge-starter-node` to return payloads formatted identically to the main API, including properties like `code`, `message`, `message_en`, `timestamp`, `statusCode`, and `error`.