### PR TITLE
feat(compliance): add database audit trails (closes #1572)

### DIFF
--- a/migrations/20260723_create_audit_logs.down.sql
+++ b/migrations/20260723_create_audit_logs.down.sql
@@ -1,0 +1,8 @@
+DROP TRIGGER IF EXISTS prevent_audit_log_delete ON audit_logs;
+DROP TRIGGER IF EXISTS prevent_audit_log_update ON audit_logs;
+DROP FUNCTION IF EXISTS prevent_audit_log_modification();
+
+DROP TRIGGER IF EXISTS compliance_document_status_audit
+  ON compliance_documents;
+DROP FUNCTION IF EXISTS log_compliance_document_status_change();
+

--- a/migrations/20260723_create_audit_logs.sql
+++ b/migrations/20260723_create_audit_logs.sql
@@ -1,0 +1,60 @@
+-- Add immutable audit trails for compliance document status changes.
+
+CREATE OR REPLACE FUNCTION log_compliance_document_status_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.updated_by IS NULL THEN
+    RAISE EXCEPTION
+      'updated_by is required when changing a compliance document status';
+  END IF;
+
+  INSERT INTO audit_logs (
+    admin_id,
+    action,
+    resource,
+    resource_id,
+    diff
+  )
+  VALUES (
+    NEW.updated_by,
+    'COMPLIANCE_STATUS_CHANGED',
+    'compliance_document',
+    NEW.id::TEXT,
+    jsonb_build_object(
+      'old_status', OLD.status,
+      'new_status', NEW.status
+    )
+  );
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS compliance_document_status_audit
+  ON compliance_documents;
+
+CREATE TRIGGER compliance_document_status_audit
+  AFTER UPDATE OF status ON compliance_documents
+  FOR EACH ROW
+  WHEN (OLD.status IS DISTINCT FROM NEW.status)
+  EXECUTE FUNCTION log_compliance_document_status_change();
+
+CREATE OR REPLACE FUNCTION prevent_audit_log_modification()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'Audit logs are immutable and cannot be modified or deleted';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS prevent_audit_log_update ON audit_logs;
+CREATE TRIGGER prevent_audit_log_update
+  BEFORE UPDATE ON audit_logs
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_audit_log_modification();
+
+DROP TRIGGER IF EXISTS prevent_audit_log_delete ON audit_logs;
+CREATE TRIGGER prevent_audit_log_delete
+  BEFORE DELETE ON audit_logs
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_audit_log_modification();
+

--- a/src/models/__tests__/auditLog.test.ts
+++ b/src/models/__tests__/auditLog.test.ts
@@ -1,0 +1,95 @@
+const mockPoolQuery = jest.fn();
+
+jest.mock("../../config/database", () => ({
+  pool: {
+    query: (...args: unknown[]) => mockPoolQuery(...args),
+  },
+}));
+
+import { AuditLogModel } from "../auditLog";
+
+describe("AuditLogModel", () => {
+  const model = new AuditLogModel();
+  const auditLog = {
+    id: "log-1",
+    adminId: "admin-1",
+    action: "COMPLIANCE_STATUS_CHANGED",
+    resource: "compliance_document",
+    resourceId: "document-1",
+    diff: {
+      old_status: "draft",
+      new_status: "published",
+    },
+    ipAddress: null,
+    userAgent: null,
+    createdAt: new Date("2026-07-23T00:00:00.000Z"),
+  };
+
+  beforeEach(() => {
+    mockPoolQuery.mockReset();
+  });
+
+  it("creates an audit log with a parameterized query", async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [auditLog] });
+
+    await expect(
+      model.create({
+        adminId: auditLog.adminId,
+        action: auditLog.action,
+        resource: auditLog.resource,
+        resourceId: auditLog.resourceId,
+        diff: auditLog.diff,
+      }),
+    ).resolves.toEqual(auditLog);
+
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO audit_logs"),
+      [
+        "admin-1",
+        "COMPLIANCE_STATUS_CHANGED",
+        "compliance_document",
+        "document-1",
+        JSON.stringify(auditLog.diff),
+        null,
+        null,
+      ],
+    );
+  });
+
+  it("finds an audit log by ID", async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [auditLog] });
+
+    await expect(model.findById("log-1")).resolves.toEqual(auditLog);
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("WHERE id = $1"),
+      ["log-1"],
+    );
+  });
+
+  it("returns null when an audit log does not exist", async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    await expect(model.findById("missing")).resolves.toBeNull();
+  });
+
+  it("lists audit logs using parameterized filters and pagination", async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [auditLog] });
+
+    await expect(
+      model.list({
+        adminId: "admin-1",
+        resource: "compliance_document",
+        resourceId: "document-1",
+        limit: 25,
+        offset: 5,
+      }),
+    ).resolves.toEqual([auditLog]);
+
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /admin_id = \$1[\s\S]+resource = \$2[\s\S]+resource_id = \$3/,
+      ),
+      ["admin-1", "compliance_document", "document-1", 25, 5],
+    );
+  });
+});

