### PR TITLE
feat: DLQ 90-day cleanup, DB index alerts, SLA dashboard, memory profiler

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -218,3 +218,58 @@ document.getElementById("tab-btn-toml").addEventListener("click", () => selectTa
 document.getElementById("tab-btn-kyc").addEventListener("click", () => selectTab("kyc"));
 document.getElementById("tab-btn-stats").addEventListener("click", () => selectTab("stats"));
 document.getElementById("btn-copy-code").addEventListener("click", copyCode);
+
+// SLA Dashboard
+function formatDelay(seconds) {
+  if (seconds === null || seconds === undefined) return "—";
+  if (seconds < 1) return `${Math.round(seconds * 1000)} ms`;
+  return `${seconds.toFixed(2)} s`;
+}
+
+async function loadSlaMetrics() {
+  const fields = ["sla-total", "sla-compliance", "sla-avg", "sla-p95", "sla-minmax", "sla-breached"];
+  fields.forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = "Loading…";
+  });
+
+  try {
+    const res = await fetch("/api/admin/monitoring/sla");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (!data.success || !data.metrics) throw new Error("Unexpected response");
+
+    const m = data.metrics;
+    document.getElementById("sla-total").textContent = m.total_deposits.toLocaleString();
+    document.getElementById("sla-compliance").textContent =
+      `${m.sla_compliance_rate.toFixed(1)}%`;
+    document.getElementById("sla-avg").textContent = formatDelay(m.avg_delay_seconds);
+    document.getElementById("sla-p95").textContent = formatDelay(m.p95_delay_seconds);
+    document.getElementById("sla-minmax").textContent =
+      `${formatDelay(m.min_delay_seconds)} / ${formatDelay(m.max_delay_seconds)}`;
+    document.getElementById("sla-breached").textContent = m.sla_breached.toLocaleString();
+
+    const breachCard = document.getElementById("sla-breach-card");
+    if (breachCard) {
+      breachCard.classList.toggle("sla-card-danger", m.sla_breached > 0);
+      breachCard.classList.toggle("sla-card-alert", m.sla_breached === 0);
+    }
+
+    const updatedAt = document.getElementById("sla-updated-at");
+    if (updatedAt) updatedAt.textContent = new Date().toLocaleTimeString();
+  } catch (err) {
+    fields.forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.textContent = "—";
+    });
+    const updatedAt = document.getElementById("sla-updated-at");
+    if (updatedAt) updatedAt.textContent = "unavailable";
+  }
+}
+
+// Load on page start and refresh every 60 seconds
+loadSlaMetrics();
+setInterval(loadSlaMetrics, 60000);
+
+const btnRefreshSla = document.getElementById("btn-refresh-sla");
+if (btnRefreshSla) btnRefreshSla.addEventListener("click", loadSlaMetrics);

--- a/public/index.html
+++ b/public/index.html
@@ -215,6 +215,43 @@
       </div>
     </section>
 
+    <!-- SLA Monitoring Dashboard -->
+    <section id="sla" class="sla-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Deposit SLA Dashboard</h2>
+          <p>Live monitoring of deposit approval processing times over the last 24 hours. SLA threshold: 30 seconds.</p>
+        </div>
+        <div class="sla-grid">
+          <div class="sla-card glass">
+            <div class="sla-label">Total Deposits (24h)</div>
+            <div class="sla-value" id="sla-total">—</div>
+          </div>
+          <div class="sla-card glass">
+            <div class="sla-label">SLA Compliance Rate</div>
+            <div class="sla-value" id="sla-compliance">—</div>
+          </div>
+          <div class="sla-card glass">
+            <div class="sla-label">Avg Processing Time</div>
+            <div class="sla-value" id="sla-avg">—</div>
+          </div>
+          <div class="sla-card glass">
+            <div class="sla-label">P95 Processing Time</div>
+            <div class="sla-value" id="sla-p95">—</div>
+          </div>
+          <div class="sla-card glass">
+            <div class="sla-label">Min / Max Delay</div>
+            <div class="sla-value" id="sla-minmax">—</div>
+          </div>
+          <div class="sla-card glass sla-card-alert" id="sla-breach-card">
+            <div class="sla-label">SLA Breaches</div>
+            <div class="sla-value" id="sla-breached">—</div>
+          </div>
+        </div>
+        <p class="sla-updated">Last updated: <span id="sla-updated-at">—</span> &nbsp;·&nbsp; <button class="btn-refresh" id="btn-refresh-sla">Refresh</button></p>
+      </div>
+    </section>
+
     <!-- API Section -->
     <section id="api" class="api-section">
       <div class="container">

