### PR TITLE
Add Apollo APQ Redis instrumentation

### DIFF
--- a/src/graphql/server.ts
+++ b/src/graphql/server.ts
@@ -28,6 +28,64 @@ const mergedResolvers = {
   ...subscriptionResolvers,
 };
 
+function persistedQueryHash(request: any): string | undefined {
+  const hash = request?.extensions?.persistedQuery?.sha256Hash;
+  return typeof hash === "string" && hash.length > 0 ? hash : undefined;
+}
+
+function hasQueryText(request: any): boolean {
+  return typeof request?.query === "string" && request.query.trim().length > 0;
+}
+
+function createAPQInstrumentationPlugin() {
+  return {
+    async requestDidStart(requestContext: any) {
+      const hash = persistedQueryHash(requestContext.request);
+      if (!hash) return {};
+
+      const requestHasQueryText = hasQueryText(requestContext.request);
+      logger.info(
+        {
+          apqHash: hash,
+          hashOnly: !requestHasQueryText,
+        },
+        "GraphQL APQ request received",
+      );
+
+      return {
+        async didResolveOperation() {
+          if (!requestHasQueryText) {
+            logger.info(
+              { apqHash: hash },
+              "GraphQL APQ hash resolved from Redis cache",
+            );
+          }
+        },
+        async didEncounterErrors(errorContext: any) {
+          const codes = (errorContext.errors || []).map(
+            (error: any) => error?.extensions?.code,
+          );
+          if (codes.includes("PERSISTED_QUERY_NOT_FOUND")) {
+            logger.info(
+              { apqHash: hash },
+              "GraphQL APQ hash not found; client should retry with full query",
+            );
+          }
+        },
+        async willSendResponse(responseContext: any) {
+          const errors = responseContext.errors || [];
+          if (requestHasQueryText && errors.length === 0) {
+            logger.info(
+              { apqHash: hash },
+              "GraphQL APQ query hash stored in Redis cache",
+            );
+          }
+        },
+      };
+    },
+  };
+}
+
 export async function startApolloServer(
   app: Application,
   httpServer: Server,
@@ -70,6 +128,7 @@ export async function startApolloServer(
       process.env.NODE_ENV === "production"
         ? ApolloServerPluginLandingPageProductionDefault({ footer: false })
         : ApolloServerPluginLandingPageGraphQLPlayground(),
+      createAPQInstrumentationPlugin(),
       // Plugin for proper shutdown of WebSocket server
       {
         async serverWillStart() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -684,7 +684,7 @@ async function initializeRuntime(): Promise<void> {
 
     // Start Apollo Server with APQ enabled (must run after HTTP server is created)
     await startApolloServer(app, server);
-    console.log("Apollo GraphQL server started at /graphql");
+    console.log("Apollo GraphQL server started at /graphql with Redis APQ");
   }
 }
 


### PR DESCRIPTION
Summary
- Adds Apollo APQ instrumentation around the existing Redis-backed persisted query cache.
- Logs APQ hash-only requests, Redis-resolved cache hits, cache misses, and successful hash storage without logging query text.

Issue
- Closes #1658

Changes
- Added an Apollo request plugin in `src/graphql/server.ts` to observe APQ request flow by SHA-256 hash.
- Keeps the existing `persistedQueries.cache` Redis adapter in place for hash -> query storage.
- Updated the GraphQL startup message in `src/index.ts` to make Redis APQ enablement visible at boot.

Validation
- Ran `npm.cmd ci --ignore-scripts --prefer-offline --no-audit --no-fund` successfully.
- Ran `npx.cmd prettier --check src/graphql/server.ts src/index.ts` successfully.
- Ran `git diff --check` successfully.
- `npm.cmd run type-check` was attempted but failed because this local checkout is sparse and most imported source files are intentionally absent, producing only missing-module errors for omitted files.
- `npx.cmd eslint src/graphql/server.ts src/index.ts` was attempted but failed because the sparse checkout does not include the repo ESLint config.

Notes
- The existing `src/graphql/apqCache.ts` already stores APQ hashes in Redis; this PR adds the requested Apollo plugin-level instrumentation and boot visibility.