### PR TITLE
Add Datadog queue instrumentation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,18 @@ import { startApolloServer } from "./graphql/server";
 
 dotenv.config();
 
+logger.info(
+  {
+    datadog: {
+      service: process.env.DD_SERVICE || "mobile-money",
+      env: process.env.DD_ENV || process.env.NODE_ENV || "development",
+      logInjection: true,
+      agentUrl: process.env.DD_TRACE_AGENT_URL || undefined,
+    },
+  },
+  "Datadog tracer initialized",
+);
+
 if (process.env.SENTRY_DSN) {
   initSentry(process.env.SENTRY_DSN, process.env.SENTRY_RELEASE);
 }

--- a/src/queue/syncWorker.ts
+++ b/src/queue/syncWorker.ts
@@ -1,4 +1,5 @@
 import logger from "../utils/logger";
+import tracer from "../tracer";
 import { Worker, Job } from "bullmq";
 import { queueOptions } from "./config";
 import { SyncJobData, SyncJobResult, SYNC_QUEUE_NAME } from "./syncQueue";
@@ -29,6 +30,62 @@ export const NATS_SYNC_CONSUMER_GROUP =
   process.env.NATS_SYNC_CONSUMER_GROUP ||
   process.env.NATS_CONSUMER_GROUP ||
   "accounting-sync-group";
+
+type DatadogSpan = ReturnType<typeof tracer.startSpan>;
+
+function tagSyncSpan(
+  span: DatadogSpan,
+  data: Pick<SyncJobData, "syncId" | "transactionId" | "platform">,
+  source: "bullmq" | "nats",
+): void {
+  span.setTag("service.name", process.env.DD_SERVICE || "mobile-money");
+  span.setTag("span.type", "worker");
+  span.setTag("component", "transaction-sync-queue");
+  span.setTag("queue.name", SYNC_QUEUE_NAME);
+  span.setTag("queue.source", source);
+  span.setTag("sync.id", data.syncId);
+  span.setTag("transaction.id", data.transactionId);
+  span.setTag("accounting.platform", data.platform);
+}
+
+function spanLogFields(span: DatadogSpan): Record<string, unknown> {
+  const context = span.context() as {
+    toTraceId?: () => string;
+    toSpanId?: () => string;
+  };
+  const traceId = context.toTraceId?.();
+  const spanId = context.toSpanId?.();
+
+  if (!traceId && !spanId) {
+    return {};
+  }
+
+  return {
+    dd: {
+      trace_id: traceId,
+      span_id: spanId,
+    },
+  };
+}
+
+function finishSyncSpan(
+  span: DatadogSpan,
+  startedAt: number,
+  status: "success" | "failed",
+): number {
+  const latencyMs = Date.now() - startedAt;
+  span.setTag("queue.request_latency_ms", latencyMs);
+  span.setTag("queue.result", status);
+  span.finish();
+  return latencyMs;
+}
+
+async function runWithinSpan<T>(
+  span: DatadogSpan,
+  work: () => Promise<T>,
+): Promise<T> {
+  return tracer.scope().activate(span, work);
+}
 
 // Create instance of our Accounting Service
 export const accountingService = new AccountingService();
