### PR TITLE
feat(stellar): add Soroban contract state archiver

### DIFF
--- a/database/migrations/20260724_create_contract_state_archives.sql
+++ b/database/migrations/20260724_create_contract_state_archives.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS contract_state_archives (
+  id BIGSERIAL PRIMARY KEY,
+  contract_id TEXT NOT NULL,
+  tx_hash TEXT NOT NULL,
+  ledger BIGINT NOT NULL,
+  event_type TEXT NOT NULL,
+  event_name TEXT,
+  event_details JSONB,
+  snapshot_data JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contract_state_archives_contract_id_created_at
+  ON contract_state_archives (contract_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_contract_state_archives_tx_hash
+  ON contract_state_archives (tx_hash);

--- a/src/database/contractStateArchiveRepository.ts
+++ b/src/database/contractStateArchiveRepository.ts
@@ -1,0 +1,86 @@
+import { pool } from "../config/database";
+import { QueryResult } from "pg";
+
+export interface ContractStateArchiveRecord {
+  id?: number;
+  contractId: string;
+  txHash: string;
+  ledger: number;
+  eventType: string;
+  eventName?: string | null;
+  eventDetails?: Record<string, any> | null;
+  snapshotData?: Record<string, any> | null;
+  createdAt?: Date;
+}
+
+export interface ContractStateArchiveRow {
+  id: number;
+  contract_id: string;
+  tx_hash: string;
+  ledger: number;
+  event_type: string;
+  event_name: string | null;
+  event_details: Record<string, any> | null;
+  snapshot_data: Record<string, any> | null;
+  created_at: Date;
+}
+
+export async function insertContractStateArchive(
+  archive: ContractStateArchiveRecord,
+): Promise<QueryResult<any>> {
+  const query = `
+    INSERT INTO contract_state_archives (
+      contract_id,
+      tx_hash,
+      ledger,
+      event_type,
+      event_name,
+      event_details,
+      snapshot_data,
+      created_at
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    ON CONFLICT DO NOTHING;
+  `;
+
+  const values = [
+    archive.contractId,
+    archive.txHash,
+    archive.ledger,
+    archive.eventType,
+    archive.eventName ?? null,
+    JSON.stringify(archive.eventDetails ?? {}),
+    JSON.stringify(archive.snapshotData ?? {}),
+    archive.createdAt ?? new Date(),
+  ];
+
+  return pool.query(query, values);
+}
+
+export async function getContractStateArchiveHistory(
+  contractId: string,
+  limit: number = 20,
+): Promise<ContractStateArchiveRecord[]> {
+  const result = await pool.query<ContractStateArchiveRow>(
+    `
+      SELECT id, contract_id, tx_hash, ledger, event_type, event_name, event_details, snapshot_data, created_at
+      FROM contract_state_archives
+      WHERE contract_id = $1
+      ORDER BY created_at DESC, id DESC
+      LIMIT $2;
+    `,
+    [contractId, limit],
+  );
+
+  return (result.rows || []).map((row) => ({
+    id: row.id,
+    contractId: row.contract_id,
+    txHash: row.tx_hash,
+    ledger: row.ledger,
+    eventType: row.event_type,
+    eventName: row.event_name,
+    eventDetails: row.event_details ?? undefined,
+    snapshotData: row.snapshot_data ?? undefined,
+    createdAt: row.created_at,
+  }));
+}

--- a/src/services/stellar/__tests__/contractArchiver.test.ts
+++ b/src/services/stellar/__tests__/contractArchiver.test.ts
@@ -1,0 +1,64 @@
+import { pool } from "../../../config/database";
+import {
+  getContractStateArchiveHistory,
+  insertContractStateArchive,
+} from "../../../database/contractStateArchiveRepository";
+
+jest.mock("../../../config/database", () => ({
+  pool: {
+    query: jest.fn(),
+  },
+}));
+
+describe("contract state archive repository", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("persists contract state snapshots and returns them safely for recovery", async () => {
+    const mockedPool = pool as jest.Mocked<typeof pool>;
+
+    mockedPool.query
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] } as any)
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            id: 42,
+            contract_id: "CA_TEST",
+            tx_hash: "tx123",
+            ledger: 99,
+            event_type: "contract_event",
+            event_name: "updated",
+            event_details: { type: "updated", counter: 2 },
+            snapshot_data: { state: "archived", counter: 2 },
+            created_at: "2026-07-24T12:00:00.000Z",
+          },
+        ],
+      } as any);
+
+    await expect(
+      insertContractStateArchive({
+        contractId: "CA_TEST",
+        txHash: "tx123",
+        ledger: 99,
+        eventType: "contract_event",
+        eventName: "updated",
+        eventDetails: { type: "updated", counter: 2 },
+        snapshotData: { state: "archived", counter: 2 },
+        createdAt: new Date("2026-07-24T12:00:00.000Z"),
+      }),
+    ).resolves.toBeDefined();
+
+    const history = await getContractStateArchiveHistory("CA_TEST", 5);
+
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({
+      contractId: "CA_TEST",
+      txHash: "tx123",
+      eventName: "updated",
+      eventDetails: { type: "updated", counter: 2 },
+      snapshotData: { state: "archived", counter: 2 },
+    });
+  });
+});

