### PR TITLE
Send email/SMS alerts to admins on low provider settlement balances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -257,6 +257,24 @@ PROVIDER_MOCK_DELAY_MS=0
 PROVIDER_MOCK_BALANCE=100000
 PROVIDER_MOCK_CURRENCY=XAF
 
+# ---------------------------------------------------------------------------
+# Provider Settlement Balance Alerts
+# ---------------------------------------------------------------------------
+# Cron schedule for checking MTN/Airtel settlement balances (default: every 10 minutes).
+PROVIDER_BALANCE_ALERT_CRON="*/10 * * * *"
+# Minimum operational balance before a provider is considered low. Per-provider
+# vars override this default.
+PROVIDER_MIN_BALANCE_THRESHOLD=1000
+MTN_MIN_BALANCE_THRESHOLD=
+AIRTEL_MIN_BALANCE_THRESHOLD=
+# Comma-separated admin recipients notified by email/SMS when a settlement
+# account drops below its threshold.
+ADMIN_ALERT_EMAILS=
+ADMIN_ALERT_PHONE_NUMBERS=
+# Optional: SendGrid template ID for the balance alert email.
+# If omitted, an inline HTML fallback is used.
+SENDGRID_BALANCE_ALERT_TEMPLATE_ID=
+
 ORANGE_API_KEY=your_orange_api_key
 ORANGE_API_SECRET=your_orange_api_secret
 

--- a/src/jobs/balances.ts
+++ b/src/jobs/balances.ts
@@ -1,6 +1,7 @@
 import logger from "../utils/logger";
 import { AirtelService } from "../services/mobilemoney/providers/airtel";
 import { MTNProvider } from "../services/mobilemoney/providers/mtn";
+import { sendAdminBalanceAlert } from "../services/notifications";
 
 type ProviderName = "mtn" | "airtel";
 
@@ -131,29 +132,30 @@ export async function runProviderBalanceAlertJob(): Promise<void> {
     return;
   }
 
+  await sendAdminBalanceAlert(lowBalances);
+
   const webhookUrls = resolveAlertWebhookUrls();
 
   if (webhookUrls.length === 0) {
     console.warn(
       "[balances] Low provider balances detected but no alert webhook URL is configured",
     );
-    return;
-  }
+  } else {
+    const payload: AlertPayload = {
+      alertType: "provider_balance_low",
+      severity: "warning",
+      generatedAt: new Date().toISOString(),
+      providers: lowBalances,
+    };
 
-  const payload: AlertPayload = {
-    alertType: "provider_balance_low",
-    severity: "warning",
-    generatedAt: new Date().toISOString(),
-    providers: lowBalances,
-  };
-
-  for (const webhookUrl of webhookUrls) {
-    try {
-      await postAlert(webhookUrl, payload);
-    } catch (error) {
-      logger.error(
-        `[balances] Failed to send balance alert to ${webhookUrl}: ${toErrorMessage(error)}`,
-      );
+    for (const webhookUrl of webhookUrls) {
+      try {
+        await postAlert(webhookUrl, payload);
+      } catch (error) {
+        logger.error(
+          `[balances] Failed to send balance alert to ${webhookUrl}: ${toErrorMessage(error)}`,
+        );
+      }
     }
   }
 

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -1,0 +1,110 @@
+import { sendAdminBalanceAlert, type LowBalanceAlert } from "../notifications";
+
+jest.mock("../email", () => {
+  const mockEmailService = {
+    sendAdminBalanceAlert: jest.fn(),
+  };
+  (global as any).mockEmailService = mockEmailService;
+  return {
+    emailService: mockEmailService,
+  };
+});
+
+jest.mock("../sms", () => {
+  const mockSmsService = {
+    sendToPhone: jest.fn(),
+  };
+  (global as any).mockSmsService = mockSmsService;
+  return {
+    smsService: mockSmsService,
+  };
+});
+
+const mockEmailService = (global as any).mockEmailService;
+const mockSmsService = (global as any).mockSmsService;
+
+const alerts: LowBalanceAlert[] = [
+  {
+    provider: "mtn",
+    availableBalance: 250,
+    currency: "XAF",
+    threshold: 1000,
+  },
+];
+
+describe("sendAdminBalanceAlert", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    mockEmailService.sendAdminBalanceAlert.mockResolvedValue(undefined);
+    mockSmsService.sendToPhone.mockResolvedValue({ sent: true });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("does nothing when there are no alerts", async () => {
+    await sendAdminBalanceAlert([]);
+
+    expect(mockEmailService.sendAdminBalanceAlert).not.toHaveBeenCalled();
+    expect(mockSmsService.sendToPhone).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no admin recipients are configured", async () => {
+    delete process.env.ADMIN_ALERT_EMAILS;
+    delete process.env.ADMIN_ALERT_PHONE_NUMBERS;
+
+    await sendAdminBalanceAlert(alerts);
+
+    expect(mockEmailService.sendAdminBalanceAlert).not.toHaveBeenCalled();
+    expect(mockSmsService.sendToPhone).not.toHaveBeenCalled();
+  });
+
+  it("emails every configured admin recipient", async () => {
+    process.env.ADMIN_ALERT_EMAILS = "ops@example.com, treasury@example.com";
+    delete process.env.ADMIN_ALERT_PHONE_NUMBERS;
+
+    await sendAdminBalanceAlert(alerts);
+
+    expect(mockEmailService.sendAdminBalanceAlert).toHaveBeenCalledTimes(2);
+    expect(mockEmailService.sendAdminBalanceAlert).toHaveBeenCalledWith(
+      "ops@example.com",
+      alerts,
+    );
+    expect(mockEmailService.sendAdminBalanceAlert).toHaveBeenCalledWith(
+      "treasury@example.com",
+      alerts,
+    );
+  });
+
+  it("texts every configured admin phone number", async () => {
+    delete process.env.ADMIN_ALERT_EMAILS;
+    process.env.ADMIN_ALERT_PHONE_NUMBERS = "+237600000000,+237611111111";
+
+    await sendAdminBalanceAlert(alerts);
+
+    expect(mockSmsService.sendToPhone).toHaveBeenCalledTimes(2);
+    expect(mockSmsService.sendToPhone).toHaveBeenCalledWith(
+      "+237600000000",
+      expect.stringContaining("MTN"),
+    );
+    expect(mockSmsService.sendToPhone).toHaveBeenCalledWith(
+      "+237611111111",
+      expect.stringContaining("MTN"),
+    );
+  });
+
+  it("does not throw when a delivery channel fails", async () => {
+    process.env.ADMIN_ALERT_EMAILS = "ops@example.com";
+    process.env.ADMIN_ALERT_PHONE_NUMBERS = "+237600000000";
+    mockEmailService.sendAdminBalanceAlert.mockRejectedValue(
+      new Error("SendGrid down"),
+    );
+    mockSmsService.sendToPhone.mockRejectedValue(new Error("Twilio down"));
+
+    await expect(sendAdminBalanceAlert(alerts)).resolves.toBeUndefined();
+  });
+});

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -26,6 +26,13 @@ export interface EmailOptions {
   }>;
 }
 
