### PR TITLE
Feat/1669 refund inspection portal

### DIFF
--- a/migrations/20260729_add_kyc_compliance_overrides.down.sql
+++ b/migrations/20260729_add_kyc_compliance_overrides.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_kyc_applicants_override_status;
+
+ALTER TABLE kyc_applicants
+  DROP COLUMN IF EXISTS override_status,
+  DROP COLUMN IF EXISTS override_reason,
+  DROP COLUMN IF EXISTS overridden_by,
+  DROP COLUMN IF EXISTS overridden_at;

--- a/migrations/20260729_add_kyc_compliance_overrides.sql
+++ b/migrations/20260729_add_kyc_compliance_overrides.sql
@@ -1,0 +1,22 @@
+-- Manual compliance override support for automated KYC decisions (#1574)
+-- Lets an admin/compliance officer override the automated verification_status
+-- on a kyc_applicants record, with a full audit trail of who/when/why.
+
+ALTER TABLE kyc_applicants
+  ADD COLUMN IF NOT EXISTS override_status VARCHAR(20)
+    CHECK (override_status IN ('approved', 'rejected')),
+  ADD COLUMN IF NOT EXISTS override_reason TEXT,
+  ADD COLUMN IF NOT EXISTS overridden_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS overridden_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS idx_kyc_applicants_override_status
+  ON kyc_applicants(override_status);
+
+COMMENT ON COLUMN kyc_applicants.override_status IS
+  'Manual decision applied by a compliance officer/admin, overriding the automated verification_status. NULL means no manual override has been made.';
+COMMENT ON COLUMN kyc_applicants.override_reason IS
+  'Free-text reason recorded by the reviewer for the manual override.';
+COMMENT ON COLUMN kyc_applicants.overridden_by IS
+  'Admin/compliance officer user id who applied the manual override.';
+COMMENT ON COLUMN kyc_applicants.overridden_at IS
+  'Timestamp the manual override was applied.';

--- a/public/app.js
+++ b/public/app.js
@@ -481,3 +481,102 @@ setInterval(loadProviderMaintenance, 60000);
 const btnRefreshFailover = document.getElementById("btn-refresh-failover");
 if (btnRefreshFailover)
   btnRefreshFailover.addEventListener("click", loadProviderMaintenance);
+
+// Compliance Overrides Dashboard (#1574)
+async function overrideKycDecision(applicantRecordId, overrideStatus) {
+  const token = window.prompt(
+    "Admin auth token required to override this KYC decision:",
+  );
+  if (!token) return;
+
+  const reason =
+    window.prompt(`Reason for marking as ${overrideStatus} (optional):`, "") ||
+    undefined;
+
+  try {
+    const res = await fetch(
+      `/api/admin/monitoring/compliance/overrides/${encodeURIComponent(applicantRecordId)}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ overrideStatus, reason }),
+      },
+    );
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      alert(`Failed to override decision: ${body.message || res.status}`);
+      return;
+    }
+
+    await loadComplianceOverrides();
+  } catch (err) {
+    alert(`Failed to override decision: ${err.message || "network error"}`);
+  }
+}
+
+function renderComplianceCard(a) {
+  const effectiveStatus = a.override_status || a.verification_status;
+  const statusClass =
+    effectiveStatus === "approved"
+      ? "failover-online"
+      : effectiveStatus === "rejected"
+        ? "failover-offline"
+        : "";
+  const overrideHtml = a.override_status
+    ? `<div class="failover-reason">Manually overridden to "${a.override_status}"${a.override_reason ? `: ${a.override_reason}` : ""}</div>`
+    : "";
+
+  const card = document.createElement("div");
+  card.className = `failover-card glass ${statusClass}`;
+  card.innerHTML = `
+    <div class="failover-provider-name">${a.phone_number || a.applicant_id}</div>
+    <div class="failover-status">${effectiveStatus}</div>
+    ${overrideHtml}
+    <button class="btn-toggle-provider" data-action="approved">Approve</button>
+    <button class="btn-toggle-provider" data-action="rejected">Reject</button>
+  `;
+  card
+    .querySelector('[data-action="approved"]')
+    .addEventListener("click", () => overrideKycDecision(a.id, "approved"));
+  card
+    .querySelector('[data-action="rejected"]')
+    .addEventListener("click", () => overrideKycDecision(a.id, "rejected"));
+  return card;
+}
+
+async function loadComplianceOverrides() {
+  const grid = document.getElementById("compliance-grid");
+  const updatedAt = document.getElementById("compliance-updated-at");
+  if (!grid) return;
+
+  try {
+    const res = await fetch("/api/admin/monitoring/compliance/overrides");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (!data.success || !Array.isArray(data.applicants)) {
+      throw new Error("Unexpected response");
+    }
+
+    grid.innerHTML = "";
+    if (data.applicants.length === 0) {
+      grid.innerHTML = '<p class="failover-loading">No KYC applicants found.</p>';
+    } else {
+      data.applicants.forEach((a) => grid.appendChild(renderComplianceCard(a)));
+    }
+
+    if (updatedAt) updatedAt.textContent = new Date().toLocaleTimeString();
+  } catch (err) {
+    grid.innerHTML = '<p class="failover-loading">Failed to load compliance overrides.</p>';
+    if (updatedAt) updatedAt.textContent = "unavailable";
+  }
+}
+
+loadComplianceOverrides();
+
+const btnRefreshCompliance = document.getElementById("btn-refresh-compliance");
+if (btnRefreshCompliance)
+  btnRefreshCompliance.addEventListener("click", loadComplianceOverrides);

--- a/public/app.js
+++ b/public/app.js
@@ -580,3 +580,99 @@ loadComplianceOverrides();
 const btnRefreshCompliance = document.getElementById("btn-refresh-compliance");
 if (btnRefreshCompliance)
   btnRefreshCompliance.addEventListener("click", loadComplianceOverrides);
+
+// Refund Status Inspection Portal (#1669)
+async function triggerRefund(transactionId) {
+  const token = window.prompt(
+    "Admin auth token required to trigger this refund:",
+  );
+  if (!token) return;
+
+  try {
+    const res = await fetch(`/api/admin/transactions/${encodeURIComponent(transactionId)}/refund`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const body = await res.json().catch(() => ({}));
+
+    if (!res.ok) {
+      alert(`Failed to trigger refund: ${body.message || body.error || res.status}`);
+      return;
+    }
+
+    alert(`Refund processed: ${body.refundAmount ?? ""}`.trim());
+    await loadFailedTransactions();
+  } catch (err) {
+    alert(`Failed to trigger refund: ${err.message || "network error"}`);
+  }
+}
+
+function refundStatusLabel(t) {
+  if (t.refundStatus === "completed") return "Refunded";
+  if (t.refundStatus === "processing") return "Refund in progress";
+  if (t.refundStatus === "failed") return "Refund failed";
+  return "Not refunded";
+}
+
+function renderRefundRow(t) {
+  const statusClass =
+    t.refundStatus === "completed"
+      ? "failover-online"
+      : t.refundStatus === "failed"
+        ? "failover-offline"
+        : "";
+
+  const card = document.createElement("div");
+  card.className = `failover-card glass ${statusClass}`;
+  card.innerHTML = `
+    <div class="failover-provider-name">${t.referenceNumber}</div>
+    <div class="failover-status">${t.status} · ${t.provider}</div>
+    <div class="failover-reason">${t.phoneNumber} &nbsp;·&nbsp; Amount: ${t.amount}</div>
+    <div class="failover-reason" id="refund-status-${t.id}">${refundStatusLabel(t)}${t.refundReason ? `: ${t.refundReason}` : ""}</div>
+    <button class="btn-toggle-provider" data-action="refund" ${t.refundEligible ? "" : "disabled"}>
+      Trigger Refund
+    </button>
+  `;
+  const refundBtn = card.querySelector('[data-action="refund"]');
+  if (t.refundEligible) {
+    refundBtn.addEventListener("click", () => triggerRefund(t.id));
+  }
+  return card;
+}
+
+async function loadFailedTransactions() {
+  const grid = document.getElementById("refund-grid");
+  const updatedAt = document.getElementById("refund-updated-at");
+  if (!grid) return;
+
+  try {
+    const res = await fetch("/api/admin/monitoring/refunds/failed-transactions");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (!data.success || !Array.isArray(data.transactions)) {
+      throw new Error("Unexpected response");
+    }
+
+    grid.innerHTML = "";
+    if (data.transactions.length === 0) {
+      grid.innerHTML = '<p class="failover-loading">No failed transactions found.</p>';
+    } else {
+      data.transactions.forEach((t) => grid.appendChild(renderRefundRow(t)));
+    }
+
+    if (updatedAt) updatedAt.textContent = new Date().toLocaleTimeString();
+  } catch (err) {
+    grid.innerHTML = '<p class="failover-loading">Failed to load failed transactions.</p>';
+    if (updatedAt) updatedAt.textContent = "unavailable";
+  }
+}
+
+loadFailedTransactions();
+
+const btnRefreshRefunds = document.getElementById("btn-refresh-refunds");
+if (btnRefreshRefunds)
+  btnRefreshRefunds.addEventListener("click", loadFailedTransactions);

--- a/public/index.html
+++ b/public/index.html
@@ -266,6 +266,20 @@
       </div>
     </section>
 
+    <!-- Compliance Overrides Dashboard (#1574) -->
+    <section id="compliance-overrides" class="failover-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Compliance Overrides</h2>
+          <p>Manually override automated KYC decisions after review. Admin authentication required.</p>
+        </div>
+        <div class="failover-grid" id="compliance-grid">
+          <p class="failover-loading" id="compliance-loading">Loading applicants…</p>
+        </div>
+        <p class="failover-updated">Last updated: <span id="compliance-updated-at">—</span> &nbsp;·&nbsp; <button class="btn-refresh" id="btn-refresh-compliance">Refresh</button></p>
+      </div>
+    </section>
+
     <!-- API Section -->
     <section id="api" class="api-section">
       <div class="container">

--- a/public/index.html
+++ b/public/index.html
@@ -280,6 +280,20 @@
       </div>
     </section>
 
+    <!-- Refund Status Inspection Portal (#1669) -->
+    <section id="refund-portal" class="failover-section">
+      <div class="container">
+        <div class="section-header">
+          <h2>Refund Status Inspection Portal</h2>
+          <p>Inspect failed transactions and trigger administrative refunds. Admin authentication required.</p>
+        </div>
+        <div class="failover-grid" id="refund-grid">
+          <p class="failover-loading" id="refund-loading">Loading failed transactions…</p>
+        </div>
+        <p class="failover-updated">Last updated: <span id="refund-updated-at">—</span> &nbsp;·&nbsp; <button class="btn-refresh" id="btn-refresh-refunds">Refresh</button></p>
+      </div>
+    </section>
+
     <!-- API Section -->
     <section id="api" class="api-section">
       <div class="container">

--- a/src/controllers/adminController.ts
+++ b/src/controllers/adminController.ts
@@ -13,6 +13,9 @@ import { ERROR_CODES } from "../constants/errorCodes";
 import { pool } from "../config/database";
 import { providerSettingsService } from "../services/providerSettingsService";
 import { AuthRequest } from "../middleware/auth";
+import { TransactionModel, TransactionStatus } from "../models/transaction";
+
+const transactionModel = new TransactionModel();
 
 // Ensure logs directory exists
 const LOGS_DIR = path.join(process.cwd(), "logs");
@@ -623,6 +626,64 @@ export const overrideKycDecisionHandler = async (
 };
 
 /**
+ * Controller: List failed transactions for the refund inspection portal,
+ * surfacing whether a refund has already been queued/completed for each one.
+ * Acceptance Criteria: Display failed transaction logs (#1669).
+ */
+export const getFailedTransactionsHandler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  try {
+    const user = (req as AuthRequest).user;
+    if (!user || !isAdminRole(user.role)) {
+      throw createError(ERROR_CODES.FORBIDDEN, "Admin access required", {
+        message: "Admin access required",
+      });
+    }
+
+    const limit = Math.min(
+      Math.max(parseInt((req.query.limit as string) || "100", 10) || 100, 1),
+      500,
+    );
+
+    const transactions = await transactionModel.findByStatuses(
+      [TransactionStatus.Failed],
+      limit,
+    );
+
+    const failedTransactions = transactions.map((t: any) => {
+      const refund =
+        t.metadata && typeof t.metadata === "object" ? t.metadata.refund : null;
+
+      return {
+        id: t.id,
+        referenceNumber: t.referenceNumber,
+        type: t.type,
+        amount: t.amount,
+        phoneNumber: t.phoneNumber,
+        provider: t.provider,
+        status: t.status,
+        refundStatus: refund?.status ?? null,
+        refundReason: refund?.reason ?? null,
+        refundHash: refund?.hash ?? null,
+        refundCompletedAt: refund?.completedAt ?? null,
+        refundEligible:
+          t.type === "withdraw" && refund?.status !== "completed",
+        createdAt: t.createdAt,
+        updatedAt: t.updatedAt,
+      };
+    });
+
+    res.json({ success: true, transactions: failedTransactions });
+  } catch (error) {
+    if ((error as any).status) throw error;
+    winstonOutageLogger.error("Failed to fetch failed transactions", { error });
+    throw createError(ERROR_CODES.INTERNAL_ERROR, "Failed to fetch failed transactions");
+  }
+};
+
+/**
  * Express Router mounting all monitoring dashboard endpoints
  */
 import { Router } from "express";
@@ -642,6 +703,7 @@ router.get("/sla", getSlaMetrics);
 router.get("/telecom-latency", getTelecomLatencyMetricsController);
 router.get("/compliance/overrides", getComplianceOverridesHandler);
 router.post("/compliance/overrides/:applicantRecordId", overrideKycDecisionHandler);
+router.get("/refunds/failed-transactions", getFailedTransactionsHandler);
 
 export default router;
 

--- a/src/controllers/adminController.ts
+++ b/src/controllers/adminController.ts
@@ -510,6 +510,119 @@ export const toggleProviderMaintenanceHandler = async (
 };
 
 /**
+ * Controller: List KYC applicant records for compliance review, including
+ * their automated verification_status and any existing manual override.
+ * Acceptance Criteria: Allow admin users to override automated KYC decisions
+ * manually after review (#1574).
+ */
+export const getComplianceOverridesHandler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  try {
+    const user = (req as AuthRequest).user;
+    if (!user || !isAdminRole(user.role)) {
+      throw createError(ERROR_CODES.FORBIDDEN, "Admin access required", {
+        message: "Admin access required",
+      });
+    }
+
+    const result = await pool.query(
+      `SELECT
+         ka.id,
+         ka.user_id,
+         ka.applicant_id,
+         ka.provider,
+         ka.verification_status,
+         ka.kyc_level,
+         ka.override_status,
+         ka.override_reason,
+         ka.overridden_by,
+         ka.overridden_at,
+         ka.updated_at,
+         u.phone_number
+       FROM kyc_applicants ka
+       JOIN users u ON u.id = ka.user_id
+       ORDER BY ka.updated_at DESC
+       LIMIT 100`,
+    );
+
+    res.json({ success: true, applicants: result.rows });
+  } catch (error) {
+    if ((error as any).status) throw error;
+    winstonOutageLogger.error("Failed to fetch compliance overrides", { error });
+    throw createError(ERROR_CODES.INTERNAL_ERROR, "Failed to fetch compliance overrides");
+  }
+};
+
+/**
+ * Controller: Manually override an automated KYC decision.
+ * Acceptance Criteria: Limit override execution to admin role; update status
+ * successfully on override toggle click (#1574).
+ */
+export const overrideKycDecisionHandler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  try {
+    const user = (req as AuthRequest).user;
+    if (!user || !isAdminRole(user.role)) {
+      throw createError(ERROR_CODES.FORBIDDEN, "Admin access required", {
+        message: "Admin access required",
+      });
+    }
+
+    const { applicantRecordId } = req.params;
+    const { overrideStatus, reason } = req.body;
+
+    if (!applicantRecordId) {
+      throw createError(ERROR_CODES.INVALID_INPUT, "applicantRecordId is required");
+    }
+    if (overrideStatus !== "approved" && overrideStatus !== "rejected") {
+      throw createError(
+        ERROR_CODES.INVALID_INPUT,
+        "overrideStatus must be 'approved' or 'rejected'",
+      );
+    }
+
+    // Manual override also becomes the effective verification_status so the
+    // rest of the system (limits, dashboards) reflects the reviewer's decision.
+    const result = await pool.query(
+      `UPDATE kyc_applicants
+       SET override_status = $1,
+           override_reason = $2,
+           overridden_by = $3,
+           overridden_at = NOW(),
+           verification_status = $1
+       WHERE id = $4
+       RETURNING id, applicant_id, verification_status, override_status,
+                 override_reason, overridden_by, overridden_at`,
+      [overrideStatus, reason ?? null, user.id, applicantRecordId],
+    );
+
+    if (result.rows.length === 0) {
+      throw createError(ERROR_CODES.NOT_FOUND, "KYC applicant record not found");
+    }
+
+    winstonOutageLogger.info("KYC_DECISION_MANUALLY_OVERRIDDEN", {
+      applicantRecordId,
+      overrideStatus,
+      overriddenBy: user.id,
+    });
+
+    res.json({
+      success: true,
+      message: `KYC decision overridden to ${overrideStatus}`,
+      applicant: result.rows[0],
+    });
+  } catch (error) {
+    if ((error as any).status) throw error;
+    winstonOutageLogger.error("Failed to override KYC decision", { error });
+    throw createError(ERROR_CODES.INTERNAL_ERROR, "Failed to override KYC decision");
+  }
+};
+
+/**
  * Express Router mounting all monitoring dashboard endpoints
  */
 import { Router } from "express";
@@ -527,6 +640,8 @@ router.post("/circuit-breaker/reset", resetCircuitBreakerHandler);
 router.post("/circuit-breaker/trip", tripCircuitBreakerHandler);
 router.get("/sla", getSlaMetrics);
 router.get("/telecom-latency", getTelecomLatencyMetricsController);
+router.get("/compliance/overrides", getComplianceOverridesHandler);
+router.post("/compliance/overrides/:applicantRecordId", overrideKycDecisionHandler);
 
 export default router;
 


### PR DESCRIPTION
## Description

Build a panel inside the admin console allowing operators to inspect and trigger refunds for failed transactions.

## Related Issue

Fixes #1669

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Changes Made

- New getFailedTransactionsHandler — GET /refunds/failed-transactions (admin-only, same isAdminRole check as the rest of the file). Pulls failed transactions via TransactionModel.findByStatuses([Failed]), and for each one surfaces refundStatus/refundReason/refundHash/refundCompletedAt pulled out of metadata.refund, plus a refundEligible flag (type === "withdraw" and not already completed).
Registered at /api/admin/monitoring/refunds/failed-transactions.
- New "Refund Status Inspection Portal" section, same card-grid pattern as the other two panels.
Each failed transaction shows reference number, phone, amount, provider, and a refund status indicator (Not refunded / Refund in progress / Refunded / Refund failed).
"Trigger Refund" button is disabled when not eligible, otherwise POSTs to the existing /api/admin/transactions/:id/refund endpoint, then reloads the list so the status indicator updates.
-

## Testing

How did you test these changes?

## Checklist

- [x] Code follows project style
- [x] Self-reviewed my code
- [ ] Commented complex code
- [ ] Updated documentation
- [ ] No new warnings
- [ ] Added tests (if applicable)


