### PR TITLE
Fuzz test targets

### DIFF
--- a/contracts/escrow/fuzz/Cargo.toml
+++ b/contracts/escrow/fuzz/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "escrow-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata.cargo-fuzz]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1.3", features = ["derive"] }
+soroban-sdk = { version = "26.0.1", features = ["testutils"] }
+escrow = { path = ".." }
+
+# Isolate fuzz crate from workspace to avoid dependency conflicts or build speed degradation
+[workspace]

--- a/contracts/escrow/fuzz/fuzz_targets/escrow_fuzz.rs
+++ b/contracts/escrow/fuzz/fuzz_targets/escrow_fuzz.rs
@@ -1,0 +1,118 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, Env,
+};
+use escrow::{EscrowContract, EscrowContractClient};
+use arbitrary::Arbitrary;
+
+#[derive(Arbitrary, Debug)]
+struct FuzzSession {
+    amount: i128,
+    emergency_unlock_timestamp: u64,
+    lock_until_ledger: u32,
+    fee_bps: u32,
+    steps: Vec<FuzzStep>,
+}
+
+#[derive(Arbitrary, Debug)]
+enum FuzzStep {
+    Release {
+        ledger_sequence: u32,
+        ledger_timestamp: u64,
+    },
+    Refund {
+        ledger_sequence: u32,
+        ledger_timestamp: u64,
+    },
+    EmergencyRefund {
+        ledger_sequence: u32,
+        ledger_timestamp: u64,
+    },
+    SelfRefund {
+        ledger_sequence: u32,
+        ledger_timestamp: u64,
+    },
+}
+
+fuzz_target!(|session: FuzzSession| {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let depositor = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let fee_recipient = Address::generate(&env);
+
+    // Deploy a test SAC token.
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin);
+    let token_address = token_id.address();
+
+    // If the fuzzing amount is positive, try to mint exactly that amount to the depositor
+    // so we can test successful/failed deposits without test-setup level panics.
+    if session.amount > 0 {
+        let token_client = StellarAssetClient::new(&env, &token_address);
+        let mint_res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            token_client.mint(&depositor, &session.amount);
+        }));
+        if mint_res.is_err() {
+            return;
+        }
+    }
+
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Setup initial ledger state.
+    // Ensure the timestamp/sequence are non-zero.
+    env.ledger().set_sequence(1);
+    env.ledger().set_timestamp(1);
+
+    // Try to initialize the contract.
+    // `try_initialize` returns a Result and does not propagate contract-level panics or assertions.
+    let init_res = client.try_initialize(
+        &depositor,
+        &beneficiary,
+        &arbiter,
+        &token_address,
+        &session.amount,
+        &session.emergency_unlock_timestamp,
+        &session.lock_until_ledger,
+        &session.fee_bps,
+        &fee_recipient,
+    );
+
+    if init_res.is_err() {
+        return;
+    }
+
+    // If initialization was successful, we proceed to run the steps.
+    for step in session.steps {
+        match step {
+            FuzzStep::Release { ledger_sequence, ledger_timestamp } => {
+                env.ledger().set_sequence(ledger_sequence);
+                env.ledger().set_timestamp(ledger_timestamp);
+                let _ = client.try_release();
+            }
+            FuzzStep::Refund { ledger_sequence, ledger_timestamp } => {
+                env.ledger().set_sequence(ledger_sequence);
+                env.ledger().set_timestamp(ledger_timestamp);
+                let _ = client.try_refund();
+            }
+            FuzzStep::EmergencyRefund { ledger_sequence, ledger_timestamp } => {
+                env.ledger().set_sequence(ledger_sequence);
+                env.ledger().set_timestamp(ledger_timestamp);
+                let _ = client.try_emergency_refund();
+            }
+            FuzzStep::SelfRefund { ledger_sequence, ledger_timestamp } => {
+                env.ledger().set_sequence(ledger_sequence);
+                env.ledger().set_timestamp(ledger_timestamp);
+                let _ = client.try_self_refund();
+            }
+        }
+    }
+});

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -58,10 +58,10 @@ pub struct EscrowState {
 
 impl EscrowState {
     /// Compute (fee_amount, net_beneficiary_amount).
-    pub fn split(&self) -> (i128, i128) {
-        let fee = self.amount * self.fee_bps as i128 / 10_000;
-        let net = self.amount - fee;
-        (fee, net)
+    pub fn split(&self) -> Option<(i128, i128)> {
+        let fee = self.amount.checked_mul(self.fee_bps as i128)?.checked_div(10_000)?;
+        let net = self.amount.checked_sub(fee)?;
+        Some((fee, net))
     }
 }
 
@@ -100,6 +100,7 @@ impl EscrowContract {
         depositor.require_auth();
 
         assert!(amount > 0, "amount must be positive");
+        assert!(amount <= i128::MAX / 10_000, "amount is too large to prevent fee overflow");
 
         assert!(
             !env.storage().instance().has(&ESCROW),
@@ -177,7 +178,7 @@ impl EscrowContract {
 
         let tc = token::Client::new(&env, &state.token);
         let contract_addr = env.current_contract_address();
-        let (fee, net) = state.split();
+        let (fee, net) = state.split().ok_or(EscrowError::InvalidAmount)?;
 
         if fee > 0 {
             tc.transfer(&contract_addr, &state.fee_recipient, &fee);


### PR DESCRIPTION
Closes #1629 

# Pull Request: Implement Fuzz Testing and Arithmetic Safety for Escrow Contract

## Description
This pull request adds a comprehensive fuzz testing suite using `cargo-fuzz` and `libFuzzer` to find potential overflows or security vulnerabilities in the transaction methods of the atomic escrow contract. Additionally, it implements arithmetic safety improvements in the contract itself to prevent overflows during fee calculations.

## Changes

### 1. Escrow Contract Safety Enhancements (`contracts/escrow/src/lib.rs`)
* **Input Validation in `initialize`**: Added an assertion ensuring that the locked `amount` does not exceed `i128::MAX / 10_000` (since `fee_bps` is capped at `10_000`). This mathematically guarantees that no multiplications inside the fee split calculation will overflow `i128::MAX`.
* **Checked Arithmetic in `split`**: Modified `split()` to use checked multiplication, division, and subtraction, returning an `Option<(i128, i128)>` instead of executing unchecked/potentially panicking operations.
* **Error Handling in `release`**: Handled the safe return from `split()` using `.ok_or(EscrowError::InvalidAmount)` to gracefully return a contract error instead of triggering host-level panics.

### 2. Fuzzing Suite Setup (`contracts/escrow/fuzz/Cargo.toml`)
* Added a nested cargo-fuzz crate containing dependencies: `libfuzzer-sys`, `arbitrary` (with `derive` feature), and `soroban-sdk` (with `testutils` feature).
* Isolated the fuzz crate from the workspace via an empty `[workspace]` block to prevent compilation speed degradation and cargo toolchain conflicts.

### 3. Fuzz Target Implementation (`contracts/escrow/fuzz/fuzz_targets/escrow_fuzz.rs`)
* Created a fuzz target script that structures fuzzed parameters (`FuzzSession`) and action sequences (`FuzzStep`).
* Orchestrates transaction steps (`Release`, `Refund`, `EmergencyRefund`, `SelfRefund`) under randomized ledger sequences and timestamps inside a mocked Soroban environment.
* Utilizes generated client `try_*` methods to catch contract errors cleanly and flag only true host/logic crashes.

## Verification Plan
1. Ensure the Rust nightly toolchain and cargo-fuzz are installed:
   ```bash
   rustup toolchain install nightly
   cargo install cargo-fuzz
   ```
2. Run the fuzz tests targeting 100,000 successful iterations:
   ```bash
   cd contracts/escrow/fuzz
   cargo +nightly fuzz run escrow_fuzz -- -runs=100000
   ```