--- a/scripts/profileMemory.ts
+++ b/scripts/profileMemory.ts
@@ -1,0 +1,117 @@
+/**
+ * Memory profiling script for batch payout workloads.
+ *
+ * Usage:
+ *   # Basic heap snapshot (captures GC state before/after a simulated batch):
+ *   node --expose-gc -r tsx/cjs scripts/profileMemory.ts
+ *
+ *   # With Chrome DevTools inspector (attach devtools to chrome://inspect):
+ *   node --inspect --expose-gc -r tsx/cjs scripts/profileMemory.ts
+ *
+ *   # With built-in CPU profile (writes cpu.cpuprofile alongside heap snapshots):
+ *   node --expose-gc --cpu-prof -r tsx/cjs scripts/profileMemory.ts
+ *
+ * Outputs:
+ *   heap-before-<timestamp>.heapsnapshot  — baseline before batch
+ *   heap-after-<timestamp>.heapsnapshot   — after batch, before forced GC
+ *   heap-gc-<timestamp>.heapsnapshot      — after explicit GC (reveals true leaks)
+ *
+ * Open .heapsnapshot files in Chrome DevTools → Memory → Load profile.
+ * Compare "heap-after" vs "heap-gc" to spot allocations that GC cannot reclaim.
+ */
+
+import v8 from "v8";
+import fs from "fs";
+import path from "path";
+
+declare const gc: (() => void) | undefined;
+
+const BATCH_SIZE = parseInt(process.env.PROFILE_BATCH_SIZE || "1000", 10);
+const SNAPSHOT_DIR = process.env.PROFILE_SNAPSHOT_DIR || process.cwd();
+
+function writeSnapshot(label: string): string {
+  const timestamp = Date.now();
+  const filename = path.join(SNAPSHOT_DIR, `heap-${label}-${timestamp}.heapsnapshot`);
+  const snapshot = v8.writeHeapSnapshot(filename);
+  console.log(`[profileMemory] Snapshot written: ${snapshot}`);
+  return snapshot;
+}
+
+function forceGc(): void {
+  if (typeof gc !== "function") {
+    console.warn(
+      "[profileMemory] gc() not available. Re-run with --expose-gc to enable forced GC.",
+    );
+    return;
+  }
+  gc();
+  console.log("[profileMemory] Forced GC complete.");
+}
+
+function memUsageMb(): string {
+  const u = process.memoryUsage();
+  return (
+    `rss=${(u.rss / 1048576).toFixed(1)}MB ` +
+    `heapUsed=${(u.heapUsed / 1048576).toFixed(1)}MB ` +
+    `heapTotal=${(u.heapTotal / 1048576).toFixed(1)}MB ` +
+    `external=${(u.external / 1048576).toFixed(1)}MB`
+  );
+}
+
+/**
+ * Simulates a batch payout workload to surface allocation patterns.
+ * Replace the body with actual payout logic (e.g. import and call
+ * processBatchPayouts) to profile real code paths.
+ */
+async function simulateBatchPayout(batchSize: number): Promise<void> {
+  const items: Array<{ id: string; amount: number; recipient: string }> = [];
+
+  for (let i = 0; i < batchSize; i++) {
+    // Mimic per-item allocation: object + string fields
+    items.push({
+      id: `payout-${i}-${Math.random().toString(36).slice(2)}`,
+      amount: Math.round(Math.random() * 100000) / 100,
+      recipient: `+2547${String(i).padStart(8, "0")}`,
+    });
+  }
+
+  // Simulate async I/O delay per item (replace with actual provider calls)
+  await Promise.all(
+    items.map(
+      (item) =>
+        new Promise<void>((resolve) =>
+          setImmediate(() => {
+            void item; // prevent optimiser from eliminating the allocation
+            resolve();
+          }),
+        ),
+    ),
+  );
+}
+
+async function main(): Promise<void> {
+  console.log(`[profileMemory] Starting — batch size: ${BATCH_SIZE}`);
+  console.log(`[profileMemory] Initial memory: ${memUsageMb()}`);
+
+  writeSnapshot("before");
+
+  console.log(`[profileMemory] Running simulated batch payout (${BATCH_SIZE} items)…`);
+  await simulateBatchPayout(BATCH_SIZE);
+
+  console.log(`[profileMemory] After batch: ${memUsageMb()}`);
+  writeSnapshot("after");
+
+  forceGc();
+  console.log(`[profileMemory] After GC:    ${memUsageMb()}`);
+  writeSnapshot("gc");
+
+  console.log("[profileMemory] Done. Load the .heapsnapshot files in Chrome DevTools.");
+  console.log(
+    "[profileMemory] Tip: compare heap-after vs heap-gc — objects retained after GC indicate leaks.",
+  );
+}
+
+main().catch((err) => {
+  console.error("[profileMemory] Fatal:", err);
+  process.exitCode = 1;
+});

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -16,6 +16,11 @@ const productionSsl =
 const SLOW_QUERY_THRESHOLD_MS = parseInt(
   process.env.SLOW_QUERY_THRESHOLD_MS || "1000",
 );
