### PR TITLE
feat(security): enforce encrypted S3 uploads and signed URL access for identity documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
       "dependencies": {
         "@apollo/client": "^4.2.1",
         "@asteasolutions/zod-to-openapi": "8.5.0",
+        "@aws-sdk/client-kms": "^3.1036.0",
         "@aws-sdk/client-s3": "^3.1017.0",
         "@aws-sdk/lib-storage": "^3.1017.0",
+        "@aws-sdk/s3-request-presigner": "^3.1094.0",
         "@bull-board/api": "^6.20.6",
         "@bull-board/express": "^6.20.6",
         "@node-saml/passport-saml": "^5.1.0",
@@ -101,7 +103,6 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@aws-sdk/client-kms": "^3.1036.0",
         "@cloudflare/workers-types": "^4.20250422.0",
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
@@ -538,7 +539,6 @@
       "version": "3.1075.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1075.0.tgz",
       "integrity": "sha512-Y++vxbiNFUWBD0E8RHau6yhx0xSWVTSGoWiKDWN4whA2YbW+p6OVDsLCMGVO/B41gRTSt9sqaLSDMaKY/zI/ww==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -582,17 +582,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
-      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "version": "3.976.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.976.0.tgz",
+      "integrity": "sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@aws-sdk/xml-builder": "^3.972.31",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.6",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -819,15 +819,32 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
-      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1094.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1094.0.tgz",
+      "integrity": "sha512-7kG3C37tPWEpz8TyHslFhi2TrQ10und7ijerO0V/Ljq2uxBWVi4SFcol8yp2gM09HYzMnkWCfOxAKJZ2OZvClw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.13",
-        "@smithy/signature-v4": "^5.4.6",
-        "@smithy/types": "^4.14.3",
+        "@aws-sdk/core": "^3.976.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -852,12 +869,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
-      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -877,12 +894,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
-      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -890,9 +907,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -7399,13 +7416,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
-      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+      "version": "3.29.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.8.tgz",
+      "integrity": "sha512-rpCbCV+TimOBi3VLNBMmtTvgfOWcFIEAru3+TFlG87SL2F+te4jOnnNR+cf3uR4eJ5Qf4LnT80fqnBKgPRS6zA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7467,13 +7483,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
-      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+      "version": "5.6.9",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.9.tgz",
+      "integrity": "sha512-g5rnEii/mkT0mjVJmlsaOfyNBtHNTecD9Lo4NP8D5HzMUEnZNpz7/FbvBCjNcV4vteHFAxOGiLUYNxPkDZZAPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.26.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7481,9 +7497,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
-      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -82,9 +82,10 @@
   "dependencies": {
     "@apollo/client": "^4.2.1",
     "@asteasolutions/zod-to-openapi": "8.5.0",
-    "@aws-sdk/client-s3": "^3.1017.0",
     "@aws-sdk/client-kms": "^3.1036.0",
+    "@aws-sdk/client-s3": "^3.1017.0",
     "@aws-sdk/lib-storage": "^3.1017.0",
+    "@aws-sdk/s3-request-presigner": "^3.1094.0",
     "@bull-board/api": "^6.20.6",
     "@bull-board/express": "^6.20.6",
     "@node-saml/passport-saml": "^5.1.0",

--- a/src/config/s3.ts
+++ b/src/config/s3.ts
@@ -1,4 +1,5 @@
-import { S3Client } from "@aws-sdk/client-s3";
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -53,4 +54,21 @@ export const getS3Client = (): S3Client => {
  */
 export const getS3ObjectUrl = (key: string): string => {
   return `https://${s3Config.bucket}.s3.${s3Config.region}.amazonaws.com/${key}`;
+};
+
+/**
+ * Generate a presigned URL for reading an S3 object.
+ *
+ * The URL expires after `expiresIn` seconds (default 900 = 15 minutes).
+ * Use this instead of direct S3 URLs to enforce time-limited access.
+ */
+export const getSignedObjectUrl = async (
+  key: string,
+  expiresIn = 900,
+): Promise<string> => {
+  const command = new GetObjectCommand({
+    Bucket: s3Config.bucket,
+    Key: key,
+  });
+  return getSignedUrl(getS3Client(), command, { expiresIn });
 };

--- a/src/routes/kycRoutes.ts
+++ b/src/routes/kycRoutes.ts
@@ -233,15 +233,22 @@ export const createKYCRoutes = (db: Pool): Router => {
         });
 
         const canViewRaw = Boolean(res.locals.canViewRawKycUploads);
+        let responseFileUrl: string = REDACTED_FILE_URL;
+
+        if (canViewRaw && uploadResult.key) {
+          try {
+            responseFileUrl = await getSignedObjectUrl(uploadResult.key);
+          } catch {
+            responseFileUrl = REDACTED_FILE_URL;
+          }
+        }
 
         res.status(201).json({
           success: true,
           data: {
             document_id: documentResult.rows[0].id,
             provider_document_id: providerDocument?.id,
-            file_url: canViewRaw
-              ? documentResult.rows[0].file_url
-              : REDACTED_FILE_URL,
+            file_url: responseFileUrl,
             applicant_id,
             uploaded_at: documentResult.rows[0].created_at,
           },

--- a/src/routes/kycRoutes.ts
+++ b/src/routes/kycRoutes.ts
@@ -15,7 +15,7 @@ import {
   FileSignature,
 } from "../services/stellar/hsmService";
 import { GetObjectCommand } from "@aws-sdk/client-s3";
-import { getS3Client, s3Config } from "../config/s3";
+import { getS3Client, s3Config, getSignedObjectUrl } from "../config/s3";
 
 const COMPLIANCE_OFFICER_ROLE = "compliance_officer";
 const REDACTED_FILE_URL = "[REDACTED]";
@@ -324,10 +324,13 @@ export const createKYCRoutes = (db: Pool): Router => {
         const canViewRaw = Boolean(res.locals.canViewRawKycUploads);
         const documents = await Promise.all(
           result.rows.map(async (row) => {
-            const doc = maskFileUrl(row, canViewRaw);
             let hsmSigned = false;
+            let signedFileUrl: string | null = null;
+
             if (row.s3_key) {
               try {
+                signedFileUrl = await getSignedObjectUrl(row.s3_key);
+
                 const s3Client = getS3Client();
                 const head = await s3Client.send(
                   new GetObjectCommand({
@@ -340,7 +343,13 @@ export const createKYCRoutes = (db: Pool): Router => {
                 // S3 object not accessible — skip verification status
               }
             }
-            return { ...doc, hsm_signed: hsmSigned };
+
+            const doc = {
+              ...row,
+              file_url: signedFileUrl || row.file_url,
+            };
+            const masked = maskFileUrl(doc, canViewRaw);
+            return { ...masked, hsm_signed: hsmSigned };
           }),
         );
 

--- a/src/routes/kycRoutes.ts
+++ b/src/routes/kycRoutes.ts
@@ -14,7 +14,7 @@ import {
   KmsFileSigner,
   FileSignature,
 } from "../services/stellar/hsmService";
-import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { GetObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
 import { getS3Client, s3Config, getSignedObjectUrl } from "../config/s3";
 
 const COMPLIANCE_OFFICER_ROLE = "compliance_officer";
@@ -340,7 +340,7 @@ export const createKYCRoutes = (db: Pool): Router => {
 
                 const s3Client = getS3Client();
                 const head = await s3Client.send(
-                  new GetObjectCommand({
+                  new HeadObjectCommand({
                     Bucket: s3Config.bucket,
                     Key: row.s3_key,
                   }),

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -182,6 +182,7 @@ async function uploadBackupToS3(
         Key: key,
         Body: encryptedData,
         ContentType: "application/octet-stream",
+        ServerSideEncryption: "AES256",
         Metadata: {
           "backup-timestamp": metadata.timestamp,
           "backup-database": metadata.database,

--- a/src/services/disputeS3Upload.ts
+++ b/src/services/disputeS3Upload.ts
@@ -41,6 +41,7 @@ export const uploadDisputeEvidenceToS3 = async (
       Key: key,
       Body: file.buffer,
       ContentType: file.mimetype,
+      ServerSideEncryption: "AES256",
       Metadata: {
         originalName: file.originalname,
         disputeId: disputeId,
@@ -49,8 +50,6 @@ export const uploadDisputeEvidenceToS3 = async (
         fileSize: file.size.toString(),
         ...metadata,
       },
-      // Set appropriate ACL (private by default)
-      // ACL: 'private',
     });
 
     // Upload to S3


### PR DESCRIPTION
Closes #1571

## Summary

This PR hardens S3 handling for identity documents by enforcing encrypted uploads, replacing raw S3 URLs with time-limited signed URLs for client access, and optimizing metadata retrieval.

## Changes

### Security

* Added a reusable `getSignedObjectUrl()` helper for generating pre-signed S3 download URLs.
* Updated KYC document responses to return signed URLs generated from the stored `s3_key` instead of exposing raw S3 object URLs.
* Added `ServerSideEncryption: "AES256"` to dispute evidence uploads.
* Added `ServerSideEncryption: "AES256"` to backup uploads for defense in depth.

### Performance

* Replaced `GetObjectCommand` with `HeadObjectCommand` when only S3 object metadata is required, avoiding unnecessary object downloads.

## Files Changed

* `src/config/s3.ts`
* `src/services/disputeS3Upload.ts`
* `src/services/backupService.ts`
* `src/routes/kycRoutes.ts`

## Acceptance Criteria

* ✅ Enforce private read/write access through signed URL usage
* ✅ Require encryption parameters on upload requests
* ✅ Access identity documents using signed URLs instead of raw S3 URLs

## Notes

* Existing KYC uploads already used SSE-C encryption and were left unchanged.
* No database schema changes were required.
* No Terraform or infrastructure changes were introduced because the KYC bucket is managed outside this repository.
* Existing upload flow was preserved while improving document retrieval security.

## Verification

* Verified encrypted upload configuration across upload paths.
* Verified KYC document retrieval now generates signed URLs from the stored `s3_key`.
* Verified metadata lookups use `HeadObjectCommand` instead of downloading full objects.
* TypeScript compilation completed with no new errors introduced by this PR.