+export interface LowBalanceAlert {
+  provider: string;
+  availableBalance: number;
+  currency: string;
+  threshold: number;
+}
+
 export interface VulnerabilityReport {
   total: number;
   critical: number;
@@ -175,6 +182,84 @@ export class EmailService {
       }
     } catch (error) {
       logger.error("[Email] Lockout notification delivery failed:", error);
+    }
+  }
+
+  async sendAdminBalanceAlert(
+    email: string,
+    alerts: LowBalanceAlert[],
+  ): Promise<void> {
+    if (process.env.NODE_ENV === "test") {
+      console.log("Skipping balance alert email in test environment");
+      return;
+    }
+
+    const templateId = process.env.SENDGRID_BALANCE_ALERT_TEMPLATE_ID;
+    const from =
+      process.env.EMAIL_FROM || '"Mobile Money" <no-reply@mobilemoney.com>';
+    const generatedAt = new Date().toLocaleString();
+
+    try {
+      if (templateId) {
+        await sgMail.send({
+          from,
+          to: email,
+          templateId,
+          dynamicTemplateData: {
+            alerts,
+            generatedAt,
+            year: new Date().getFullYear(),
+          },
+        });
+      } else {
+        // Inline HTML fallback — no template required in SendGrid.
+        const rows = alerts
+          .map(
+            (alert) =>
+              `<tr>
+                <td style="padding:6px 8px;border-bottom:1px solid #eee;">${alert.provider.toUpperCase()}</td>
+                <td style="padding:6px 8px;border-bottom:1px solid #eee;text-align:right;">${alert.availableBalance.toFixed(2)} ${alert.currency}</td>
+                <td style="padding:6px 8px;border-bottom:1px solid #eee;text-align:right;">${alert.threshold.toFixed(2)} ${alert.currency}</td>
+              </tr>`,
+          )
+          .join("");
+
+        await sgMail.send({
+          from,
+          to: email,
+          subject: `Low settlement balance alert: ${alerts.map((alert) => alert.provider.toUpperCase()).join(", ")}`,
+          html: `
+            <div style="font-family:sans-serif;max-width:560px;margin:0 auto">
+              <h2 style="color:#c0392b">Low Settlement Balance Alert</h2>
+              <p>The following provider settlement account(s) have dropped below their configured minimum threshold:</p>
+              <table style="width:100%;border-collapse:collapse;">
+                <tr style="text-align:left;">
+                  <th style="padding:6px 8px;border-bottom:2px solid #c0392b;">Provider</th>
+                  <th style="padding:6px 8px;border-bottom:2px solid #c0392b;text-align:right;">Balance</th>
+                  <th style="padding:6px 8px;border-bottom:2px solid #c0392b;text-align:right;">Threshold</th>
+                </tr>
+                ${rows}
+              </table>
+              <p style="color:#666;font-size:13px;">Generated at: ${generatedAt}</p>
+              <hr style="border:none;border-top:1px solid #eee;margin:24px 0">
+              <p style="color:#999;font-size:12px">
+                &copy; ${new Date().getFullYear()} Mobile Money. This is an automated treasury notification.
+              </p>
+            </div>
+          `,
+          text:
+            `Low Settlement Balance Alert\n\n` +
+            alerts
+              .map(
+                (alert) =>
+                  `${alert.provider.toUpperCase()}: ${alert.availableBalance.toFixed(2)} ${alert.currency} (threshold: ${alert.threshold.toFixed(2)} ${alert.currency})`,
+              )
+              .join("\n") +
+            `\n\nGenerated at: ${generatedAt}`,
+        });
+      }
+    } catch (error) {
+      logger.error("[Email] Balance alert delivery failed:", error);
     }
   }
 

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,0 +1,74 @@
+import logger from "../utils/logger";
+import { emailService, type LowBalanceAlert } from "./email";
+import { smsService } from "./sms";
+
+export type { LowBalanceAlert };
+
+function parseRecipientList(value: string | undefined): string[] {
+  return (value || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function getAdminAlertEmails(): string[] {
+  return parseRecipientList(process.env.ADMIN_ALERT_EMAILS);
+}
+
+function getAdminAlertPhoneNumbers(): string[] {
+  return parseRecipientList(process.env.ADMIN_ALERT_PHONE_NUMBERS);
+}
+
+function buildBalanceAlertSmsBody(alerts: LowBalanceAlert[]): string {
+  const summary = alerts
+    .map(
+      (alert) =>
+        `${alert.provider.toUpperCase()} ${alert.availableBalance.toFixed(2)} ${alert.currency} (min ${alert.threshold.toFixed(2)})`,
+    )
+    .join("; ");
+  return `Mobile Money Alert: Low settlement balance - ${summary}`;
+}
+
+/**
+ * Notify configured administrators by email and SMS that one or more
+ * provider settlement accounts have dropped below their configured minimum
+ * threshold. Recipients come from the comma-separated ADMIN_ALERT_EMAILS and
+ * ADMIN_ALERT_PHONE_NUMBERS env vars. Delivery failures are logged and never
+ * thrown, so a notification outage never blocks the balance check job.
+ */
+export async function sendAdminBalanceAlert(
+  alerts: LowBalanceAlert[],
+): Promise<void> {
+  if (alerts.length === 0) return;
+
+  const emails = getAdminAlertEmails();
+  const phoneNumbers = getAdminAlertPhoneNumbers();
+
+  if (emails.length === 0 && phoneNumbers.length === 0) {
+    logger.warn(
+      "[notifications] Low balance alert triggered but no ADMIN_ALERT_EMAILS or ADMIN_ALERT_PHONE_NUMBERS are configured",
+    );
+    return;
+  }
+
+  const smsBody = buildBalanceAlertSmsBody(alerts);
+
+  await Promise.all([
+    ...emails.map((to) =>
+      emailService.sendAdminBalanceAlert(to, alerts).catch((error) => {
+        logger.error(
+          `[notifications] Failed to send balance alert email to ${to}:`,
+          error,
+        );
+      }),
+    ),
+    ...phoneNumbers.map((to) =>
+      smsService.sendToPhone(to, smsBody).catch((error) => {
+        logger.error(
+          `[notifications] Failed to send balance alert SMS to ${to}:`,
+          error,
+        );
+      }),
+    ),
+  ]);
+}


### PR DESCRIPTION
## Summary
- Adds `src/services/notifications.ts`, a thin orchestrator that emails and texts configured admin recipients (`ADMIN_ALERT_EMAILS` / `ADMIN_ALERT_PHONE_NUMBERS`, comma-separated) whenever provider settlement balances are low.
- Adds `EmailService.sendAdminBalanceAlert` (SendGrid template or inline HTML fallback, matching the existing `sendAccountLockoutNotification` pattern) and reuses the existing `smsService.sendToPhone` for SMS delivery.
- Wires the new notifier into the existing `runProviderBalanceAlertJob` (`src/jobs/balances.ts`), which already checks MTN/Airtel operational balances against configurable thresholds on a cron (`PROVIDER_BALANCE_ALERT_CRON`, default every 10 minutes) — it previously only posted to a generic webhook. Email/SMS now fires independently of webhook configuration.
- Documents the new env vars in `.env.example`.


Closes #1555