### PR TITLE
Compliance: Set up suspicious transaction alert triggers

### DIFF
--- a/src/queue/syncWorker.ts
+++ b/src/queue/syncWorker.ts
@@ -11,6 +11,7 @@ import {
 import { pool } from "../config/database";
 import { addAccountingRetryJob } from "./accountingRetryQueue";
 import { natsManager, NATS_QUEUE_ENABLED, type JsMsg } from "./nats";
+import { amlService, AMLTransactionRecord } from "../services/aml";
 
 const getSyncConcurrency = (): number => {
   const envVal = process.env.SYNC_WORKER_CONCURRENCY;
@@ -54,6 +55,52 @@ async function logAccountingSyncError(
 }
 
 /**
+ * Evaluates AML compliance and suspicious structuring patterns for synced transactions
+ */
+export async function checkSyncTransactionCompliance(
+  transactionId: string,
+  amountStr?: string,
+): Promise<void> {
+  try {
+    const query = `SELECT user_id AS "userId", type, amount, created_at AS "createdAt" FROM transactions WHERE id = $1`;
+    const result = await pool.query<{
+      userId: string;
+      type: "deposit" | "withdraw";
+      amount: number;
+      createdAt: Date;
+    }>(query, [transactionId]);
+
+    if (result.rows.length > 0) {
+      const row = result.rows[0];
+      const record: AMLTransactionRecord = {
+        id: transactionId,
+        userId: row.userId,
+        type: row.type || "deposit",
+        amount: Number(amountStr ?? row.amount),
+        createdAt: row.createdAt ? new Date(row.createdAt) : new Date(),
+      };
+      const amlResult = await amlService.monitorTransaction(record);
+      if (amlResult.flagged) {
+        logger.warn(
+          {
+            transactionId,
+            userId: row.userId,
+            reasons: amlResult.reasons,
+            ruleHits: amlResult.ruleHits,
+          },
+          "[SyncWorker] Suspicious transaction / structuring alert triggered during sync",
+        );
+      }
+    }
+  } catch (err) {
+    logger.error(
+      { transactionId, err },
+      "[SyncWorker] Failed to evaluate AML compliance on sync transaction",
+    );
+  }
+}
+
+/**
  * Sync Queue Processor Function
  * Handles the execution logic for a sync job, distinguishing transient and permanent errors.
  * On permanent failure after max retries, moves job to accounting retry queue for manual/scheduled retry.
@@ -73,6 +120,9 @@ export async function processSyncJob(
     },
     "Processing accounting sync operation",
   );
+
+  // Scan transaction for suspicious structuring / AML alert triggers
+  await checkSyncTransactionCompliance(transactionId, payload?.amount);
 
   try {
     if (platform === "quickbooks") {
@@ -210,6 +260,8 @@ async function processNatsSyncMessage(
   console.log(
     `[SyncWorker] [NATS] Processing accounting sync for transaction ${transactionId} to ${platform} (syncId=${syncId})`,
   );
+
+  await checkSyncTransactionCompliance(transactionId, data.payload?.amount);
 
   try {
     if (platform === "quickbooks") {

--- a/src/services/__tests__/amlStructuring.test.ts
+++ b/src/services/__tests__/amlStructuring.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, beforeEach, jest } from "@jest/globals";
+import { AMLService, AMLTransactionRecord } from "../aml";
+
+jest.mock("../../config/database", () => ({
+  pool: {
+    query: jest.fn<any>().mockResolvedValue({ rows: [] }),
+  },
+}));
+
+jest.mock("../cachedTransactionService", () => ({
+  getCachedAmlProfileSnapshot: jest.fn<any>().mockResolvedValue({
+    historicalCount: 0,
+    countLastHour: 0,
+    countLast24Hours: 0,
+    countLast7Days: 0,
+    movingAverageAmount: 0,
+    lastLocationMetadata: null,
+    lastLocationAt: null,
+  }),
+}));
+
+describe("AMLService - Suspicious Structuring Alerts (#1569)", () => {
+  let amlService: AMLService;
+
+  beforeEach(() => {
+    amlService = new AMLService({
+      singleTransactionThresholdXaf: 1_000_000,
+      structuringThresholdRatio: 0.8,
+      structuringFrequencyLimit: 3,
+    });
+  });
+
+  it("should flag user submitting multiple transactions just below KYC threshold", async () => {
+    const userId = "user-123";
+    const now = new Date();
+
+    const recentTxs: AMLTransactionRecord[] = [
+      {
+        id: "tx-1",
+        userId,
+        type: "deposit",
+        amount: 850_000, // 85% of threshold
+        createdAt: new Date(now.getTime() - 10 * 60 * 1000),
+      },
+      {
+        id: "tx-2",
+        userId,
+        type: "deposit",
+        amount: 900_000, // 90% of threshold
+        createdAt: new Date(now.getTime() - 5 * 60 * 1000),
+      },
+    ];
+
+    const currentTx: AMLTransactionRecord = {
+      id: "tx-3",
+      userId,
+      type: "deposit",
+      amount: 950_000, // 95% of threshold
+      createdAt: now,
+    };
+
+    const result = await amlService.evaluateTransaction(currentTx, recentTxs);
+
+    expect(result.flagged).toBe(true);
+    expect(result.ruleHits.some((hit) => hit.rule === "threshold_structuring")).toBe(true);
+    expect(result.reasons[0]).toContain("Structuring attempt detected");
+  });
+
+  it("should not flag transactions below the structuring floor ratio", async () => {
+    const userId = "user-456";
+    const now = new Date();
+
+    const recentTxs: AMLTransactionRecord[] = [
+      {
+        id: "tx-1",
+        userId,
+        type: "deposit",
+        amount: 100_000, // well below 80%
+        createdAt: new Date(now.getTime() - 10 * 60 * 1000),
+      },
+    ];
+
+    const currentTx: AMLTransactionRecord = {
+      id: "tx-2",
+      userId,
+      type: "deposit",
+      amount: 200_000,
+      createdAt: now,
+    };
+
+    const result = await amlService.evaluateTransaction(currentTx, recentTxs);
+
+    expect(result.flagged).toBe(false);
+    expect(result.ruleHits.some((hit) => hit.rule === "threshold_structuring")).toBe(false);
+  });
+});

--- a/src/services/aml.ts
+++ b/src/services/aml.ts
@@ -17,7 +17,8 @@ export type AMLRule =
   | "daily_total_threshold"
   | "rapid_structuring"
   | "sanction_match"
-  | "dynamic_profile_score";
+  | "dynamic_profile_score"
+  | "threshold_structuring";
 
 export interface AMLTransactionLocation {
   lat: number;
@@ -84,6 +85,8 @@ export interface AMLConfig {
   rapidWindowMinutes: number;
   rapidTransactionCount: number;
   structuringFloorXaf: number;
+  structuringThresholdRatio: number;
+  structuringFrequencyLimit: number;
   alertBufferSize: number;
   profileScoreThreshold: number;
   velocityHourlyCap: number;
@@ -138,6 +141,12 @@ const defaultConfig: AMLConfig = {
   rapidWindowMinutes: Number(process.env.AML_RAPID_WINDOW_MINUTES || 15),
   rapidTransactionCount: Number(process.env.AML_RAPID_TRANSACTION_COUNT || 3),
   structuringFloorXaf: Number(process.env.AML_STRUCTURING_FLOOR_XAF || 100_000),
+  structuringThresholdRatio: Number(
+    process.env.AML_STRUCTURING_THRESHOLD_RATIO || 0.8,
+  ),
+  structuringFrequencyLimit: Number(
+    process.env.AML_STRUCTURING_FREQUENCY_LIMIT || 3,
+  ),
   alertBufferSize: Number(process.env.AML_ALERT_BUFFER_SIZE || 5000),
   profileScoreThreshold: Number(process.env.AML_PROFILE_SCORE_THRESHOLD || 50),
   velocityHourlyCap: Number(process.env.AML_VELOCITY_HOURLY_CAP || 5),
@@ -506,6 +515,32 @@ export class AMLService {
       });
     }
 
+    // Scan user transaction frequency patterns for structuring just below KYC threshold
+    const structuringLowerBound =
+      this.config.singleTransactionThresholdXaf *
+      this.config.structuringThresholdRatio;
+    const structuringTxsJustBelowThreshold = windowTxs.filter(
+      (tx) =>
+        tx.amount >= structuringLowerBound &&
+        tx.amount < this.config.singleTransactionThresholdXaf,
+    );
+
+    const isCurrentStructuring =
+      current.amount >= structuringLowerBound &&
+      current.amount < this.config.singleTransactionThresholdXaf;
+
+    const totalStructuringCount =
+      structuringTxsJustBelowThreshold.length + (isCurrentStructuring ? 1 : 0);
+
+    if (totalStructuringCount >= this.config.structuringFrequencyLimit) {
+      ruleHits.push({
+        rule: "threshold_structuring",
+        message: `Structuring attempt detected: user submitted ${totalStructuringCount} transaction requests just below KYC threshold (${this.config.singleTransactionThresholdXaf} XAF)`,
+        observed: totalStructuringCount,
+        threshold: this.config.structuringFrequencyLimit,
+      });
+    }
+
     if (ruleHits.length === 0) {
       return {
         flagged: false,
@@ -520,7 +555,8 @@ export class AMLService {
     const severity: AMLAlertSeverity = ruleHits.some(
       (hit) =>
         hit.rule === "single_transaction_threshold" ||
-        hit.rule === "daily_total_threshold",
+        hit.rule === "daily_total_threshold" ||
+        hit.rule === "threshold_structuring",
     )
       ? "high"
       : "medium";
@@ -663,6 +699,7 @@ export class AMLService {
       rapid_structuring: 0,
       sanction_match: 0,
       dynamic_profile_score: 0,
+      threshold_structuring: 0,
     };
 
     const dailyMap = new Map<string, number>();
@@ -695,6 +732,26 @@ export class AMLService {
       const { AMLAlertModel } = await import("../models/amlAlert.js");
       const model = new AMLAlertModel();
       await model.create(alert);
+
+      // Send alert notifications to administrators
+      try {
+        const { notificationRouter } = await import("./notificationRouter.js");
+        await notificationRouter.routeSystemNotification(
+          alert.severity === "high" ? "high" : "medium",
+          "compliance_aml_alert",
+          `Suspicious Transaction Alert: User ${alert.userId}`,
+          `Compliance alert triggered for user ${alert.userId}: ${alert.reasons.join("; ")}`,
+          {
+            alertId: alert.id,
+            userId: alert.userId,
+            transactionId: alert.transactionId,
+            ruleHits: alert.ruleHits,
+            severity: alert.severity,
+          },
+        );
+      } catch (notifyErr) {
+        logger.error("Failed to send administrator alert notification:", notifyErr);
+      }
 
       if (alert.severity === "high") {
         console.log(


### PR DESCRIPTION
This PR sets up suspicious transaction alert triggers for compliance teams when a user submits multiple transaction requests just below KYC verification thresholds.

closes #1569