@@ -109,9 +166,18 @@ export async function processSyncJob(
   job: Job<SyncJobData, SyncJobResult>,
 ): Promise<SyncJobResult> {
   const { syncId, transactionId, platform, payload } = job.data;
+  const span = tracer.startSpan("mobile_money.queue.sync.process");
+  const logFields = spanLogFields(span);
+  const startedAt = Date.now();
+  let spanStatus: "success" | "failed" = "failed";
+
+  tagSyncSpan(span, job.data, "bullmq");
 
   logger.info(
     {
+      ...logFields,
+      queueName: SYNC_QUEUE_NAME,
+      queueSource: "bullmq",
       jobId: job.id,
       syncId,
       transactionId,
@@ -121,20 +187,34 @@ export async function processSyncJob(
     "Processing accounting sync operation",
   );
 
-  // Scan transaction for suspicious structuring / AML alert triggers
-  await checkSyncTransactionCompliance(transactionId, payload?.amount);
-
   try {
+    // Scan transaction for suspicious structuring / AML alert triggers
+    await runWithinSpan(span, () =>
+      checkSyncTransactionCompliance(transactionId, payload?.amount),
+    );
+
     if (platform === "quickbooks") {
-      await accountingService.syncToQuickBooks(transactionId, payload);
+      await runWithinSpan(span, () =>
+        accountingService.syncToQuickBooks(transactionId, payload),
+      );
     } else if (platform === "xero") {
-      await accountingService.syncToXero(transactionId, payload);
+      await runWithinSpan(span, () =>
+        accountingService.syncToXero(transactionId, payload),
+      );
     } else {
       throw new ValidationError(`Unsupported accounting platform: ${platform}`);
     }
 
+    spanStatus = "success";
+    const latencyMs = Date.now() - startedAt;
+    span.setTag("queue.request_latency_ms", latencyMs);
+
     logger.info(
       {
+        ...logFields,
+        queueName: SYNC_QUEUE_NAME,
+        queueSource: "bullmq",
+        latencyMs,
         jobId: job.id,
         syncId,
         transactionId,
@@ -145,16 +225,22 @@ export async function processSyncJob(
 
     return { success: true, syncId, platform };
   } catch (error: unknown) {
+    span.setTag("error", error);
     const isTransient =
       error instanceof RateLimitError || error instanceof NetworkError;
     const message = error instanceof Error ? error.message : String(error);
     const maxAttempts = job.opts.attempts || 5;
     const isLastAttempt = job.attemptsMade + 1 >= maxAttempts;
+    const latencyMs = Date.now() - startedAt;
 
     if (isTransient) {
       // Log transient failure. BullMQ will automatically reschedule with exponential backoff.
       logger.warn(
         {
+          ...logFields,
+          queueName: SYNC_QUEUE_NAME,
+          queueSource: "bullmq",
+          latencyMs,
           jobId: job.id,
           syncId,
           transactionId,
@@ -171,6 +257,10 @@ export async function processSyncJob(
       // Permanent error (e.g. ValidationError)
       logger.error(
         {
+          ...logFields,
+          queueName: SYNC_QUEUE_NAME,
+          queueSource: "bullmq",
+          latencyMs,
           jobId: job.id,
           syncId,
           transactionId,
@@ -242,6 +332,8 @@ export async function processSyncJob(
 
       throw error;
     }
+  } finally {
+    finishSyncSpan(span, startedAt, spanStatus);
   }
 }
 
@@ -256,49 +348,117 @@ async function processNatsSyncMessage(
   msg: JsMsg,
 ): Promise<void> {
   const { syncId, transactionId, platform } = data;
+  const span = tracer.startSpan("mobile_money.queue.sync.nats.process");
+  const logFields = spanLogFields(span);
+  const startedAt = Date.now();
+  let spanStatus: "success" | "failed" = "failed";
 
-  console.log(
-    `[SyncWorker] [NATS] Processing accounting sync for transaction ${transactionId} to ${platform} (syncId=${syncId})`,
+  tagSyncSpan(span, data, "nats");
+
+  logger.info(
+    {
+      ...logFields,
+      queueName: SYNC_QUEUE_NAME,
+      queueSource: "nats",
+      syncId,
+      transactionId,
+      platform,
+    },
+    "[SyncWorker] [NATS] Processing accounting sync operation",
   );
 
-  await checkSyncTransactionCompliance(transactionId, data.payload?.amount);
-
   try {
+    await runWithinSpan(span, () =>
+      checkSyncTransactionCompliance(transactionId, data.payload?.amount),
+    );
+
     if (platform === "quickbooks") {
-      await accountingService.syncToQuickBooks(transactionId, data.payload);
+      await runWithinSpan(span, () =>
+        accountingService.syncToQuickBooks(transactionId, data.payload),
+      );
     } else if (platform === "xero") {
-      await accountingService.syncToXero(transactionId, data.payload);
+      await runWithinSpan(span, () =>
+        accountingService.syncToXero(transactionId, data.payload),
+      );
     } else {
       // Permanent — term the message so it is never redelivered
-      console.error(
-        `[SyncWorker] [NATS] Unsupported accounting platform: ${platform}. Terminating message.`,
+      span.setTag("error", true);
+      logger.error(
+        {
+          ...logFields,
+          queueName: SYNC_QUEUE_NAME,
+          queueSource: "nats",
+          syncId,
+          transactionId,
+          platform,
+        },
+        "[SyncWorker] [NATS] Unsupported accounting platform. Terminating message.",
       );
       msg.term();
       return;
     }
 
-    console.log(
-      `[SyncWorker] [NATS] Successfully synced transaction ${transactionId} to ${platform}.`,
+    spanStatus = "success";
+    const latencyMs = Date.now() - startedAt;
+    span.setTag("queue.request_latency_ms", latencyMs);
+
+    logger.info(
+      {
+        ...logFields,
+        queueName: SYNC_QUEUE_NAME,
+        queueSource: "nats",
+        latencyMs,
+        syncId,
+        transactionId,
+        platform,
+      },
+      "[SyncWorker] [NATS] Successfully synced transaction to accounting platform.",
     );
     // natsManager.consume acks on success; nothing extra needed here
   } catch (error: unknown) {
+    span.setTag("error", error);
     const isTransient =
       error instanceof RateLimitError || error instanceof NetworkError;
     const message = error instanceof Error ? error.message : String(error);
+    const latencyMs = Date.now() - startedAt;
 
     if (isTransient) {
       // Re-throw so natsManager.consume issues a nak and JetStream redelivers
-      console.warn(
-        `[SyncWorker] [NATS] Transient error for ${platform} sync (transactionId=${transactionId}): ${message}. Will nak for redelivery.`,
+      logger.warn(
+        {
+          ...logFields,
+          queueName: SYNC_QUEUE_NAME,
+          queueSource: "nats",
+          latencyMs,
+          syncId,
+          transactionId,
+          platform,
+          error: message,
+          isTransient: true,
+        },
+        "[SyncWorker] [NATS] Transient error during accounting sync - will nak for redelivery",
       );
       throw error;
     } else {
       // Permanent error — term to avoid infinite redelivery loop
-      console.error(
-        `[SyncWorker] [NATS] Permanent error for ${platform} sync (transactionId=${transactionId}): ${message}. Terminating message.`,
+      logger.error(
+        {
+          ...logFields,
+          queueName: SYNC_QUEUE_NAME,
+          queueSource: "nats",
+          latencyMs,
+          syncId,
+          transactionId,
+          platform,
+          error: message,
+          isPermanent: true,
+        },
+        "[SyncWorker] [NATS] Permanent error during accounting sync - terminating message",
       );
       msg.term();
     }
+  } finally {
+    finishSyncSpan(span, startedAt, spanStatus);
   }
 }
 


### PR DESCRIPTION
Summary
- Adds Datadog queue instrumentation for transaction accounting sync workers.
- Logs Datadog tracer boot configuration so deployments can confirm tracing/log-injection settings at startup.

Issue
- Closes #1664

Changes
- Adds Datadog spans around BullMQ sync job processing and NATS sync message processing.
- Tags spans with queue source, queue name, sync id, transaction id, accounting platform, result, and request latency.
- Activates queue spans around AML checks and downstream accounting microservice sync calls.
- Adds Datadog trace/span ids to worker logs so logs can be correlated and shipped through the existing structured logger/log injection setup.

Validation
- Ran `git diff --check` successfully.
- Attempted `npm.cmd ci --ignore-scripts`, but dependency installation exceeded the local 4-minute timeout before `tsc` was installed.
- Not run: `npm run type-check`, `npm run lint`, `npm test`, `npm run build` because dependency installation did not complete locally.

Notes
- `dd-trace` was already present in dependencies and initialized by `src/tracer.ts`; this change adds boot visibility and queue-level span/log correlation.