### PR TITLE
feat(webhook): validate telecom carrier callback source IPs

### DIFF
--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -79,6 +79,12 @@ export const configSchema = convict({
         default: "",
         env: "MTN_CALLBACK_SECRET",
       },
+      allowedIps: {
+        doc: "Comma-separated list of allowed CIDR blocks for MTN callbacks",
+        format: String,
+        default: "",
+        env: "MTN_ALLOWED_IPS",
+      },
       callbackSignatureHeader: {
         doc: "Header used by MTN for callback signature verification",
         format: String,
@@ -98,6 +104,12 @@ export const configSchema = convict({
         format: "nat",
         default: 1000000,
         env: "AIRTEL_MAX_AMOUNT",
+      },
+      allowedIps: {
+        doc: "Comma-separated list of allowed CIDR blocks for Airtel callbacks",
+        format: String,
+        default: "",
+        env: "AIRTEL_ALLOWED_IPS",
       },
       webBaseUrl: {
         doc: "Airtel web base URL (session mode)",
@@ -131,6 +143,12 @@ export const configSchema = convict({
         default: 750000,
         env: "ORANGE_MAX_AMOUNT",
       },
+      allowedIps: {
+        doc: "Comma-separated list of allowed CIDR blocks for Orange callbacks",
+        format: String,
+        default: "",
+        env: "ORANGE_ALLOWED_IPS",
+      },
     },
     orangeMadagascar: {
       minAmount: {
@@ -144,6 +162,12 @@ export const configSchema = convict({
         format: "nat",
         default: 5000000,
         env: "ORANGE_MADAGASCAR_MAX_AMOUNT",
+      },
+      allowedIps: {
+        doc: "Comma-separated list of allowed CIDR blocks for Orange Madagascar callbacks",
+        format: String,
+        default: "",
+        env: "ORANGE_MADAGASCAR_ALLOWED_IPS",
       },
       callbackSecret: {
         doc: "Orange Madagascar callback HMAC secret for verifying incoming callbacks",

--- a/src/middleware/validateSourceIp.ts
+++ b/src/middleware/validateSourceIp.ts
@@ -1,0 +1,74 @@
+import { Request, Response, NextFunction } from "express";
+import ipaddr from "ipaddr.js";
+import { getConfigValue } from "../config/appConfig";
+import logger from "../utils/logger";
+
+export function validateSourceIp(provider: "mtn" | "airtel" | "orange" | "orangeMadagascar") {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const providersConfig = getConfigValue("providers");
+      const providerConfig = providersConfig[provider];
+      
+      if (!providerConfig || typeof providerConfig.allowedIps !== "string") {
+        logger.warn({ provider }, "No allowed IP configuration found for provider. Skipping IP validation.");
+        return next();
+      }
+      
+      const allowedIpsStr = providerConfig.allowedIps.trim();
+      if (!allowedIpsStr) {
+        // Empty configuration means no IP restrictions
+        return next();
+      }
+
+      const allowedBlocks = allowedIpsStr.split(",").map(ip => ip.trim()).filter(Boolean);
+      
+      let reqIp = req.ip || req.socket.remoteAddress;
+      
+      if (!reqIp) {
+        logger.warn({ provider }, "Could not determine request IP");
+        return res.status(403).json({ status: "error", message: "Forbidden: Cannot determine source IP" });
+      }
+
+      // ipaddr.js process() helps with IPv4-mapped IPv6 addresses (e.g. ::ffff:192.168.1.1)
+      let parsedReqIp;
+      try {
+        parsedReqIp = ipaddr.process(reqIp);
+      } catch (err) {
+        logger.warn({ provider, ip: reqIp }, "Failed to parse request IP");
+        return res.status(403).json({ status: "error", message: "Forbidden: Invalid IP format" });
+      }
+
+      let isAllowed = false;
+      
+      for (const block of allowedBlocks) {
+        try {
+          if (block.includes("/")) {
+            const parsedCidr = ipaddr.parseCIDR(block);
+            if (parsedReqIp.kind() === parsedCidr[0].kind() && parsedReqIp.match(parsedCidr)) {
+              isAllowed = true;
+              break;
+            }
+          } else {
+            const parsedAllowedIp = ipaddr.parse(block);
+            if (parsedReqIp.kind() === parsedAllowedIp.kind() && parsedReqIp.toString() === parsedAllowedIp.toString()) {
+              isAllowed = true;
+              break;
+            }
+          }
+        } catch (err) {
+          logger.error({ provider, block, error: err }, "Invalid allowed IP/CIDR configured");
+        }
+      }
+
+      if (!isAllowed) {
+        logger.warn({ provider, ip: reqIp }, "Request from unauthorized IP");
+        return res.status(403).json({ status: "error", message: "Forbidden: Unauthorized source IP" });
+      }
+
+      next();
+    } catch (error) {
+      logger.error({ provider, error }, "Error validating source IP");
+      return res.status(500).json({ status: "error", message: "Internal server error" });
+    }
+  };
+}

--- a/src/routes/webhookRoutes.ts
+++ b/src/routes/webhookRoutes.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { validateWebhookSignature } from "../middleware/validateWebhookSignature";
 import { ingestRateLimiter } from "../middleware/ingestRateLimit";
 import { validateRequest } from "../middleware/validation";
+import { validateSourceIp } from "../middleware/validateSourceIp";
 import logger from "../utils/logger";
 
 const router = Router();
@@ -35,6 +36,7 @@ const orangeBatchCallbackSchema = z.object({
 // MTN webhook
 router.post(
   "/mtn/callback",
+  validateSourceIp("mtn"),
   validateWebhookSignature("mtn"),
   async (req: Request, res: Response) => {
     const transactionId = req.body?.transactionId;
@@ -67,6 +69,7 @@ router.post(
 // Orange webhook
 router.post(
   "/orange/callback",
+  validateSourceIp("orange"),
   validateWebhookSignature("orange"),
   validateRequest(orangeCallbackSchema),
   async (req: Request, res: Response) => {
@@ -84,6 +87,7 @@ router.post(
 
 router.post(
   "/orange/callback/batch",
+  validateSourceIp("orange"),
   validateWebhookSignature("orange"),
   validateRequest(orangeBatchCallbackSchema),
   async (req: Request, res: Response) => {
@@ -101,6 +105,7 @@ router.post(
 // Airtel webhook
 router.post(
   "/airtel/callback",
+  validateSourceIp("airtel"),
   validateWebhookSignature("airtel"),
   async (req: Request, res: Response) => {
     logger.info(


### PR DESCRIPTION
Implements validation for telecom carrier callback source IPs by loading allowed IP ranges from config files and returning 403 Forbidden for invalid origins.

Closes #1633