### PR TITLE
feat(moov): implement Côte d'Ivoire deposit endpoints (closes #1560)

### DIFF
--- a/src/config/__tests__/appConfig.test.ts
+++ b/src/config/__tests__/appConfig.test.ts
@@ -67,7 +67,7 @@ describe("Centralized Configuration System", () => {
   });
 
   test("all provider limits should be properly configured", () => {
-    const providers = ["mtn", "airtel", "orange"];
+    const providers = ["mtn", "airtel", "orange", "moovCoteDivoire"];
 
     providers.forEach((provider) => {
       const minAmount = getConfigValue(`providers.${provider}.minAmount`);
@@ -76,5 +76,15 @@ describe("Centralized Configuration System", () => {
       expect(minAmount).toBeGreaterThan(0);
       expect(maxAmount).toBeGreaterThan(minAmount);
     });
+  });
+
+  test("should configure Moov Côte d'Ivoire for XOF deposit pushes", () => {
+    expect(getConfigValue("providers.moovCoteDivoire.currency")).toBe("XOF");
+    expect(getConfigValue("providers.moovCoteDivoire.authPath")).toBe(
+      "/oauth/token",
+    );
+    expect(getConfigValue("providers.moovCoteDivoire.depositPushPath")).toBe(
+      "/payments/deposit",
+    );
   });
 });

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -136,6 +136,62 @@ export const configSchema = convict({
         env: "MTN_UG_CURRENCY",
       },
     },
