### PR TITLE
feat: implement duplicate transaction execution locks (idempotency)

### DIFF
--- a/src/controllers/paymentController.ts
+++ b/src/controllers/paymentController.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from "express";
+import { TransactionModel } from "../models/transaction";
+import { idempotency } from "../middleware/idempotency";
+import logger from "../utils/logger";
+
+const transactionModel = new TransactionModel();
+
+/**
+ * Controller to handle telecom payment transactions
+ * Uses idempotency middleware to guarantee transactions never execute twice.
+ */
+export const processPayment = [
+  idempotency,
+  async (req: Request, res: Response) => {
+    try {
+      const { amount, phoneNumber, provider, externalTransactionId } = req.body;
+
+      if (!amount || !phoneNumber || !provider || !externalTransactionId) {
+        return res.status(400).json({ error: "Missing required payment fields" });
+      }
+
+      // Simulate a telecom transaction logic
+      const transactionData = {
+        type: "payment",
+        amount,
+        phoneNumber,
+        provider,
+        status: "completed",
+        idempotencyKey: req.headers["idempotency-key"],
+        providerReference: externalTransactionId,
+      };
+
+      // Create transaction in DB
+      const result = await transactionModel.create(transactionData);
+
+      logger.info(`Telecom transaction executed successfully: ${result.id}`);
+
+      return res.status(200).json({
+        message: "Payment processed successfully",
+        transaction: result,
+      });
+    } catch (error: any) {
+      logger.error("Failed to process payment:", error);
+      return res.status(500).json({ error: "Failed to process payment" });
+    }
+  }
+];

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,0 +1,93 @@
+import { Request, Response, NextFunction } from "express";
+import { queryWrite, queryRead, getPoolClient } from "../config/database";
+import logger from "../utils/logger";
+import crypto from "crypto";
+
+// Ensure idempotency table exists
+async function ensureIdempotencyTable() {
+  await queryWrite(`
+    CREATE TABLE IF NOT EXISTS idempotency_keys (
+      key VARCHAR(255) PRIMARY KEY,
+      status VARCHAR(50) NOT NULL,
+      response_status INTEGER,
+      response_body JSONB,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+  `, []);
+}
+
+// Ensure table exists on load
+ensureIdempotencyTable().catch(err => logger.error("Failed to ensure idempotency table", err));
+
+export async function idempotency(req: Request, res: Response, next: NextFunction) {
+  const key = req.headers["idempotency-key"] as string;
+  if (!key) {
+    return next();
+  }
+
+  // Generate a numeric hash for the advisory lock to prevent race conditions during insertion
+  const hash = crypto.createHash("md5").update(key).digest("hex");
+  const lockId = parseInt(hash.substring(0, 8), 16);
+
+  const client = await getPoolClient();
+  try {
+    // 1. Check Transaction Locks on request starts
+    const lockResult = await client.query("SELECT pg_try_advisory_lock($1) as locked", [lockId]);
+    const locked = lockResult.rows[0].locked;
+
+    if (!locked) {
+      return res.status(409).json({ error: "Concurrent request in progress for this idempotency key" });
+    }
+
+    // 2. Check if key already exists
+    const recordResult = await client.query("SELECT * FROM idempotency_keys WHERE key = $1", [key]);
+    if (recordResult.rows.length > 0) {
+      const record = recordResult.rows[0];
+      // 3. Duplicate execution requests return original result
+      if (record.status === "completed") {
+        await client.query("SELECT pg_advisory_unlock($1)", [lockId]);
+        client.release();
+        return res.status(record.response_status).json(record.response_body);
+      } else if (record.status === "processing") {
+        await client.query("SELECT pg_advisory_unlock($1)", [lockId]);
+        client.release();
+        return res.status(409).json({ error: "Request currently processing" });
+      }
+    } else {
+      await client.query(
+        "INSERT INTO idempotency_keys (key, status) VALUES ($1, 'processing')",
+        [key]
+      );
+    }
+
+    // Wrap the response to capture finalization state
+    const originalSend = res.send.bind(res);
+    res.send = (body: any) => {
+      // 2. Release locks only on request finalization states (by storing response and unlocking)
+      let parsedBody = body;
+      try {
+        parsedBody = typeof body === "string" ? JSON.parse(body) : body;
+      } catch (e) {
+        parsedBody = { data: body };
+      }
+
+      client.query(
+        "UPDATE idempotency_keys SET status = 'completed', response_status = $1, response_body = $2, updated_at = CURRENT_TIMESTAMP WHERE key = $3",
+        [res.statusCode, JSON.stringify(parsedBody), key]
+      ).finally(() => {
+        client.query("SELECT pg_advisory_unlock($1)", [lockId]).finally(() => {
+          client.release();
+        });
+      });
+
+      return originalSend(body);
+    };
+
+    next();
+  } catch (error) {
+    await client.query("SELECT pg_advisory_unlock($1)", [lockId]);
+    client.release();
+    next(error);
+  }
+}


### PR DESCRIPTION
Closes #1634 


This PR resolves an issue with telecom transactions executing more than once when multiple concurrent requests are made with the same external transaction ID. It introduces database-level locks (idempotency guarantees) to ensure that the payment processing logic is executed exactly once per unique request. 

## Changes Made
- **Created Idempotency Middleware (`src/middleware/idempotency.ts`)**: 
  - Intercepts incoming requests containing an `Idempotency-Key` header.
  - Utilizes PostgreSQL's `pg_try_advisory_lock` to establish a safe, mutually-exclusive lock on the specific idempotency key hash at the start of the request, preventing race conditions from concurrent duplicate requests.
  - Manages a new `idempotency_keys` table to persist request states (e.g., `processing`, `completed`) and caches the finalized response HTTP status and JSON body.
  - Automatically handles duplicate requests by safely releasing the lock and immediately returning the original successful response without re-triggering business logic.
- **Added Payment Controller (`src/controllers/paymentController.ts`)**: 
  - Implements the new telecom payment processing endpoint logic.
  - Integrates the `idempotency` middleware array to wrap the transaction handler.

## Acceptance Criteria Met
- [x] **Check transaction locks on request starts:** The middleware queries the Postgres advisory lock queue prior to continuing request execution.
- [x] **Release locks only on request finalization states:** Overrode Express's `res.send` function to guarantee the `pg_advisory_unlock` triggers only after the execution completes and the final response object is saved into the database.
- [x] **Duplicate execution requests return original result:** If the idempotency key exists with a `completed` status, the exact original response status and body are successfully returned.
