### PR TITLE
Security: Cleanly scrub PII data from error logs

### DIFF
--- a/src/utils/__tests__/loggerPiiScrubbing.test.ts
+++ b/src/utils/__tests__/loggerPiiScrubbing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { scrubLogOutput, logSanitizerMiddleware } from "../logger";
+
+describe("Logger PII Scrubbing (#1578)", () => {
+  it("scrubs emails and phone numbers from raw log strings", () => {
+    const rawLog = "Failed payment for user john.doe@example.com with phone +237677123456";
+    const scrubbed = scrubLogOutput(rawLog);
+
+    expect(scrubbed).not.toContain("john.doe@example.com");
+    expect(scrubbed).not.toContain("+237677123456");
+    expect(scrubbed).toContain("[REDACTED]");
+  });
+
+  it("scrubs PII parameters in JSON formatted log strings", () => {
+    const jsonLog = JSON.stringify({
+      level: "ERROR",
+      message: "Authentication failure",
+      email: "alice@domain.org",
+      phoneNumber: "+14155552671",
+      firstName: "Alice",
+      lastName: "Smith",
+    });
+
+    const scrubbed = scrubLogOutput(jsonLog);
+    const parsed = JSON.parse(scrubbed);
+
+    expect(parsed.email).toBe("[REDACTED]");
+    expect(parsed.phoneNumber).toBe("[REDACTED]");
+    expect(parsed.firstName).toBe("[REDACTED]");
+    expect(parsed.lastName).toBe("[REDACTED]");
+  });
+
+  it("sanitizes Express request object via logSanitizerMiddleware", () => {
+    const req: any = {
+      body: {
+        email: "bob@test.com",
+        phone: "+237699001122",
+        firstName: "Bob",
+      },
+      query: {
+        user_email: "bob.query@test.com",
+      },
+      params: {
+        phone_number: "+237699001122",
+      },
+    };
+
+    const next = jest.fn();
+    logSanitizerMiddleware(req, {}, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.body.email).toBe("[REDACTED]");
+    expect(req.body.phone).toBe("[REDACTED]");
+    expect(req.body.firstName).toBe("[REDACTED]");
+    expect(req.query.user_email).toBe("[REDACTED]");
+    expect(req.params.phone_number).toBe("[REDACTED]");
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -66,6 +66,30 @@ const PII_MASTER_KEY_FIELDS = [
   "DB_ENCRYPTION_KEY",
 ];
 
+/** User PII parameter field names to redact in logs */
+export const PII_USER_FIELDS = [
+  "email",
+  "e_mail",
+  "user_email",
+  "userEmail",
+  "phone",
+  "phoneNumber",
+  "phone_number",
+  "mobile",
+  "msisdn",
+  "telephone",
+  "first_name",
+  "firstName",
+  "last_name",
+  "lastName",
+  "display_name",
+  "displayName",
+  "full_name",
+  "fullName",
+  "user_name",
+  "userName",
+];
+
 type ScrubFilter = { pattern: RegExp; replacement: string };
 
 function buildJsonKeyValueScrubFilters(keys: string[]): ScrubFilter[] {
@@ -88,7 +112,11 @@ function buildJsonKeyValueScrubFilters(keys: string[]): ScrubFilter[] {
 }
 
 const PII_SCRUB_REGEX_FILTERS: ScrubFilter[] = [
-  ...buildJsonKeyValueScrubFilters([...REDACT_KEYS, ...PII_MASTER_KEY_FIELDS]),
+  ...buildJsonKeyValueScrubFilters([
+    ...REDACT_KEYS,
+    ...PII_MASTER_KEY_FIELDS,
+    ...PII_USER_FIELDS,
+  ]),
   // Bearer tokens embedded in message strings
   {
     pattern: /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g,
@@ -99,12 +127,22 @@ const PII_SCRUB_REGEX_FILTERS: ScrubFilter[] = [
     pattern: /\bS[A-Z2-7]{55}\b/g,
     replacement: SCRUB_CENSOR,
   },
+  // Standalone email addresses
+  {
+    pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+    replacement: SCRUB_CENSOR,
+  },
+  // Standalone international phone numbers (E.164: + followed by 8-15 digits)
+  {
+    pattern: /\+1?\d{9,14}\b/g,
+    replacement: SCRUB_CENSOR,
+  },
 ];
 
 const PII_KEY_VALUE_PATTERN =
-  /\b(master[_-]?key|pii[_-]?master[_-]?key|db[_-]?encryption[_-]?key)\s*[=:]\s*['"]?[^\s'",}]+['"]?/gi;
+  /\b(master[_-]?key|pii[_-]?master[_-]?key|db[_-]?encryption[_-]?key|email|user[_-]?email|phone[_-]?number|phone|msisdn|mobile|first[_-]?name|last[_-]?name|display[_-]?name|full[_-]?name|user[_-]?name)\s*[=:]\s*['"]?[^\s'",}]+['"]?/gi;
 
-function scrubLogOutput(chunk: string): string {
+export function scrubLogOutput(chunk: string): string {
   let result = chunk.replace(
     PII_KEY_VALUE_PATTERN,
     (match, key: string) => `${key}=${SCRUB_CENSOR}`,
@@ -115,6 +153,26 @@ function scrubLogOutput(chunk: string): string {
     result = result.replace(pattern, replacement);
   }
   return result;
+}
+
+/** Express middleware for sanitizing PII in request payloads and parameters */
+export function logSanitizerMiddleware(req: any, res: any, next: any): void {
+  if (req.body && typeof req.body === "object") {
+    try {
+      req.body = JSON.parse(scrubLogOutput(JSON.stringify(req.body)));
+    } catch {}
+  }
+  if (req.query && typeof req.query === "object") {
+    try {
+      req.query = JSON.parse(scrubLogOutput(JSON.stringify(req.query)));
+    } catch {}
+  }
+  if (req.params && typeof req.params === "object") {
+    try {
+      req.params = JSON.parse(scrubLogOutput(JSON.stringify(req.params)));
+    } catch {}
+  }
+  if (typeof next === "function") next();
 }
 
 /** Wrap any pino destination so regex scrubbing runs before the transport prints. */
@@ -260,12 +318,16 @@ const logger: Logger = pino(
       paths: [
         ...REDACT_KEYS,
         ...PII_MASTER_KEY_FIELDS,
+        ...PII_USER_FIELDS,
         ...REDACT_KEYS.map((key) => `*.${key}`),
         ...PII_MASTER_KEY_FIELDS.map((key) => `*.${key}`),
+        ...PII_USER_FIELDS.map((key) => `*.${key}`),
         ...REDACT_KEYS.map((key) => `req.headers.${key}`),
         ...REDACT_KEYS.map((key) => `*.req.headers.${key}`),
         ...PII_MASTER_KEY_FIELDS.map((key) => `req.headers.${key}`),
         ...PII_MASTER_KEY_FIELDS.map((key) => `*.req.headers.${key}`),
+        ...PII_USER_FIELDS.map((key) => `req.headers.${key}`),
+        ...PII_USER_FIELDS.map((key) => `*.req.headers.${key}`),
       ],
       censor: SCRUB_CENSOR,
     },


### PR DESCRIPTION
This PR implements log sanitization middleware and log formatters to ensure user names, emails, and phone numbers are scrubbed from error logs before writing to console/file.

closes #1578