+    moovCoteDivoire: {
+      minAmount: {
+        doc: "Minimum transaction amount for Moov Côte d'Ivoire (XOF)",
+        format: "nat",
+        default: 100,
+        env: "MOOV_CI_MIN_AMOUNT",
+      },
+      maxAmount: {
+        doc: "Maximum transaction amount for Moov Côte d'Ivoire (XOF)",
+        format: "nat",
+        default: 1000000,
+        env: "MOOV_CI_MAX_AMOUNT",
+      },
+      baseUrl: {
+        doc: "Base URL for the Moov Côte d'Ivoire API",
+        format: String,
+        default: "",
+        env: "MOOV_CI_BASE_URL",
+      },
+      authPath: {
+        doc: "Path for acquiring a Moov Côte d'Ivoire access token",
+        format: String,
+        default: "/oauth/token",
+        env: "MOOV_CI_AUTH_PATH",
+      },
+      depositPushPath: {
+        doc: "Path for triggering a Moov Côte d'Ivoire deposit push",
+        format: String,
+        default: "/payments/deposit",
+        env: "MOOV_CI_DEPOSIT_PUSH_PATH",
+      },
+      apiKey: {
+        doc: "Client ID for the Moov Côte d'Ivoire API",
+        format: String,
+        default: "",
+        env: "MOOV_CI_API_KEY",
+      },
+      apiSecret: {
+        doc: "Client secret for the Moov Côte d'Ivoire API",
+        format: String,
+        default: "",
+        env: "MOOV_CI_API_SECRET",
+      },
+      currency: {
+        doc: "Currency code for Moov Côte d'Ivoire transactions",
+        format: ["XOF"],
+        default: "XOF",
+        env: "MOOV_CI_CURRENCY",
+      },
+      timeoutMs: {
+        doc: "HTTP timeout for Moov Côte d'Ivoire API requests",
+        format: "nat",
+        default: 10000,
+        env: "MOOV_CI_TIMEOUT_MS",
+      },
+    },
     airtel: {
       minAmount: {
         doc: "Minimum transaction amount for Airtel (XAF)",

--- a/src/services/providers/__tests__/moovCoteDivoire.test.ts
+++ b/src/services/providers/__tests__/moovCoteDivoire.test.ts
@@ -1,0 +1,168 @@
+import axios from "axios";
+import { MoovCoteDivoireProvider } from "../moovCoteDivoire";
+
+jest.mock("axios");
+
+const axiosMock = axios as jest.Mocked<typeof axios>;
+
+const providerConfig = {
+  apiKey: "test-client-id",
+  apiSecret: "test-client-secret",
+  baseUrl: "https://moov.example.test",
+  authPath: "/auth/token",
+  depositPushPath: "/deposits/push",
+  timeoutMs: 5_000,
+};
+
+describe("MoovCoteDivoireProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getAccessToken", () => {
+    it("acquires and caches an access token", async () => {
+      axiosMock.post.mockResolvedValueOnce({
+        data: { access_token: "moov-token", expires_in: 3600 },
+      });
+      const provider = new MoovCoteDivoireProvider(providerConfig);
+
+      await expect(provider.getAccessToken()).resolves.toBe("moov-token");
+      await expect(provider.getAccessToken()).resolves.toBe("moov-token");
+
+      expect(axiosMock.post).toHaveBeenCalledTimes(1);
+      expect(axiosMock.post).toHaveBeenCalledWith(
+        "https://moov.example.test/auth/token",
+        { grant_type: "client_credentials" },
+        {
+          headers: {
+            Authorization: `Basic ${Buffer.from(
+              "test-client-id:test-client-secret",
+            ).toString("base64")}`,
+            "Content-Type": "application/json",
+          },
+          timeout: 5_000,
+        },
+      );
+    });
+
+    it("rejects an incomplete token response", async () => {
+      axiosMock.post.mockResolvedValueOnce({
+        data: { expires_in: 3600 },
+      });
+      const provider = new MoovCoteDivoireProvider(providerConfig);
+
+      await expect(provider.getAccessToken()).rejects.toThrow(
+        "token response is missing required fields",
+      );
+    });
+
+    it("rejects incomplete provider configuration", async () => {
+      const provider = new MoovCoteDivoireProvider({
+        ...providerConfig,
+        apiSecret: "",
+      });
+
+      await expect(provider.getAccessToken()).rejects.toThrow(
+        "API configuration is incomplete",
+      );
+      expect(axiosMock.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("triggerDepositPush", () => {
+    it("triggers an authenticated XOF deposit push", async () => {
+      axiosMock.post
+        .mockResolvedValueOnce({
+          data: { access_token: "moov-token", expires_in: 3600 },
+        })
+        .mockResolvedValueOnce({
+          data: { transactionId: "moov-transaction-1", status: "PENDING" },
+        });
+      const provider = new MoovCoteDivoireProvider(providerConfig);
+
+      const result = await provider.triggerDepositPush(
+        "+225 07 01 02 03 04",
+        "5000",
+        "deposit-1",
+      );
+
+      expect(result).toEqual({
+        success: true,
+        referenceId: "deposit-1",
+        data: {
+          transactionId: "moov-transaction-1",
+          status: "PENDING",
+        },
+      });
+      expect(axiosMock.post).toHaveBeenNthCalledWith(
+        2,
+        "https://moov.example.test/deposits/push",
+        {
+          amount: 5000,
+          currency: "XOF",
+          phoneNumber: "2250701020304",
+          referenceId: "deposit-1",
+        },
+        {
+          headers: {
+            Authorization: "Bearer moov-token",
+            "Content-Type": "application/json",
+          },
+          timeout: 5_000,
+        },
+      );
+    });
+
+    it("rejects phone numbers outside Côte d'Ivoire", async () => {
+      const provider = new MoovCoteDivoireProvider(providerConfig);
+
+      const result = await provider.triggerDepositPush(
+        "+2348012345678",
+        5000,
+        "deposit-2",
+      );
+
+      expect(result).toEqual({
+        success: false,
+        referenceId: "deposit-2",
+        error: "Invalid Côte d'Ivoire phone number",
+      });
+      expect(axiosMock.post).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-positive deposit amounts", async () => {
+      const provider = new MoovCoteDivoireProvider(providerConfig);
+
+      const result = await provider.triggerDepositPush(
+        "0701020304",
+        0,
+        "deposit-3",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Deposit amount must be greater than zero");
+      expect(axiosMock.post).not.toHaveBeenCalled();
+    });
+
+    it("returns a safe error when the provider request fails", async () => {
+      axiosMock.post
+        .mockResolvedValueOnce({
+          data: { access_token: "moov-token", expires_in: 3600 },
+        })
+        .mockRejectedValueOnce(new Error("upstream failure"));
+      const provider = new MoovCoteDivoireProvider(providerConfig);
+
+      const result = await provider.requestPayment(
+        "0701020304",
+        "5000",
+        "deposit-4",
+      );
+
+      expect(result).toEqual({
+        success: false,
+        referenceId: "deposit-4",
+        error: "Moov Côte d'Ivoire deposit push failed",
+      });
+    });
+  });
+});

--- a/src/services/providers/moovCoteDivoire.ts
+++ b/src/services/providers/moovCoteDivoire.ts
@@ -1,0 +1,226 @@
+import axios, { AxiosError } from "axios";
+import { randomUUID } from "crypto";
+import { getConfigValue } from "../../config/appConfig";
+import logger from "../../utils/logger";
+import { maskPII } from "../../utils/masking";
+import { BaseProvider, ProviderAuthConfig } from "./baseProvider";
+
+const DEFAULT_AUTH_PATH = "/oauth/token";
+const DEFAULT_DEPOSIT_PUSH_PATH = "/payments/deposit";
+const DEFAULT_CURRENCY = "XOF";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+interface MoovTokenResponse {
+  access_token?: string;
+  expires_in?: number | string;
+}
+
+interface MoovCoteDivoireAppConfig {
+  apiKey: string;
+  apiSecret: string;
+  baseUrl: string;
+  authPath: string;
+  depositPushPath: string;
+  currency: string;
+  timeoutMs: number;
+}
+
+export interface MoovCoteDivoireConfig extends Partial<ProviderAuthConfig> {
+  authPath?: string;
+  depositPushPath?: string;
+  currency?: string;
+}
+
+interface ResolvedMoovCoteDivoireConfig extends ProviderAuthConfig {
+  authPath: string;
+  depositPushPath: string;
+  currency: string;
+}
+
+export interface MoovDepositPushResult {
+  success: boolean;
+  referenceId: string;
+  data?: unknown;
+  error?: string;
+}
+
+function getAppConfig(): MoovCoteDivoireAppConfig {
+  return getConfigValue(
+    "providers.moovCoteDivoire",
+  ) as MoovCoteDivoireAppConfig;
+}
+
+function buildConfig(
+  options: MoovCoteDivoireConfig = {},
+): ResolvedMoovCoteDivoireConfig {
+  const appConfig = getAppConfig();
+
+  return {
+    apiKey: options.apiKey ?? appConfig.apiKey,
+    apiSecret: options.apiSecret ?? appConfig.apiSecret,
+    baseUrl: options.baseUrl ?? appConfig.baseUrl,
+    timeoutMs: options.timeoutMs ?? appConfig.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    tokenExpiryLeewaySeconds: options.tokenExpiryLeewaySeconds ?? 30,
+    authPath: options.authPath ?? appConfig.authPath ?? DEFAULT_AUTH_PATH,
+    depositPushPath:
+      options.depositPushPath ??
+      appConfig.depositPushPath ??
+      DEFAULT_DEPOSIT_PUSH_PATH,
+    currency: options.currency ?? appConfig.currency ?? DEFAULT_CURRENCY,
+  };
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function normalizePhoneNumber(phoneNumber: string): string {
+  const digits = phoneNumber.replace(/\D/g, "");
+
+  if (digits.startsWith("225")) {
+    return digits;
+  }
+  return `225${digits}`;
+}
+
+export class MoovCoteDivoireProvider extends BaseProvider {
+  private readonly authPath: string;
+  private readonly depositPushPath: string;
+  private readonly currency: string;
+
+  constructor(options: MoovCoteDivoireConfig = {}) {
+    const config = buildConfig(options);
+    super(config);
+    this.authPath = config.authPath;
+    this.depositPushPath = config.depositPushPath;
+    this.currency = config.currency;
+  }
+
+  public validatePhoneNumber(phoneNumber: string): boolean {
+    return /^225\d{10}$/.test(normalizePhoneNumber(phoneNumber));
+  }
+
+  public async getAccessToken(): Promise<string> {
+    if (this.isTokenValid()) {
+      return this.cachedToken!;
+    }
+
+    if (!this.apiKey || !this.apiSecret || !this.baseUrl) {
+      throw new Error("Moov Côte d'Ivoire API configuration is incomplete");
+    }
+
+    const response = await axios.post<MoovTokenResponse>(
+      joinUrl(this.baseUrl, this.authPath),
+      { grant_type: "client_credentials" },
+      {
+        headers: this.buildOAuth2TokenRequestHeaders(),
+        timeout: this.timeoutMs,
+      },
+    );
+
+    const accessToken = response.data?.access_token;
+    const expiresIn = Number(response.data?.expires_in);
+
+    if (
+      !accessToken ||
+      typeof accessToken !== "string" ||
+      !Number.isFinite(expiresIn) ||
+      expiresIn <= 0
+    ) {
+      throw new Error(
+        "Moov Côte d'Ivoire token response is missing required fields",
+      );
+    }
+
+    this.cacheToken(accessToken, expiresIn);
+    return accessToken;
+  }
+
+  public async triggerDepositPush(
+    phoneNumber: string,
+    amount: string | number,
+    requestId = randomUUID(),
+  ): Promise<MoovDepositPushResult> {
+    const normalizedPhoneNumber = normalizePhoneNumber(phoneNumber);
+    const numericAmount = Number(amount);
+
+    if (!/^225\d{10}$/.test(normalizedPhoneNumber)) {
+      return {
+        success: false,
+        referenceId: requestId,
+        error: "Invalid Côte d'Ivoire phone number",
+      };
+    }
+
+    if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+      return {
+        success: false,
+        referenceId: requestId,
+        error: "Deposit amount must be greater than zero",
+      };
+    }
+
+    const startedAt = Date.now();
+    try {
+      const accessToken = await this.getAccessToken();
+      const response = await axios.post(
+        joinUrl(this.baseUrl, this.depositPushPath),
+        {
+          amount: numericAmount,
+          currency: this.currency,
+          phoneNumber: normalizedPhoneNumber,
+          referenceId: requestId,
+        },
+        {
+          headers: {
+            Authorization: this.buildBearerAuthHeader(accessToken),
+            "Content-Type": "application/json",
+          },
+          timeout: this.timeoutMs,
+        },
+      );
+
+      logger.info(
+        maskPII({
+          referenceId: requestId,
+          phoneNumber: normalizedPhoneNumber,
+          durationMs: Date.now() - startedAt,
+        }),
+        "Moov Côte d'Ivoire deposit push requested",
+      );
+
+      return {
+        success: true,
+        referenceId: requestId,
+        data: response.data,
+      };
+    } catch (error: unknown) {
+      const statusCode =
+        error instanceof AxiosError ? error.response?.status : undefined;
+
+      logger.error(
+        maskPII({
+          referenceId: requestId,
+          phoneNumber: normalizedPhoneNumber,
+          durationMs: Date.now() - startedAt,
+          statusCode,
+        }),
+        "Moov Côte d'Ivoire deposit push failed",
+      );
+
+      return {
+        success: false,
+        referenceId: requestId,
+        error: "Moov Côte d'Ivoire deposit push failed",
+      };
+    }
+  }
+
+  public async requestPayment(
+    phoneNumber: string,
+    amount: string,
+    requestId?: string,
+  ): Promise<MoovDepositPushResult> {
+    return this.triggerDepositPush(phoneNumber, amount, requestId);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a dedicated Moov Money integration for Côte d’Ivoire XOF deposits. The implementation acquires and caches access tokens, validates Ivorian phone numbers, and triggers authenticated deposit-push requests.

## Changes

- `src/services/providers/moovCoteDivoire.ts`
  - Added Moov authentication and token caching.
  - Added XOF deposit-push handling.
  - Added phone-number and amount validation.
  - Added safe logging and error handling.
- `src/config/appConfig.ts`
  - Added centralized Moov Côte d’Ivoire credentials, paths, limits, currency, and timeout configuration.
- `src/services/providers/__tests__/moovCoteDivoire.test.ts`
  - Added authentication, caching, validation, deposit-push, and failure tests.
- `src/config/__tests__/appConfig.test.ts`
  - Added Moov configuration and limits coverage.

## Approach

- Reused the existing `BaseProvider` authentication and token-cache utilities.
- Followed existing Axios, Convict, Jest, logging, and PII-masking patterns.
- Kept API URLs and paths configurable.
- Enforced XOF as the provider currency.
- Introduced zero new libraries.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Testing

Testing was performed in a disposable Docker environment with lifecycle scripts disabled and networking disabled during test execution.

- Prettier completed successfully on all changed files.
- New Moov Côte d’Ivoire tests passed.
- Existing generic Moov tests passed.
- App configuration tests passed.
- 3 test suites passed.
- 33 tests passed.
- 0 failures.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the changes
- [x] No new warnings introduced by the implementation
- [x] Added tests for the new functionality
- [x] Relevant existing tests pass
- [x] Zero new dependencies introduced

Closes #1560