--- a/src/services/stellar/contractArchiver.ts
+++ b/src/services/stellar/contractArchiver.ts
@@ -1,0 +1,93 @@
+import { getStellarServer } from "../../config/stellar";
+import { insertContractStateArchive } from "../../database/contractStateArchiveRepository";
+import EventSource from "eventsource";
+
+export interface ContractArchiverConfig {
+  contractId?: string;
+  streamUrl?: string;
+}
+
+export interface ContractStateArchivePayload {
+  contractId: string;
+  txHash: string;
+  ledger: number;
+  eventType: string;
+  eventName?: string | null;
+  eventDetails?: Record<string, any> | null;
+  snapshotData?: Record<string, any> | null;
+  createdAt?: Date;
+}
+
+export class ContractArchiverService {
+  private readonly contractId: string;
+  private readonly horizon: any;
+  private readonly streamUrl: string;
+
+  constructor(config: ContractArchiverConfig = {}) {
+    this.horizon = getStellarServer();
+    this.contractId = config.contractId || process.env.SOROBAN_CONTRACT_ID || "";
+    const horizonUrl = (this.horizon as any).serverURL || (this.horizon as any).host;
+    this.streamUrl =
+      config.streamUrl ||
+      `${horizonUrl}/accounts/${this.contractId}/transactions?cursor=now&limit=200&order=asc`;
+  }
+
+  start(): void {
+    if (!this.contractId) {
+      console.warn("SOROBAN_CONTRACT_ID not set – contract state archiver disabled");
+      return;
+    }
+
+    const eventSource = new EventSource(this.streamUrl);
+
+    eventSource.onmessage = async (msg) => {
+      try {
+        const data = JSON.parse(msg.data);
+        if (!data || !data._embedded?.records) return;
+
+        for (const tx of data._embedded.records) {
+          const operationsResponse = await this.horizon
+            .operations()
+            .forTransaction(tx.id)
+            .call();
+
+          for (const op of operationsResponse.records) {
+            const operation = op as any;
+            if (operation.type !== "contract_event") continue;
+            if (operation.contract !== this.contractId) continue;
+
+            const payload: ContractStateArchivePayload = {
+              contractId: this.contractId,
+              txHash: tx.hash,
+              ledger: tx.ledger_seq,
+              eventType: operation.type,
+              eventName: operation.value?.type || operation.value?.name || null,
+              eventDetails: operation.value?.payload || operation.value || null,
+              snapshotData: {
+                contract: this.contractId,
+                txHash: tx.hash,
+                ledger: tx.ledger_seq,
+                value: operation.value || {},
+              },
+              createdAt: new Date(),
+            };
+
+            await insertContractStateArchive(payload);
+          }
+        }
+      } catch (error) {
+        console.error("Contract state archiver failed to process event", error);
+      }
+    };
+
+    eventSource.onerror = (error) => {
+      console.error("Contract state archiver stream error", error);
+      setTimeout(() => this.start(), 5000);
+    };
+  }
+}
+
+export function initializeContractArchiver() {
+  const service = new ContractArchiverService();
+  service.start();
+}

--- a/src/services/stellar/stellarService.ts
+++ b/src/services/stellar/stellarService.ts
@@ -644,8 +644,10 @@ export class StellarService {
 
 // Added startEventSubscription to initialize Horizon event subscription
 import { startEventSubscription } from "./escrowEventSubscriber";
+import { initializeContractArchiver } from "./contractArchiver";
 
 // Export function to start event subscription (called from application bootstrap)
 export function initializeEscrowEventProcessing() {
   startEventSubscription();
+  initializeContractArchiver();
 }


### PR DESCRIPTION
## Summary

- add a background Soroban contract event archiver that listens for Horizon contract events and persists snapshots for recovery
- store contract state archive records with transaction, ledger, event payload, and snapshot data in Postgres
- expose a repository helper to read archived history safely for replay/recovery workflows
- add regression coverage for archive persistence and recovery history retrieval

## Testing

- npm test -- --runTestsByPath src/services/stellar/__tests__/contractArchiver.test.ts --runInBand
- npm run type-check

Closes #1627