--- a/src/models/auditLog.ts
+++ b/src/models/auditLog.ts
@@ -1,0 +1,128 @@
+import { pool } from "../config/database";
+
+export interface AuditLog {
+  id: string;
+  adminId: string;
+  action: string;
+  resource: string;
+  resourceId: string | null;
+  diff: Record<string, unknown>;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: Date;
+}
+
+export interface CreateAuditLogInput {
+  adminId: string;
+  action: string;
+  resource: string;
+  resourceId?: string | null;
+  diff: Record<string, unknown>;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+}
+
+export interface AuditLogFilter {
+  adminId?: string;
+  resource?: string;
+  resourceId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+const selectFields = `
+  id,
+  admin_id AS "adminId",
+  action,
+  resource,
+  resource_id AS "resourceId",
+  diff,
+  ip_address AS "ipAddress",
+  user_agent AS "userAgent",
+  created_at AS "createdAt"
+`;
+
+export class AuditLogModel {
+  async create(input: CreateAuditLogInput): Promise<AuditLog> {
+    const result = await pool.query(
+      `
+        INSERT INTO audit_logs (
+          admin_id,
+          action,
+          resource,
+          resource_id,
+          diff,
+          ip_address,
+          user_agent
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        RETURNING ${selectFields}
+      `,
+      [
+        input.adminId,
+        input.action,
+        input.resource,
+        input.resourceId ?? null,
+        JSON.stringify(input.diff),
+        input.ipAddress ?? null,
+        input.userAgent ?? null,
+      ],
+    );
+
+    return result.rows[0];
+  }
+
+  async findById(id: string): Promise<AuditLog | null> {
+    const result = await pool.query(
+      `
+        SELECT ${selectFields}
+        FROM audit_logs
+        WHERE id = $1
+      `,
+      [id],
+    );
+
+    return result.rows[0] ?? null;
+  }
+
+  async list(filter: AuditLogFilter = {}): Promise<AuditLog[]> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filter.adminId) {
+      params.push(filter.adminId);
+      conditions.push(`admin_id = $${params.length}`);
+    }
+
+    if (filter.resource) {
+      params.push(filter.resource);
+      conditions.push(`resource = $${params.length}`);
+    }
+
+    if (filter.resourceId) {
+      params.push(filter.resourceId);
+      conditions.push(`resource_id = $${params.length}`);
+    }
+
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    params.push(filter.limit ?? 100);
+    const limitParameter = params.length;
+    params.push(filter.offset ?? 0);
+    const offsetParameter = params.length;
+
+    const result = await pool.query(
+      `
+        SELECT ${selectFields}
+        FROM audit_logs
+        ${whereClause}
+        ORDER BY created_at DESC
+        LIMIT $${limitParameter} OFFSET $${offsetParameter}
+      `,
+      params,
+    );
+
+    return result.rows;
+  }
+}


### PR DESCRIPTION
## Summary

Compliance document status changes were not automatically recorded in an immutable database audit trail.

This adds database-triggered audit logging for compliance document status transitions and prevents existing audit records from being updated or deleted.

## Changes

- `migrations/20260723_create_audit_logs.sql`
  - Adds a trigger that records compliance document status changes.
  - Records the responsible user, action, target document, and old/new statuses.
  - Adds database triggers that reject updates and deletions of audit records.
- `migrations/20260723_create_audit_logs.down.sql`
  - Removes the audit and immutability triggers and their functions.
- `src/models/auditLog.ts`
  - Adds typed, parameterized create and read operations for audit logs.
  - Deliberately exposes no update or delete operations.
- `src/models/__tests__/auditLog.test.ts`
  - Tests audit-log creation, retrieval, filtering, and pagination.

## Approach

- Used the existing `audit_logs` schema instead of introducing a duplicate audit table.
- Followed the repository's PostgreSQL trigger pattern for immutable ledger records.
- Logs only genuine status transitions using `IS DISTINCT FROM`.
- Requires an accountable `updated_by` user for every compliance status change.
- Uses parameterized database queries throughout.
- Zero new libraries introduced.

## Testing

- Focused Jest suite passed: 4 tests across 1 suite.
- Prettier verification passed for all changed TypeScript files.
- `git diff --check` passed.
- Validated the migration against an isolated PostgreSQL 16 Docker container.
- Confirmed a real compliance status transition creates exactly one audit record.
- Confirmed a no-op status assignment creates no additional record.
- Confirmed database attempts to update or delete audit records are rejected.

Closes #1572
