### PR TITLE
feat(frontend): check uptime status from health endpoint

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -32,19 +32,22 @@ async function updateSystemStatus() {
   const text = document.getElementById("status-text");
 
   try {
-    const res = await fetch("/ready");
+    const res = await fetch("/health");
     if (res.ok) {
       const data = await res.json();
-      if (data.status === "ready") {
+      if (data.status === "ok") {
         dot.className = "status-dot online";
+        text.className = "status-text online";
         text.textContent = "System: Operational";
         return;
       }
     }
     dot.className = "status-dot offline";
+    text.className = "status-text";
     text.textContent = "System: Issues Detected";
   } catch (error) {
     dot.className = "status-dot offline";
+    text.className = "status-text";
     text.textContent = "System: Offline";
   }
 }

--- a/public/style.css
+++ b/public/style.css
@@ -130,6 +130,10 @@ body {
   animation: pulse-dot-green 2s infinite;
 }
 
+.status-text.online {
+  color: hsl(var(--success));
+}
+
 .status-dot.offline {
   background-color: 0 84% 60%;
   animation: pulse-dot-red 2s infinite;


### PR DESCRIPTION
Added a live uptime indicator to the frontend that queries the /health endpoint on load. Updated the DOM to render a green status text when all modules are ready.

Closes #1620