+// Queries exceeding this threshold suggest a missing or unused index and trigger
+// a higher-severity warning alongside the standard slow-query log entry.
+const SLOW_QUERY_INDEX_ALERT_THRESHOLD_MS = parseInt(
+  process.env.SLOW_QUERY_INDEX_ALERT_THRESHOLD_MS || "5000",
+);
 const ENABLE_SLOW_QUERY_LOGGING =
   process.env.ENABLE_SLOW_QUERY_LOGGING === "true" ||
   (process.env.NODE_ENV === "development" &&
@@ -188,21 +193,39 @@ function sanitizeParams(params: any[]): any[] {
 }
 
 /**
- * Logs slow queries with sanitized information
+ * Logs slow queries with sanitized information.
+ * Queries above SLOW_QUERY_INDEX_ALERT_THRESHOLD_MS also emit a warn-level
+ * entry flagging a possible missing index.
  */
 function logSlowQuery(query: string, duration: number, params?: any[]): void {
   if (!ENABLE_SLOW_QUERY_LOGGING) return;
 
+  const sanitized = sanitizeQuery(query);
+  const sanitizedParams = params ? sanitizeParams(params) : undefined;
+  const durationRounded = Math.round(duration);
+
   const logEntry = {
     type: "slow_query",
-    duration: Math.round(duration),
+    duration: durationRounded,
     threshold: SLOW_QUERY_THRESHOLD_MS,
-    query: sanitizeQuery(query),
-    params: params ? sanitizeParams(params) : undefined,
+    query: sanitized,
+    params: sanitizedParams,
     timestamp: new Date().toISOString(),
   };
 
   console.log(JSON.stringify(logEntry));
+
+  if (duration > SLOW_QUERY_INDEX_ALERT_THRESHOLD_MS) {
+    logger.warn("possible_missing_index", {
+      type: "possible_missing_index",
+      duration: durationRounded,
+      index_alert_threshold: SLOW_QUERY_INDEX_ALERT_THRESHOLD_MS,
+      hint: "Query exceeded index-alert threshold. Review EXPLAIN ANALYZE output and confirm a matching index exists.",
+      query: sanitized,
+      params: sanitizedParams,
+      timestamp: new Date().toISOString(),
+    });
+  }
 }
 
 // Enhanced Pool with query timing

--- a/src/controllers/adminController.ts
+++ b/src/controllers/adminController.ts
@@ -10,6 +10,7 @@ import {
 } from "../utils/circuitBreaker";
 import { createError } from "../middleware/errorHandler";
 import { ERROR_CODES } from "../constants/errorCodes";
+import { pool } from "../config/database";
 
 // Ensure logs directory exists
 const LOGS_DIR = path.join(process.cwd(), "logs");
@@ -329,6 +330,76 @@ export const tripCircuitBreakerHandler = async (req: Request, res: Response): Pr
 };
 
 /**
+ * Controller: SLA tracking metrics for deposit approvals.
+ * Calculates processing time from deposit initiation (created_at) to completion
+ * (updated_at where status = 'completed') over a rolling 24-hour window.
+ * SLA breach threshold is 30 seconds per deposit.
+ */
+const SLA_BREACH_THRESHOLD_SECONDS = parseInt(
+  process.env.SLA_BREACH_THRESHOLD_SECONDS || "30",
+  10,
+);
+
+export const getSlaMetrics = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await pool.query<{
+      total_deposits: string;
+      avg_delay_seconds: string | null;
+      min_delay_seconds: string | null;
+      max_delay_seconds: string | null;
+      sla_breached: string;
+      p95_delay_seconds: string | null;
+    }>(
+      `SELECT
+         COUNT(*)                                                          AS total_deposits,
+         AVG(EXTRACT(EPOCH FROM (updated_at - created_at)))               AS avg_delay_seconds,
+         MIN(EXTRACT(EPOCH FROM (updated_at - created_at)))               AS min_delay_seconds,
+         MAX(EXTRACT(EPOCH FROM (updated_at - created_at)))               AS max_delay_seconds,
+         COUNT(*) FILTER (
+           WHERE EXTRACT(EPOCH FROM (updated_at - created_at)) > $1
+         )                                                                 AS sla_breached,
+         PERCENTILE_CONT(0.95) WITHIN GROUP (
+           ORDER BY EXTRACT(EPOCH FROM (updated_at - created_at))
+         )                                                                 AS p95_delay_seconds
+       FROM transactions
+       WHERE type = 'deposit'
+         AND status = 'completed'
+         AND created_at >= NOW() - INTERVAL '24 hours'`,
+      [SLA_BREACH_THRESHOLD_SECONDS],
+    );
+
+    const row = result.rows[0];
+    const total = parseInt(row.total_deposits, 10);
+    const breached = parseInt(row.sla_breached, 10);
+    const avgDelay = row.avg_delay_seconds !== null ? parseFloat(row.avg_delay_seconds) : null;
+    const minDelay = row.min_delay_seconds !== null ? parseFloat(row.min_delay_seconds) : null;
+    const maxDelay = row.max_delay_seconds !== null ? parseFloat(row.max_delay_seconds) : null;
+    const p95Delay = row.p95_delay_seconds !== null ? parseFloat(row.p95_delay_seconds) : null;
+
+    const slaComplianceRate = total > 0 ? ((total - breached) / total) * 100 : 100;
+
+    res.json({
+      success: true,
+      window: "24h",
+      sla_breach_threshold_seconds: SLA_BREACH_THRESHOLD_SECONDS,
+      timestamp: new Date().toISOString(),
+      metrics: {
+        total_deposits: total,
+        sla_breached: breached,
+        sla_compliance_rate: Math.round(slaComplianceRate * 100) / 100,
+        avg_delay_seconds: avgDelay !== null ? Math.round(avgDelay * 1000) / 1000 : null,
+        min_delay_seconds: minDelay !== null ? Math.round(minDelay * 1000) / 1000 : null,
+        max_delay_seconds: maxDelay !== null ? Math.round(maxDelay * 1000) / 1000 : null,
+        p95_delay_seconds: p95Delay !== null ? Math.round(p95Delay * 1000) / 1000 : null,
+      },
+    });
+  } catch (error) {
+    winstonOutageLogger.error("Failed to fetch SLA metrics", { error });
+    throw createError(ERROR_CODES.INTERNAL_ERROR, "Failed to fetch SLA metrics");
+  }
+};
+
+/**
  * Express Router mounting all monitoring dashboard endpoints
  */
 import { Router } from "express";
