### PR TITLE
feat(frontend): add Light, Carbon, and Dark theme toggle

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,3 +1,31 @@
+// Theme Management
+function setTheme(theme) {
+  document.documentElement.dataset.theme = theme;
+  document.querySelectorAll(".theme-switcher button").forEach(btn => {
+    const active = btn.dataset.theme === theme;
+    btn.classList.toggle("active", active);
+    btn.setAttribute("aria-pressed", active);
+  });
+}
+
+function saveTheme(theme) {
+  localStorage.setItem("theme", theme);
+  setTheme(theme);
+}
+
+function loadTheme() {
+  const saved = localStorage.getItem("theme") || "carbon";
+  setTheme(saved);
+}
+
+// Initialize theme before anything else
+loadTheme();
+
+// Theme switcher event listeners
+document.querySelectorAll(".theme-switcher button").forEach(btn => {
+  btn.addEventListener("click", () => saveTheme(btn.dataset.theme));
+});
+
 // Live API Status Polling
 async function updateSystemStatus() {
   const dot = document.getElementById("status-dot");

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,11 @@
         <span class="status-dot pulsing" id="status-dot"></span>
         <span class="status-text" id="status-text">Checking system status...</span>
       </div>
+      <div class="theme-switcher" role="group" aria-label="Theme selector">
+        <button data-theme="light" aria-label="Light theme">Light</button>
+        <button data-theme="carbon" aria-label="Carbon theme">Carbon</button>
+        <button data-theme="dark" aria-label="Dark theme">Dark</button>
+      </div>
     </div>
   </header>
 
@@ -260,6 +265,6 @@
     </div>
   </footer>
 
-  <script src="/app.js?v=2"></script>
+  <script src="/app.js?v=3"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -34,6 +34,7 @@
 
 html {
   scroll-behavior: smooth;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 body {
@@ -735,6 +736,133 @@ body {
 
 .step-item p a:hover {
   text-decoration: underline;
+}
+
+/* Theme Switcher */
+.theme-switcher {
+  display: flex;
+  gap: 2px;
+  background-color: rgba(255, 255, 255, 0.04);
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  padding: 3px;
+}
+
+.theme-switcher button {
+  background: transparent;
+  border: none;
+  color: hsl(var(--text-muted));
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.theme-switcher button:hover {
+  color: hsl(var(--text-primary));
+}
+
+.theme-switcher button.active {
+  background-color: hsl(var(--primary));
+  color: hsl(var(--bg-dark));
+}
+
+/* Theme Overrides */
+html[data-theme="light"] {
+  --bg-dark: 0 0% 98%;
+  --bg-card: 0 0% 100%;
+  --bg-card-hover: 0 0% 96%;
+  --text-primary: 240 10% 8%;
+  --text-secondary: 240 5% 35%;
+  --text-muted: 240 5% 50%;
+  --border: 240 6% 85%;
+  --border-glow: 180 100% 35% / 0.1;
+}
+
+html[data-theme="dark"] {
+  --bg-dark: 0 0% 3%;
+  --bg-card: 0 0% 6%;
+  --bg-card-hover: 0 0% 10%;
+  --text-primary: 0 0% 100%;
+  --text-secondary: 0 0% 60%;
+  --text-muted: 0 0% 40%;
+  --border: 0 0% 12%;
+  --border-glow: 180 100% 35% / 0.2;
+}
+
+/* Light Theme — Semantic Element Overrides */
+html[data-theme="light"] .app-header {
+  background-color: rgba(255, 255, 255, 0.85);
+  border-bottom-color: hsl(var(--border));
+}
+
+html[data-theme="light"] .glass {
+  background: rgba(255, 255, 255, 0.75);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+html[data-theme="light"] .step-item:hover {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+html[data-theme="light"] .app-footer {
+  background-color: #f5f5f5;
+}
+
+html[data-theme="light"] .input-wrapper {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+html[data-theme="light"] .input-wrapper select {
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+html[data-theme="light"] .calc-details {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+html[data-theme="light"] .api-tabs {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+html[data-theme="light"] .api-code-container {
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+html[data-theme="light"] .code-header {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+html[data-theme="light"] .code-block code {
+  color: #1a1a2e;
+}
+
+html[data-theme="light"] .theme-switcher {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+html[data-theme="light"] .system-status-badge {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+/* Dark Theme — Semantic Element Overrides */
+html[data-theme="dark"] .app-header {
+  background-color: rgba(0, 0, 0, 0.85);
+}
+
+html[data-theme="dark"] .glass {
+  background: rgba(10, 10, 12, 0.7);
+  border-color: rgba(255, 255, 255, 0.04);
+}
+
+html[data-theme="dark"] .app-footer {
+  background-color: #000000;
+}
+
+html[data-theme="dark"] .theme-switcher {
+  background-color: rgba(255, 255, 255, 0.03);
 }
 
 /* Responsive Rules */


### PR DESCRIPTION
Closes #1614

## Summary

Implements a landing page theme selector that allows users to switch between **Light**, **Carbon**, and **Dark** themes while preserving their preference across page reloads.

## Changes

* Added a segmented theme selector to the page header.
* Implemented Light, Carbon, and Dark themes using CSS variable overrides.
* Preserved the current appearance as the default **Carbon** theme to minimize visual regressions.
* Persisted the selected theme using `localStorage`.
* Applied the saved theme during page initialization to prevent theme flashing.
* Added accessibility improvements with `aria-label`, `aria-pressed`, and grouped controls.
* Reused the existing transition timing to provide smooth theme switching.
* Updated the frontend asset cache version.

## Acceptance Criteria

* ✅ Built selector buttons inside the user page header.
* ✅ Applied theme styles using CSS variables.
* ✅ Saved theme selections to `localStorage`.

## Notes

* Only variables that change between themes are overridden.
* Existing brand colors (`--primary`, `--secondary`, and `--success`) remain unchanged.
* The implementation is intentionally scoped to the landing page with no unrelated frontend changes.
