### PR TITLE
feat(redis): fallback to local array cache on cluster dropouts

### DIFF
--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -11,6 +11,30 @@ type SentinelNode = {
   port: number;
 };
 
+const localFallbackCache: Array<{ key: string; value: string }> = [];
+let isRedisClusterOffline = false;
+
+function getLocalCache(key: string): string | null {
+  const item = localFallbackCache.find(c => c.key === key);
+  return item ? item.value : null;
+}
+
+function setLocalCache(key: string, value: string): void {
+  const item = localFallbackCache.find(c => c.key === key);
+  if (item) {
+    item.value = value;
+  } else {
+    localFallbackCache.push({ key, value });
+  }
+}
+
+function delLocalCache(key: string): void {
+  const index = localFallbackCache.findIndex(c => c.key === key);
+  if (index !== -1) {
+    localFallbackCache.splice(index, 1);
+  }
+}
+
 const DEFAULT_REDIS_URL = "redis://localhost:6379";
 const BASE_REDIS_URL = process.env.REDIS_URL || DEFAULT_REDIS_URL;
 const SENTINEL_MASTER_NAME =
@@ -272,6 +296,10 @@ async function handleClusterRedirection(host: string, port: number): Promise<voi
 
 redisClient.on("error", (err) => {
   logger.error("Redis Client Error:", err);
+  if (!isRedisClusterOffline) {
+    logger.warn("Redis cluster status: offline, falling back to local array caches.");
+    isRedisClusterOffline = true;
+  }
   if (SENTINEL_ENABLED && /READONLY/i.test(String(err?.message || ""))) {
     void forceFailoverReconnect("redis:readonly");
   }
@@ -295,6 +323,10 @@ redisClient.on("connect", () => {
 
 redisClient.on("ready", () => {
   console.log("Redis: Ready");
+  if (isRedisClusterOffline) {
+    logger.warn("Redis cluster status: online, normal operation restored.");
+    isRedisClusterOffline = false;
+  }
   void verifyConnectedNodeRole();
 });
 
@@ -331,7 +363,49 @@ export async function disconnectRedis(): Promise<void> {
   }
 }
 
-export { redisClient };
+const proxyHandler: ProxyHandler<typeof redisClient> = {
+  get(target, prop, receiver) {
+    if (prop === "get") {
+      return async (...args: Parameters<typeof target.get>) => {
+        if (isRedisClusterOffline) return getLocalCache(args[0] as string);
+        try { return await target.get(...args); }
+        catch (e) { return getLocalCache(args[0] as string); }
+      };
+    }
+    if (prop === "set") {
+      return async (...args: Parameters<typeof target.set>) => {
+        if (isRedisClusterOffline) {
+          setLocalCache(args[0] as string, String(args[1]));
+          return "OK";
+        }
+        try { return await target.set(...args); }
+        catch (e) {
+          setLocalCache(args[0] as string, String(args[1]));
+          return "OK";
+        }
+      };
+    }
+    if (prop === "del") {
+      return async (...args: Parameters<typeof target.del>) => {
+        if (isRedisClusterOffline) {
+          const key = Array.isArray(args[0]) ? args[0][0] : args[0];
+          delLocalCache(key as string);
+          return 1;
+        }
+        try { return await target.del(...args); }
+        catch (e) {
+          const key = Array.isArray(args[0]) ? args[0][0] : args[0];
+          delLocalCache(key as string);
+          return 1;
+        }
+      };
+    }
+    return Reflect.get(target, prop, receiver);
+  }
+};
+
+const exportedRedisClient = new Proxy(redisClient, proxyHandler);
+export { exportedRedisClient as redisClient };
 
 export function createRedisStore() {
   return new RedisStore({


### PR DESCRIPTION
Closes #1599 


To ensure the high availability and resilience of our backend, we need a mechanism to gracefully handle scenarios where the Redis cluster goes offline. Previously, connection dropouts would cause the backend to stall or fail when interacting with Redis.

#### Changes Made
This PR introduces a robust fallback mechanism that seamlessly reroutes Redis `get`, `set`, and `del` operations to a local in-memory array cache during a cluster outage. 

Specifically, the following changes were made:
1. **Connection Failure Detection**: 
   - Added event listeners to `redisClient.on("error")` and `redisClient.on("ready")` to automatically detect when the cluster drops offline or comes back online.
   - We now track the cluster's availability using an `isRedisClusterOffline` state flag.
2. **Local Array Cache Fallback**:
   - Implemented a local array structure (`localFallbackCache`) to temporarily store data in memory during an outage.
   - Created helper functions (`getLocalCache`, `setLocalCache`, `delLocalCache`) to interact with this array cache.
3. **Proxy Client Methods**:
   - Wrapped the exported `redisClient` using a JavaScript `Proxy`. 
   - Intercepted the `get`, `set`, and `del` methods. If the `isRedisClusterOffline` flag is active, these methods will instantly read/write to the local array cache instead of attempting to query the offline Redis cluster.
   - If an ongoing command fails due to a sudden dropout, the `catch` blocks will automatically fall back to the local cache as well.
4. **Metrics and Logging**:
   - Added `logger.warn` statements that log specific metrics when the cluster status transitions between `offline` and `online`.

#### Acceptance Criteria Met
- [x] Catch Redis connection failure events.
- [x] Utilize local array caches during outages.
- [x] Log warn metrics of cluster status.