### PR TITLE
Feature: Optimize WebSocket pub/sub payload sizes (#1594)

### DIFF
--- a/src/websocket/__tests__/websocketManager.test.ts
+++ b/src/websocket/__tests__/websocketManager.test.ts
@@ -2,6 +2,7 @@ import { IncomingMessage, Server } from "http";
 import { WebSocketManager } from "../websocketManager";
 import { verifyToken } from "../../auth/jwt";
 import { createClient } from "redis";
+import { TransactionModel } from "../../models/transaction";
 
 type ConnectionHandler = (ws: unknown, req: IncomingMessage) => void;
 
@@ -13,6 +14,12 @@ jest.mock("../../auth/jwt", () => ({
 
 jest.mock("redis", () => ({
   createClient: jest.fn(),
+}));
+
+jest.mock("../../models/transaction", () => ({
+  TransactionModel: jest.fn().mockImplementation(() => ({
+    findById: jest.fn(),
+  })),
 }));
 
 jest.mock("ws", () => {
@@ -44,6 +51,7 @@ type MockClient = {
   ping: jest.Mock;
   terminate: jest.Mock;
   on: jest.Mock;
+  handlers: Map<string, (...args: unknown[]) => void>;
 };
 
 function createMockClient(): MockClient {
@@ -60,6 +68,7 @@ function createMockClient(): MockClient {
     on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
       handlers.set(event, handler);
     }),
+    handlers,
   };
 
   return client;
@@ -82,6 +91,9 @@ describe("WebSocketManager", () => {
   >;
   const mockCreateClient = createClient as jest.MockedFunction<
     typeof createClient
+  >;
+  const MockTransactionModel = TransactionModel as jest.MockedClass<
+    typeof TransactionModel
   >;
 
   beforeEach(() => {
@@ -120,12 +132,60 @@ describe("WebSocketManager", () => {
       userId: "user-123",
     });
 
-    expect(client.send).toHaveBeenCalledWith(
-      expect.stringContaining('"type":"transaction.updated"'),
+    expect(JSON.parse(client.send.mock.calls[0][0] as string)).toEqual({
+      type: "transaction.updated",
+      data: { transactionId: "tx-1" },
+    });
+
+    await manager.close();
+  });
+
+  it("returns transaction details on demand for the authenticated user", async () => {
+    mockVerifyToken.mockReturnValue({
+      userId: "user-123",
+      email: "user@example.com",
+    });
+
+    const manager = new WebSocketManager({} as Server);
+    const client = createMockClient();
+
+    connectClient(client);
+
+    client.send.mockClear();
+
+    const transactionModel = MockTransactionModel.mock.instances[0] as {
+      findById: jest.Mock;
+    };
+    transactionModel.findById.mockResolvedValue({
+      id: "tx-42",
+      status: "completed",
+      userId: "user-123",
+    });
+
+    await Promise.resolve(
+      client.handlers.get("message")?.(
+        JSON.stringify({
+          type: "transaction.details",
+          data: { transactionId: "tx-42" },
+        }),
+      ),
     );
-    expect(client.send).toHaveBeenCalledWith(
-      expect.stringContaining('"id":"tx-1"'),
+
+    expect(transactionModel.findById).toHaveBeenCalledWith(
+      "tx-42",
+      "user-123",
     );
+    expect(JSON.parse(client.send.mock.calls[0][0] as string)).toEqual({
+      type: "transaction.details",
+      data: {
+        transactionId: "tx-42",
+        transaction: {
+          id: "tx-42",
+          status: "completed",
+          userId: "user-123",
+        },
+      },
+    });
 
     await manager.close();
   });
@@ -244,9 +304,7 @@ describe("WebSocketManager", () => {
         message: {
           type: "transaction.updated",
           data: {
-            id: "tx-other-instance",
-            status: "completed",
-            userId: "user-scaling",
+            transactionId: "tx-other-instance",
           },
         },
       });
@@ -255,12 +313,10 @@ describe("WebSocketManager", () => {
     }
 
     // Verify the message was delivered to the local client
-    expect(client.send).toHaveBeenCalledWith(
-      expect.stringContaining('"type":"transaction.updated"'),
-    );
-    expect(client.send).toHaveBeenCalledWith(
-      expect.stringContaining('"id":"tx-other-instance"'),
-    );
+    expect(JSON.parse(client.send.mock.calls[0][0] as string)).toEqual({
+      type: "transaction.updated",
+      data: { transactionId: "tx-other-instance" },
+    });
 
     await manager.close();
   });
@@ -376,24 +432,13 @@ describe("WebSocketManager", () => {
 
     client.send.mockClear();
 
-    // Simulate client subscribing to a transaction
-    const handlers = new Map<string, (...args: unknown[]) => void>();
-    client.on.mockImplementation(
-      (event: string, handler: (...args: unknown[]) => void) => {
-        handlers.set(event, handler);
-      },
-    );
-
     // Send subscription message
-    const messageHandler = handlers.get("message");
-    if (messageHandler) {
-      messageHandler(
-        JSON.stringify({
-          type: "subscribe",
-          data: { transactionId: "tx-sub-123" },
-        }),
-      );
-    }
+    client.handlers.get("message")?.(
+      JSON.stringify({
+        type: "subscribe",
+        data: { transactionId: "tx-sub-123" },
+      }),
+    );
 
     // Broadcast to that transaction ID
     await manager.broadcastTransactionUpdate({

--- a/src/websocket/websocketManager.ts
+++ b/src/websocket/websocketManager.ts
@@ -292,7 +292,6 @@ export class WebSocketManager {
     this.broadcastLocally(payload.id, message);
   }
 
-
   private async sendTransactionDetails(
     client: AuthenticatedWebSocket,
     transactionId: string,
@@ -316,7 +315,7 @@ export class WebSocketManager {
         data: {
           transactionId,
           transaction,
-        } as TransactionDetailsResponsePayload,
+        } satisfies TransactionDetailsResponsePayload,
       };
 
       this.sendToClient(client, response);
@@ -328,6 +327,7 @@ export class WebSocketManager {
       });
     }
   }
+
   /** Send a message to all locally-connected clients subscribed to transactionId. */
   private broadcastLocally(
     transactionId: string,

--- a/src/websocket/websocketManager.ts
+++ b/src/websocket/websocketManager.ts
@@ -3,6 +3,7 @@ import { WebSocketServer, WebSocket } from "ws";
 import { IncomingMessage, Server } from "http";
 import { createClient, RedisClientType } from "redis";
 import { verifyToken } from "../auth/jwt";
+import { TransactionModel, type Transaction } from "../models/transaction";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,6 +19,15 @@ export interface TransactionUpdatePayload {
   status: string;
   userId?: string | null;
   [key: string]: unknown;
+}
+
+interface TransactionDetailsRequestPayload {
+  transactionId: string;
+}
+
+interface TransactionDetailsResponsePayload {
+  transactionId: string;
+  transaction: Transaction | null;
 }
 
 interface AuthenticatedWebSocket extends WebSocket {
@@ -49,6 +59,7 @@ export class WebSocketManager {
   private userRooms: Map<string, Set<string>> = new Map();
   // Map of transactionId -> Set of client IDs subscribed to that transaction
   private subscriptions: Map<string, Set<string>> = new Map();
+  private transactionModel = new TransactionModel();
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
   private redisSub: RedisClientType | null = null;
   private redisPub: RedisClientType | null = null;
@@ -122,7 +133,7 @@ export class WebSocketManager {
 
       // Handle incoming messages from client
       client.on("message", (rawData) => {
-        this.handleMessage(clientId, client, rawData.toString());
+        void this.handleMessage(clientId, client, rawData.toString());
       });
 
       // Cleanup on disconnect
@@ -146,11 +157,11 @@ export class WebSocketManager {
   // Message handling
   // -------------------------------------------------------------------------
 
-  private handleMessage(
+  private async handleMessage(
     clientId: string,
     client: AuthenticatedWebSocket,
     rawData: string,
-  ): void {
+  ): Promise<void> {
     let message: WebSocketMessage;
 
     try {
@@ -179,6 +190,13 @@ export class WebSocketManager {
         const payload = message.data as { transactionId: string };
         if (!payload?.transactionId) break;
         this.unsubscribe(clientId, client, payload.transactionId);
+        break;
+      }
+
+      case "transaction.details": {
+        const payload = message.data as TransactionDetailsRequestPayload;
+        if (!payload?.transactionId) break;
+        await this.sendTransactionDetails(client, payload.transactionId);
         break;
       }
 
@@ -247,7 +265,7 @@ export class WebSocketManager {
   ): Promise<void> {
     const message: WebSocketMessage = {
       type: "transaction.updated",
-      data: payload,
+      data: { transactionId: payload.id },
     };
 
     // Publish to Redis for inter-process distribution
@@ -274,6 +292,42 @@ export class WebSocketManager {
     this.broadcastLocally(payload.id, message);
   }
 
+
+  private async sendTransactionDetails(
+    client: AuthenticatedWebSocket,
+    transactionId: string,
+  ): Promise<void> {
+    try {
+      const transaction = await this.transactionModel.findById(
+        transactionId,
+        client.userId,
+      );
+
+      if (!transaction) {
+        this.sendToClient(client, {
+          type: "transaction.details.not_found",
+          data: { transactionId },
+        });
+        return;
+      }
+
+      const response: WebSocketMessage = {
+        type: "transaction.details",
+        data: {
+          transactionId,
+          transaction,
+        } as TransactionDetailsResponsePayload,
+      };
+
+      this.sendToClient(client, response);
+    } catch (err) {
+      logger.error(err, `Failed to load transaction details (${transactionId}):`);
+      this.sendToClient(client, {
+        type: "error",
+        data: { message: "Failed to load transaction details" },
+      });
+    }
+  }
   /** Send a message to all locally-connected clients subscribed to transactionId. */
   private broadcastLocally(
     transactionId: string,


### PR DESCRIPTION
Closes #1594 

### Description
This PR addresses issue #1594 by optimizing the WebSocket pub/sub message payloads to improve performance and scalability. 

Instead of broadcasting full transaction details, the WebSocket broadcast now transmits only small identifiers (like transaction IDs). Clients can fetch the full transaction details on demand when needed, significantly reducing the payload size over the socket connection.

### Acceptance Criteria Met
- [x] Limited message body payloads to ID elements.
- [x] Clients now request transaction details on demand.
- [x] Ensured web socket performance scales efficiently.