@@ -344,5 +415,6 @@ router.get("/alerts", (_req: Request, res: Response) => {
 router.get("/logs", getOutageLogs);
 router.post("/circuit-breaker/reset", resetCircuitBreakerHandler);
 router.post("/circuit-breaker/trip", tripCircuitBreakerHandler);
+router.get("/sla", getSlaMetrics);
 
 export default router;

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -28,6 +28,7 @@ import { runSanctionSyncJob } from "./sanctionSyncJob";
 import { runJwtKeyRotationJob } from "./jwtKeyRotationJob";
 import { startNotificationWorker } from "../workers/notificationWorker";
 import { runTravelRuleExportJob } from "../services/compliance/travelRuleExport";
+import { runDlqCleanupJob } from "../queue/dlq";
 
 interface JobConfig {
   name: string;
@@ -185,6 +186,12 @@ const JOBS: JobConfig[] = [
     // Hourly - exports pending Travel Rule compliance records to regulatory reporting endpoints
     schedule: process.env.TRAVEL_RULE_EXPORT_CRON || "0 * * * *",
     handler: runTravelRuleExportJob,
+  },
+  {
+    name: "dlq-cleanup",
+    // Daily at 3:30 AM — removes DLQ entries older than 90 days after overnight audit window
+    schedule: process.env.DLQ_CLEANUP_CRON || "30 3 * * *",
+    handler: runDlqCleanupJob,
   },
 ];
 

--- a/src/queue/dlq.ts
+++ b/src/queue/dlq.ts
@@ -3,6 +3,7 @@ import { connection } from "./config";
 import { Request, Response } from "express";
 import { ERROR_CODES } from "../constants/errorCodes";
 import { createError } from "../middleware/errorHandler";
+import logger from "../utils/logger";
 
 /**
  * Dead Letter Queue (DLQ) for transaction processing.
@@ -50,6 +51,46 @@ export async function capturePersistentFailure(job: Job) {
       `[DLQ] Job ${job.id} moved to Dead Letter Queue after ${job.attemptsMade} failed attempts.`,
     );
   }
+}
+
+const DLQ_RETENTION_DAYS = parseInt(
+  process.env.DLQ_RETENTION_DAYS || "90",
+  10,
+);
+
+/**
+ * Removes DLQ entries older than DLQ_RETENTION_DAYS (default 90 days).
+ * Safe to run repeatedly — jobs that have already been removed are skipped.
+ */
+export async function runDlqCleanupJob(): Promise<void> {
+  const cutoffMs = DLQ_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const cutoffTimestamp = Date.now() - cutoffMs;
+
+  const jobs = await deadLetterQueue.getJobs(["waiting"], 0, 9999);
+  const stale = jobs.filter((job) => job.timestamp < cutoffTimestamp);
+
+  if (stale.length === 0) {
+    logger.info("[dlq-cleanup] No stale DLQ entries to remove.");
+    return;
+  }
+
+  let removed = 0;
+  let failed = 0;
+
+  for (const job of stale) {
+    try {
+      await job.remove();
+      removed++;
+    } catch (err) {
+      failed++;
+      logger.warn(`[dlq-cleanup] Failed to remove DLQ entry ${job.id}:`, err);
+    }
+  }
+
+  logger.info(
+    `[dlq-cleanup] Cleaned ${removed} stale DLQ entries older than ${DLQ_RETENTION_DAYS} days` +
+      (failed > 0 ? ` (${failed} failed to remove)` : ""),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR implements four monitoring and observability improvements: automated DLQ cleanup for stale dead-letter jobs, DB index performance alert thresholds for very slow queries, an SLA tracking dashboard for deposit approvals, and a memory profiling script for batch payout workloads.

closes #1659
closes #1657
closes #1663
closes #1656

## Changes

- **#1659 — DLQ 90-day cleanup scheduler**: Added `runDlqCleanupJob()` to `src/queue/dlq.ts`. Queries all `waiting` DLQ jobs, filters those older than `DLQ_RETENTION_DAYS` (default 90 days via env var), and calls `job.remove()` on each. Logs removal count and any failures. Registered in `src/jobs/scheduler.ts` as a nightly job at 3:30 AM (`DLQ_CLEANUP_CRON` env override supported).

- **#1657 — DB index performance alert thresholds**: Added `SLOW_QUERY_INDEX_ALERT_THRESHOLD_MS` constant to `src/config/database.ts` (default 5000ms, 5× the base slow-query threshold). Extended `logSlowQuery()` to emit a `logger.warn` with type `possible_missing_index` when a query exceeds this higher threshold, including the sanitized query and a hint to run `EXPLAIN ANALYZE`. Queries below this threshold still log the existing `slow_query` JSON entry.

- **#1663 — SLA tracking dashboard**: Added `getSlaMetrics` handler to `src/controllers/adminController.ts` querying the `transactions` table for completed deposits in the last 24h. Returns total, avg/min/max/P95 processing time (updated_at − created_at), SLA breach count, and compliance rate. SLA threshold is 30s (configurable via `SLA_BREACH_THRESHOLD_SECONDS`). Route mounted at `GET /api/admin/monitoring/sla`. Added a 6-card SLA panel to `public/index.html` and a polling JS function in `public/app.js` (refreshes every 60s, manual refresh button included).

- **#1656 — Memory profiling script**: Created `scripts/profileMemory.ts`. Captures three heap snapshots (`heap-before`, `heap-after`, `heap-gc`) around a simulated batch payout loop. Uses `v8.writeHeapSnapshot()` and `global.gc()` (requires `--expose-gc`). Outputs `.heapsnapshot` files loadable in Chrome DevTools Memory tab. Includes a `simulateBatchPayout()` stub to replace with real payout logic. Batch size and snapshot directory are configurable via env vars.

## Test plan

- #1659: DLQ cleanup runs on the nightly cron; re-running is safe (stale jobs removed once, fresh jobs untouched).
- #1657: Trigger a query exceeding 5000ms to verify `possible_missing_index` warning appears in logs with sanitized query.
- #1663: `GET /api/admin/monitoring/sla` returns correct JSON shape; SLA panel renders and auto-refreshes on the public dashboard.
- #1656: `node --expose-gc -r tsx/cjs scripts/profileMemory.ts` writes three snapshots; `gc()` availability confirmed with `--expose-gc` flag.

---

Not built locally (no node_modules in clone); relying on CI for compilation checks.