### PR TITLE
feat(compliance): enforce multi-tier KYC limits (closes #1565)

### DIFF
--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -11,8 +11,6 @@ import {
   TransactionStatus,
 } from "../models/transaction";
 import { lockManager, LockKeys } from "../utils/lock";
-import { TransactionLimitService } from "../services/transactionLimit/transactionLimitService";
-import { KYCService } from "../services/kyc/kycService";
 import {
   MobileMoneyProvider,
   validateProviderLimits,
@@ -24,7 +22,6 @@ import { twoFactorWithdrawalService } from "../services/twoFactorWithdrawalServi
 import { totpService } from "../services/auth/totp";
 import {
   CancelTransactionResponse,
-  LimitExceededErrorResponse,
   PhoneSearchResponse,
   TransactionDetailResponse,
   TransactionResponse,
@@ -38,6 +35,7 @@ import { ERROR_CODES } from "../constants/errorCodes";
 import { travelRuleService } from "../compliance/travelRule";
 import { createError } from "../middleware/errorHandler";
 import { sep08Service } from "../services/compliance/sep08";
+import { enforceKycCheck } from "../middleware/kycCheck";
 
 const IDEMPOTENCY_TTL_HOURS = Number(
   process.env.IDEMPOTENCY_KEY_TTL_HOURS || 24,
@@ -53,11 +51,6 @@ const stellarService = new StellarService();
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mobileMoneyService = new MobileMoneyService();
 const transactionModel = new TransactionModel();
-const kycService = new KYCService();
-const transactionLimitService = new TransactionLimitService(
-  kycService,
-  transactionModel,
-);
 
 async function addTransactionJob(
   data: TransactionJobData,
@@ -484,18 +477,21 @@ async function applyTravelRule(transaction: Transaction): Promise<void> {
  * Verifies approval status before ledger submission per SEP-08 specification.
  * Rejects transactions if verification returns failed status.
  */
-async function applySEP08Verification(
-  transaction: Transaction,
-): Promise<void> {
+async function applySEP08Verification(transaction: Transaction): Promise<void> {
   if (transaction.type !== "deposit") return;
 
   try {
     const paymentAsset = getConfiguredPaymentAsset();
-    const verificationResult =
-      await sep08Service.verifyDepositApproval(transaction, paymentAsset.code);
+    const verificationResult = await sep08Service.verifyDepositApproval(
+      transaction,
+      paymentAsset.code,
+    );
 
     if (verificationResult.status === "failed") {
-      await transactionModel.updateStatus(transaction.id, TransactionStatus.Failed);
+      await transactionModel.updateStatus(
+        transaction.id,
+        TransactionStatus.Failed,
+      );
       await transactionModel.addTags(transaction.id, ["sep08-rejected"]);
       await transactionModel.updateAdminNotes(
         transaction.id,
@@ -503,7 +499,8 @@ async function applySEP08Verification(
       );
 
       throw createError(ERROR_CODES.COMPLIANCE_REQUIRED, null, {
-        error: verificationResult.message || "SEP-08 compliance verification failed",
+        error:
+          verificationResult.message || "SEP-08 compliance verification failed",
         code: "SEP08_VERIFICATION_FAILED",
         details: {
           transactionId: transaction.id,
@@ -513,7 +510,10 @@ async function applySEP08Verification(
     }
 
     if (verificationResult.status === "pending") {
-      await transactionModel.updateStatus(transaction.id, TransactionStatus.Failed);
+      await transactionModel.updateStatus(
+        transaction.id,
+        TransactionStatus.Failed,
+      );
       await transactionModel.addTags(transaction.id, ["sep08-pending"]);
       await transactionModel.updateAdminNotes(
         transaction.id,
@@ -575,8 +575,7 @@ async function processTransactionRequest(
       req.body.provider = req.body.provider.toLowerCase();
     }
 
-    const { amount, phoneNumber, provider, stellarAddress, userId, notes } =
-      req.body;
+    const { amount, phoneNumber, provider, stellarAddress, notes } = req.body;
 
     const requestAmount = getRequestAmount(amount);
     if (!Number.isFinite(requestAmount) || requestAmount <= 0) {
@@ -606,32 +605,11 @@ async function processTransactionRequest(
       return res.status(400).json({ error: providerLimitCheck.error });
     }
 
-    const limitCheck = await transactionLimitService.checkTransactionLimit(
-      userId,
-      requestAmount,
-    );
-
-    if (!limitCheck.allowed) {
-      const body: LimitExceededErrorResponse = {
-        code: "TRANSACTION_LIMIT_EXCEEDED",
-        message: limitCheck.message || "Transaction limit exceeded",
-        message_en: "Transaction limit exceeded",
-        timestamp: new Date().toISOString(),
-        details: {
-          kycLevel: limitCheck.kycLevel,
-          dailyLimit: limitCheck.dailyLimit,
-          currentDailyTotal: limitCheck.currentDailyTotal,
-          remainingLimit: limitCheck.remainingLimit,
-          message: limitCheck.message,
-          upgradeAvailable: limitCheck.upgradeAvailable,
-        },
-      };
-
-      // return res.status(400).json(body);
-      throw createError(ERROR_CODES.INVALID_INPUT, null, {
-        body,
-      });
+    const kycOutcome = await enforceKycCheck(req, res);
+    if (!kycOutcome.allowed) {
+      return res;
     }
+    const { userId } = kycOutcome;
 
     // Check mandatory 2FA for withdrawals
     if (type === "withdraw") {
@@ -1212,10 +1190,7 @@ export const listAmlAlertsHandler = async (req: Request, res: Response) => {
 
     const alerts = amlService.getAlerts({
       status: statusFilter as
-        | "pending_review"
-        | "reviewed"
-        | "dismissed"
-        | undefined,
+        "pending_review" | "reviewed" | "dismissed" | undefined,
       userId: typeof userId === "string" ? userId : undefined,
       startDate: parsedStart,
       endDate: parsedEnd,

--- a/src/middleware/__tests__/kycCheck.test.ts
+++ b/src/middleware/__tests__/kycCheck.test.ts
@@ -1,0 +1,168 @@
+import { NextFunction, Request, Response } from "express";
+
+jest.mock("../../services/kyc/kycService", () => ({
+  KYCService: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock("../../models/transaction", () => ({
+  TransactionModel: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock("../../services/transactionLimit/transactionLimitService", () => ({
+  TransactionLimitService: jest.fn().mockImplementation(() => ({})),
+}));
+
+import { createKycCheck } from "../kycCheck";
+
+describe("kycCheck middleware", () => {
+  const kycLevels = {
+    unverified: "unverified",
+    basic: "basic",
+    full: "full",
+  } as const;
+  const checkTransactionLimit = jest.fn();
+  const middleware = createKycCheck({ checkTransactionLimit });
+
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: jest.MockedFunction<NextFunction>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    req = {
+      body: {
+        userId: "user-1",
+        amount: 5000,
+      },
+      jwtUser: {
+        userId: "user-1",
+      },
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    next = jest.fn();
+  });
+
+  it("retrieves the authenticated user's KYC limit and allows the request", async () => {
+    checkTransactionLimit.mockResolvedValue({
+      allowed: true,
+      kycLevel: kycLevels.unverified,
+      dailyLimit: 10000,
+      currentDailyTotal: 2000,
+      remainingLimit: 3000,
+    });
+
+    await middleware(req as Request, res as Response, next);
+
+    expect(checkTransactionLimit).toHaveBeenCalledWith("user-1", 5000);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 with Basic upgrade instructions for an unverified user", async () => {
+    checkTransactionLimit.mockResolvedValue({
+      allowed: false,
+      kycLevel: kycLevels.unverified,
+      dailyLimit: 10000,
+      currentDailyTotal: 8000,
+      remainingLimit: 2000,
+      message:
+        "Transaction limit exceeded. Upgrade to Basic KYC for 100,000 XAF daily limit.",
+      upgradeAvailable: true,
+    });
+
+    await middleware(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "TRANSACTION_LIMIT_EXCEEDED",
+        message: expect.stringContaining("Upgrade to Basic KYC"),
+        details: expect.objectContaining({
+          kycLevel: kycLevels.unverified,
+          dailyLimit: 10000,
+          upgradeAvailable: true,
+        }),
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 with Full upgrade instructions for a basic user", async () => {
+    checkTransactionLimit.mockResolvedValue({
+      allowed: false,
+      kycLevel: kycLevels.basic,
+      dailyLimit: 100000,
+      currentDailyTotal: 99000,
+      remainingLimit: 1000,
+      message:
+        "Transaction limit exceeded. Upgrade to Full KYC for 1,000,000 XAF daily limit.",
+      upgradeAvailable: true,
+    });
+
+    await middleware(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Upgrade to Full KYC"),
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("does not suggest an unavailable upgrade for a full KYC user", async () => {
+    checkTransactionLimit.mockResolvedValue({
+      allowed: false,
+      kycLevel: kycLevels.full,
+      dailyLimit: 1000000,
+      currentDailyTotal: 990000,
+      remainingLimit: 10000,
+      message: "Transaction limit exceeded for the full KYC daily limit.",
+      upgradeAvailable: false,
+    });
+
+    await middleware(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          kycLevel: kycLevels.full,
+          upgradeAvailable: false,
+        }),
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects a transaction for a different user than the JWT subject", async () => {
+    req.body = {
+      userId: "other-user",
+      amount: 5000,
+    };
+
+    await middleware(req as Request, res as Response, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "FORBIDDEN",
+        message: expect.stringContaining("authenticated user"),
+      }),
+    );
+    expect(checkTransactionLimit).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("passes service failures to the error handler", async () => {
+    const error = new Error("KYC lookup failed");
+    checkTransactionLimit.mockRejectedValue(error);
+
+    await middleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+});

--- a/src/middleware/kycCheck.ts
+++ b/src/middleware/kycCheck.ts
@@ -1,0 +1,137 @@
+import { NextFunction, Request, Response } from "express";
+import { TransactionModel } from "../models/transaction";
+import { KYCService } from "../services/kyc/kycService";
+import {
+  LimitCheckResult,
+  TransactionLimitService,
+} from "../services/transactionLimit/transactionLimitService";
+import { LimitExceededErrorResponse } from "../types/api";
+
+interface KycLimitChecker {
+  checkTransactionLimit(
+    userId: string,
+    transactionAmount: number,
+  ): Promise<LimitCheckResult>;
+}
+
+export type KycCheckOutcome =
+  | {
+      allowed: true;
+      userId: string;
+      limitCheck: LimitCheckResult;
+    }
+  | {
+      allowed: false;
+    };
+
+const transactionLimitService = new TransactionLimitService(
+  new KYCService(),
+  new TransactionModel(),
+);
+
+function buildLimitExceededResponse(
+  limitCheck: LimitCheckResult,
+): LimitExceededErrorResponse {
+  const message = limitCheck.message || "Transaction limit exceeded";
+
+  return {
+    code: "TRANSACTION_LIMIT_EXCEEDED",
+    message,
+    message_en: message,
+    timestamp: new Date().toISOString(),
+    details: {
+      kycLevel: limitCheck.kycLevel,
+      dailyLimit: limitCheck.dailyLimit,
+      currentDailyTotal: limitCheck.currentDailyTotal,
+      remainingLimit: limitCheck.remainingLimit,
+      message,
+      upgradeAvailable: limitCheck.upgradeAvailable,
+    },
+  };
+}
+
+function getRequestedUserId(req: Request): string | null {
+  return typeof req.body?.userId === "string" && req.body.userId.trim()
+    ? req.body.userId
+    : null;
+}
+
+export async function enforceKycCheck(
+  req: Request,
+  res: Response,
+  limitChecker: KycLimitChecker = transactionLimitService,
+): Promise<KycCheckOutcome> {
+  const authenticatedUserId = req.jwtUser?.userId;
+  const requestedUserId = getRequestedUserId(req);
+
+  if (
+    authenticatedUserId &&
+    requestedUserId &&
+    authenticatedUserId !== requestedUserId
+  ) {
+    res.status(403).json({
+      code: "FORBIDDEN",
+      message: "The transaction user must match the authenticated user.",
+      message_en: "The transaction user must match the authenticated user.",
+      timestamp: new Date().toISOString(),
+    });
+    return { allowed: false };
+  }
+
+  const userId = authenticatedUserId || requestedUserId;
+  if (!userId) {
+    res.status(401).json({
+      code: "UNAUTHORIZED",
+      message: "Authentication is required to verify transaction limits.",
+      message_en: "Authentication is required to verify transaction limits.",
+      timestamp: new Date().toISOString(),
+    });
+    return { allowed: false };
+  }
+
+  const transactionAmount = Number(req.body?.amount);
+  if (!Number.isFinite(transactionAmount) || transactionAmount <= 0) {
+    res.status(400).json({
+      code: "INVALID_AMOUNT",
+      message: "Amount must be a positive number.",
+      message_en: "Amount must be a positive number.",
+      timestamp: new Date().toISOString(),
+    });
+    return { allowed: false };
+  }
+
+  const limitCheck = await limitChecker.checkTransactionLimit(
+    userId,
+    transactionAmount,
+  );
+
+  if (!limitCheck.allowed) {
+    const statusCode = limitCheck.dailyLimit > 0 ? 403 : 400;
+    res.status(statusCode).json(buildLimitExceededResponse(limitCheck));
+    return { allowed: false };
+  }
+
+  req.body.userId = userId;
+  return { allowed: true, userId, limitCheck };
+}
+
+export function createKycCheck(
+  limitChecker: KycLimitChecker = transactionLimitService,
+) {
+  return async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const outcome = await enforceKycCheck(req, res, limitChecker);
+      if (outcome.allowed) {
+        next();
+      }
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+export const kycCheck = createKycCheck();

--- a/tests/controllers/transactionIdempotency.test.ts
+++ b/tests/controllers/transactionIdempotency.test.ts
@@ -51,10 +51,14 @@ jest.mock(
 );
 
 jest.mock("../../src/models/transaction", () => {
-  const actual = jest.requireActual("../../src/models/transaction");
   return {
-    ...actual,
     TransactionModel: jest.fn().mockImplementation(() => mockTransactionModel),
+    TransactionStatus: {
+      Pending: "pending",
+      Completed: "completed",
+      Failed: "failed",
+      Cancelled: "cancelled",
+    },
   };
 });
 
@@ -84,22 +88,28 @@ jest.mock("../../src/middleware/timeout", () => ({
 
 jest.mock("../../src/middleware/auth", () => ({
   authenticateToken: (req: any, _res: any, next: () => void) => {
-    req.jwtUser = { userId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", role: "user" };
+    req.jwtUser = {
+      userId: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+      role: "user",
+    };
     req.user = { id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", role: "user" };
     next();
   },
 }));
 
 jest.mock("../../src/middleware/checkAccountStatus", () => ({
-  checkAccountStatusStrict: (_req: unknown, _res: unknown, next: () => void) => next(),
+  checkAccountStatusStrict: (_req: unknown, _res: unknown, next: () => void) =>
+    next(),
 }));
 
 jest.mock("../../src/middleware/geoFencing", () => ({
-  geoFencingMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  geoFencingMiddleware: (_req: unknown, _res: unknown, next: () => void) =>
+    next(),
 }));
 
 jest.mock("../../src/middleware/geolocate", () => ({
-  geolocateMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  geolocateMiddleware: (_req: unknown, _res: unknown, next: () => void) =>
+    next(),
 }));
 
 import { transactionRoutes } from "../../src/routes/transactions";
@@ -233,6 +243,59 @@ describe("transaction idempotency routes", () => {
       mockTransactionModel.releaseExpiredIdempotencyKey,
     ).toHaveBeenCalledWith("expired-key");
     expect(mockTransactionModel.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 403 with upgrade instructions when the KYC daily limit is exceeded", async () => {
+    mockTransactionLimitService.checkTransactionLimit.mockResolvedValue({
+      allowed: false,
+      kycLevel: "unverified",
+      dailyLimit: 10000,
+      currentDailyTotal: 9000,
+      remainingLimit: 1000,
+      message:
+        "Transaction limit exceeded. Upgrade to Basic KYC for 100,000 XAF daily limit.",
+      upgradeAvailable: true,
+    });
+
+    const response = await request(createApp())
+      .post("/api/transactions/deposit")
+      .send(buildPayload());
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        code: "TRANSACTION_LIMIT_EXCEEDED",
+        message: expect.stringContaining("Upgrade to Basic KYC"),
+        details: expect.objectContaining({
+          kycLevel: "unverified",
+          dailyLimit: 10000,
+          upgradeAvailable: true,
+        }),
+      }),
+    );
+    expect(mockTransactionModel.create).not.toHaveBeenCalled();
+    expect(mockAddTransactionJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body userId that does not match the authenticated user", async () => {
+    const response = await request(createApp())
+      .post("/api/transactions/deposit")
+      .send({
+        ...buildPayload(),
+        userId: "different-user",
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        code: "FORBIDDEN",
+        message: expect.stringContaining("authenticated user"),
+      }),
+    );
+    expect(
+      mockTransactionLimitService.checkTransactionLimit,
+    ).not.toHaveBeenCalled();
+    expect(mockTransactionModel.create).not.toHaveBeenCalled();
   });
 
   it("reuses the stored transaction when the unique constraint detects a race", async () => {


### PR DESCRIPTION
## Summary

Adds multi-tier KYC enforcement to transaction creation. Transactions exceeding the user’s daily KYC-tier limit now receive a 403 Forbidden response with clear upgrade instructions.

## Changes

- `src/middleware/kycCheck.ts`
  - Retrieves the authenticated user’s KYC tier.
  - Applies existing daily transaction-limit checks.
  - Rejects tier-limit violations with a structured 403 response.
  - Prevents transaction requests from using a different user ID than the authenticated user.

- `src/controllers/transactionController.ts`
  - Integrates the shared KYC enforcement logic into transaction creation.
  - Uses the authenticated identity when creating transactions.

- `src/middleware/__tests__/kycCheck.test.ts`
  - Adds coverage for all KYC tiers, identity mismatches, allowed transactions, and error propagation.

- `tests/controllers/transactionIdempotency.test.ts`
  - Adds controller coverage for KYC-limit rejection and authenticated-user enforcement.
  - Isolates the transaction model mock from database initialization.

## Approach

- Reused the existing `KYCService` and `TransactionLimitService`.
- Followed existing middleware, controller, and error-response patterns.
- Preserved the current tier limits and rolling daily-volume calculations.
- Introduced zero new libraries.

## Testing

- 20 relevant Jest tests passed.
- Both newly added controller KYC cases passed.
- Prettier validation passed on all changed files.
- `git diff --check` passed.
- Tests ran in an isolated Docker environment with dependency scripts disabled.

The broader test run also identified unrelated existing test-harness issues: two older idempotency cases time out through an unmocked SEP08 path, and two existing controller suites reference a missing `.js` queue module.

Closes #1565